### PR TITLE
Dispatch jobs as soon as possible

### DIFF
--- a/cms/io/GeventLibrary.py
+++ b/cms/io/GeventLibrary.py
@@ -229,6 +229,8 @@ class Service:
         plus (object): additional data to pass to the function.
         seconds (float): the function will be called every seconds
                          seconds.
+                         If seconds is 0, the function will be called
+                         only once.
         immediately (bool): if True, func will be called also at the
                             beginning.
 
@@ -355,7 +357,7 @@ class Service:
                         ret = func()
                     else:
                         ret = func(plus)
-                    if ret:
+                    if ret and seconds != 0:
                         heapq.heappush(self._timeouts,
                                        (next_timeout + seconds,
                                         seconds, func, plus))

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -672,6 +672,8 @@ class EvaluationService(Service):
                          .total_seconds(),
                          immediately=True)
 
+        self.immediately_dispatch = True
+
     @rpc_method
     def search_jobs_not_done(self):
         """Look in the database for submissions that have not been
@@ -750,6 +752,8 @@ class EvaluationService(Service):
             logger.info("%s jobs still pending." % pending)
         while self.dispatch_one_job():
             pass
+
+        self.immediately_dispatch = False
 
         # We want this to run forever.
         return True
@@ -937,6 +941,9 @@ class EvaluationService(Service):
             return False
         else:
             self.queue.push(job, priority, timestamp)
+            if not self.immediately_dispatch:
+                self.add_timeout(self.dispatch_jobs, None, 0)
+                self.immediately_dispatch = True
             return True
 
     @rpc_callback
@@ -966,6 +973,10 @@ class EvaluationService(Service):
         # worker.
         if self.pool.release_worker(shard):
             return
+
+        if not self.immediately_dispatch:
+            self.add_timeout(self.dispatch_jobs, None, 0)
+            self.immediately_dispatch = True
 
         job_success = True
         if error is not None:


### PR DESCRIPTION
Currently, the evaluation service checks for jobs to dispatch every 2 seconds. Hence, there is an idle interval of some random length (0-2 seconds) between two jobs. This obviously doesn't have a big impact on long running jobs, but can make a difference if the jobs are all rather easy (e.g. compilation), especially when debugging (tasks or the server).

This commit pushes the `dispatch_jobs` method to the event queue for being called immediately whenever a job is added to the job queue or a job finished. This is done via a call to `add_timeout` with `seconds=0`. The event library has been adapted so that the function gets called only once if `seconds=0`.

As far as I see, `dispatch_jobs` often runs in parallel to `invalidate_submission`. Is that OK?