### PR TITLE
Fixed dump format versioning

### DIFF
--- a/cmscontrib/ContestImporter.py
+++ b/cmscontrib/ContestImporter.py
@@ -188,8 +188,7 @@ class ContestImporter:
                 # one) we try to update it.
                 # If no "_version" field is found we assume it's a v1.0
                 # export (before the new dump format was introduced).
-                dump_version = int(self.datas.get("_version", 0))
-                self.datas["_version"] = dump_version
+                dump_version = self.datas.get("_version", 0)
 
                 if dump_version < model_version:
                     logger.warning(

--- a/cmscontrib/DumpUpdater.py
+++ b/cmscontrib/DumpUpdater.py
@@ -70,8 +70,7 @@ def main():
 
     # If no "_version" field is found we assume it's a v1.0
     # export (before the new dump format was introduced).
-    dump_version = int(data.get("_version", 0))
-    data["_version"] = dump_version
+    dump_version = data.get("_version", 0)
 
     if dump_version == to_version:
         logger.info(


### PR DESCRIPTION
As far as I see, currently the new dump format versioning doesn't work, as the version number is not saved to the dump file ;). Furthermore, the version number should be converted to an integer. This commit should fix both issues.
