### PR TITLE
make Non-ASCII compile messages visible

### DIFF
--- a/cms/grading/__init__.py
+++ b/cms/grading/__init__.py
@@ -125,11 +125,11 @@ def compilation_step(sandbox, command):
     stdout = sandbox.get_file_to_string("compiler_stdout.txt")
     if stdout.strip() == "":
         stdout = "(empty)\n"
-    stdout = unicode(stdout, errors='ignore')
+    stdout = unicode(stdout, 'UTF-8', errors='ignore')
     stderr = sandbox.get_file_to_string("compiler_stderr.txt")
     if stderr.strip() == "":
         stderr = "(empty)\n"
-    stderr = unicode(stderr, errors='ignore')
+    stderr = unicode(stderr, 'UTF-8', errors='ignore')
     compiler_output = "Compiler standard output:\n" \
         "%s\n" \
         "Compiler standard error:\n" \


### PR DESCRIPTION
When environment variable LANG is set (for example, ja_JP.UTF-8), non-ASCII characters in a compile message are not processed correctly. This patch fixes the bug.
