### PR TITLE
AWS: Fix templates for output only submissions

### DIFF
--- a/cms/server/templates/admin/user.html
+++ b/cms/server/templates/admin/user.html
@@ -113,7 +113,7 @@ function update_additional_answer(element, invoker)
         </td>
         <td>
           {% for filename, sub_file in s.files.items() %}
-          <a href="#" onclick="utils.show_file('{{ filename.replace("%l", s.language) }}','{{ url_root }}/submission_file/{{ sub_file.id }}')">{{ filename.replace("%l", s.language) }}<br/>
+          <a href="#" onclick="utils.show_file('{{ filename.replace("%l", s.language) if s.language else filename }}','{{ url_root }}/submission_file/{{ sub_file.id }}')">{{ filename.replace("%l", s.language) if s.language else filename }}<br/>
           {% end %}
         </td>
         <td>


### PR DESCRIPTION
OutputOnly submissions have a NULL language, so replacing %l unconditionally
raises an exception and a causes a critical error in aws.
