### PR TITLE
Fix OutputOnly.py

### DIFF
--- a/cms/grading/tasktypes/OutputOnly.py
+++ b/cms/grading/tasktypes/OutputOnly.py
@@ -96,7 +96,7 @@ class OutputOnly(TaskType):
         # present we report that the outcome is 0.
         if "output_%03d.txt" % test_number not in self.job.files:
             evaluation['success'] = True
-            evaluation['outcome'] = 0.0
+            evaluation['outcome'] = "0.0"
             evaluation['text'] = "File not submitted."
             return True
 


### PR DESCRIPTION
lerks/cms@21a7a31 forgets one line, thus OutputOnly failed to evaluate when some outputs are not submitted. This patch fixes this problem.
