### PR TITLE
Bind servers to specific addresses

### DIFF
--- a/cms/cms/__init__.py
+++ b/cms/cms/__init__.py
@@ -66,6 +66,7 @@ class Config:
         self.tornado_debug = False
 
         # ContestWebServer.
+        self.contest_listen_address = [""]
         self.contest_listen_port = [8888]
         self.cookie_duration = 1800
         self.submit_local_copy = True
@@ -78,6 +79,7 @@ class Config:
         self.stl_path = "/usr/share/doc/stl-manual/html/"
 
         # AdminWebServer.
+        self.admin_listen_address = ""
         self.admin_listen_port = 8889
 
         # ScoringService.

--- a/cms/cms/async/WebAsyncLibrary.py
+++ b/cms/cms/async/WebAsyncLibrary.py
@@ -147,7 +147,7 @@ class WebService(Service):
     """
 
     def __init__(self, listen_port, handlers, parameters, shard=0,
-                 custom_logger=None, listen_address='0.0.0.0'):
+                 custom_logger=None, listen_address=""):
         Service.__init__(self, shard, custom_logger)
 
         global logger

--- a/cms/cms/server/AdminWebServer.py
+++ b/cms/cms/server/AdminWebServer.py
@@ -198,7 +198,8 @@ class AdminWebServer(WebService):
                             _aws_handlers,
                             parameters,
                             shard=shard,
-                            custom_logger=logger)
+                            custom_logger=logger,
+                            listen_address=config.admin_listen_address)
         self.file_cacher = FileCacher(self)
         self.evaluation_service = self.connect_to(
             ServiceCoord("EvaluationService", 0))

--- a/cms/cms/server/ContestWebServer.py
+++ b/cms/cms/server/ContestWebServer.py
@@ -213,7 +213,8 @@ class ContestWebServer(WebService):
                             config.contest_listen_port[shard],
                             _cws_handlers,
                             parameters,
-                            shard=shard)
+                            shard=shard,
+                            listen_address=config.contest_listen_address[shard])
         self.file_cacher = FileCacher(self)
         self.evaluation_service = self.connect_to(
             ServiceCoord("EvaluationService", 0))

--- a/cms/examples/cms.conf.sample
+++ b/cms/examples/cms.conf.sample
@@ -64,8 +64,9 @@
 
     "_section": "ContestWebServer",
 
-    "_help": "Listening http ports for the CWS listed before in",
+    "_help": "Listening http address and ports for the CWS listed before in",
     "_help": "core_services.",
+    "contest_listen_port": [""],
     "contest_listen_port": [8888],
 
     "_help": "Login cookie duration in seconds. The duration is refreshed",
@@ -103,7 +104,8 @@
 
     "_section": "AdminWebServer",
 
-    "_help": "Listening http port for AdminWebServer.",
+    "_help": "Listening http address and port for AdminWebServer.",
+    "admin_listen_address": "",
     "admin_listen_port": 8889,
 
 


### PR DESCRIPTION
This allows the administrator to bind the web servers to a specific
interface, such as localhost.
