### PR TITLE
adapt SpoolExporter to a change of ScoreType format

### DIFF
--- a/cmscontrib/SpoolExporter.py
+++ b/cmscontrib/SpoolExporter.py
@@ -27,6 +27,7 @@ Italian IOI repository for storing the results of a contest.
 import os
 import codecs
 import argparse
+import time
 
 from cms import logger
 from cms.db import ask_for_contest
@@ -106,7 +107,7 @@ class SpoolExporter:
             logger.info("Exporting submission %s." % submission.id)
             username = submission.user.username
             task = submission.task.name
-            timestamp = submission.timestamp
+            timestamp = time.mktime(submission.timestamp.timetuple())
 
             # Get source files to the spool directory.
             file_digest = submission.files["%s.%s" % (task, "%l")].digest
@@ -178,7 +179,12 @@ class SpoolExporter:
             scorers[submission.task_id].add_submission(
                 submission.id, submission.timestamp,
                 submission.user.username,
-                dict((ev.num, float(ev.outcome))
+                submission.evaluated(),
+                dict((ev.num,
+                      {"outcome": ev.outcome,
+                       "text": ev.text,
+                       "time": ev.execution_time,
+                       "memory": ev.memory_used})
                      for ev in submission.evaluations),
                 submission.tokened())
 


### PR DESCRIPTION
SpoolExporter didn't work because of some minor changes in submissions. This patch fixes it.
