### PR TITLE
User groups for timing

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -46,7 +46,7 @@ __all__ = [
     # contest
     "Contest", "Announcement",
     # user
-    "User", "Message", "Question",
+    "User", "Message", "Question", "Group",
     # task
     "Task", "Statement", "Attachment", "SubmissionFormatElement", "Dataset",
     "Manager", "Testcase",
@@ -69,7 +69,7 @@ __all__ = [
 
 # Instantiate or import these objects.
 
-version = 5
+version = 6
 
 
 engine = create_engine(config.database, echo=config.database_debug,
@@ -81,7 +81,7 @@ from .session import Session, ScopedSession, SessionGen, \
 
 from .base import metadata, Base
 from .contest import Contest, Announcement
-from .user import User, Message, Question
+from .user import User, Message, Question, Group
 from .task import Task, Statement, Attachment, SubmissionFormatElement, \
     Dataset, Manager, Testcase
 from .submission import Submission, File, Token, SubmissionResult, \

--- a/cms/server/templates/admin/add_group.html
+++ b/cms/server/templates/admin/add_group.html
@@ -1,0 +1,34 @@
+{% extends base.html %}
+
+{% block core %}
+
+<h1>New group</h1>
+
+<h2 id="title_general_info" class="toggling_on">General information</h2>
+<div id="general_info">
+  <form action="{{ url_root }}/add_group/{{ contest.id }}" method="POST">
+    <table>
+      <tr>
+        <td>Name</td>
+        <td><input type="text" name="name"/></td>
+      </tr>
+      <tr>
+        <td>Start (in UTC)</td>
+        <td><input type="text" name="start" value="{{ str(timestamp) }}"></td>
+      </tr>
+      <tr>
+        <td>End (in UTC)</td>
+        <td><input type="text" name="stop" value="{{ str(timestamp) }}"></td>
+      </tr>
+      <tr>
+        <td>Maximum length of the contest for a user (in seconds)</td>
+        <td><input type="text" name="per_user_time" value=""></td>
+      </tr>
+    </table>
+    <input type="submit"/>
+    <input type="reset" value="Reset" />
+  </form>
+  <div class="hr"></div>
+</div>
+
+{% end %}

--- a/cms/server/templates/admin/add_user.html
+++ b/cms/server/templates/admin/add_user.html
@@ -21,6 +21,16 @@
         <td><input type="text" name="username" /></td>
       </tr>
       <tr>
+        <td>Group</td>
+        <td>
+          <select name="group">
+            {% for group in contest.groups %}
+            <option value="{{ group.id }}">{{group.name}}</option>
+            {% end %}
+          </select>
+        </td>
+      </tr>
+      <tr>
         <td>Password</td>
         <!-- FIXME: Plain text? -->
         <td><input type="text" name="password" /></td>

--- a/cms/server/templates/admin/base.html
+++ b/cms/server/templates/admin/base.html
@@ -43,7 +43,7 @@ function init()
     utils.update_notifications();
     setInterval(cmsutils.bind_func(utils, utils.update_notifications), 15000);
     {% else %}
-    utils = new Utils({{ make_timestamp(timestamp) }}, {{ make_timestamp(contest.start) }}, {{ make_timestamp(contest.stop) }}, {{ phase }});
+    utils = new Utils({{ make_timestamp(timestamp) }}, {{ make_timestamp(contest.main_group.start) }}, {{ make_timestamp(contest.main_group.stop) }}, {{ phase }});
 
     firstDate = new Date();
     utils.get_time();
@@ -100,6 +100,7 @@ $(document).ready(init);
             <li class="menu_entry"><a class="menu_link" href="{{ url_root }}/contest/{{ contest.id }}">General</a></li>
             <li class="menu_entry"><a class="menu_link" href="{{ url_root }}/ranking/{{ contest.id }}">Ranking</a></li>
             <li class="menu_entry"><a class="menu_link" href="{{ url_root }}/userlist/{{ contest.id }}">Users</a></li>
+            <li class="menu_entry"><a class="menu_link" href="{{ url_root }}/grouplist/{{ contest.id }}">Groups</a></li>
             <li class="menu_entry"><a class="menu_link" href="{{ url_root }}/tasklist/{{ contest.id }}">Tasks</a></li>
             <li class="menu_entry"><a class="menu_link" href="{{ url_root }}/announcements/{{ contest.id }}">Announcements</a></li>
             <li class="menu_entry">

--- a/cms/server/templates/admin/contest.html
+++ b/cms/server/templates/admin/contest.html
@@ -20,6 +20,16 @@
       <td><input type="text" name="token_initial" value="{{ contest.token_initial if contest.token_initial is not None else "" }}" size="3" /></td>
     </tr>
     <tr>
+      <td>Main group</td>
+      <td>
+        <select name="main_group">
+          {% for group in contest.groups %}
+          <option value="{{ group.id }}" {% if contest.main_group_id == group.id %}selected{% end %}>{{group.name}}</option>
+          {% end %}
+        </select>
+      </td>
+    </tr>
+    <tr>
       <td>Maximum accumulated tokens</td>
       <td><input type="text" name="token_max" value="{{ contest.token_max if contest.token_max is not None else "" }}" size="3" /></td>
     </tr>
@@ -40,20 +50,8 @@
       <td><input type="text" name="token_gen_number" value="{{ contest.token_gen_number }}" size="3" /></td>
     </tr>
     <tr>
-      <td>Start (in UTC)</td>
-      <td><input type="text" name="start" value="{{ str(contest.start) }}"></td>
-    </tr>
-    <tr>
-      <td>End (in UTC)</td>
-      <td><input type="text" name="stop" value="{{ str(contest.stop) }}"></td>
-    </tr>
-    <tr>
       <td>Timezone (like "Europe/Rome", "America/New_York", ...)</td>
       <td><input type="text" name="timezone" value="{{ contest.timezone if contest.timezone is not None else "" }}"></td>
-    </tr>
-    <tr>
-      <td>Maximum length of the contest for a user (in seconds)</td>
-      <td><input type="text" name="per_user_time" value="{{ int(contest.per_user_time.total_seconds()) if contest.per_user_time is not None else "" }}"></td>
     </tr>
     <tr>
       <td>Maximum number of submissions for each user (for the whole contest)</td>

--- a/cms/server/templates/admin/group.html
+++ b/cms/server/templates/admin/group.html
@@ -1,0 +1,33 @@
+{% extends base.html %}
+
+{% block core %}
+
+<h1>Group {{ selected_group.name }}</h1>
+
+<h2 id="title_general_info" class="toggling_on">General Information</h2>
+<div id="general_info">
+  <form action="{{ url_root }}/group/{{ selected_group.id }}" method="POST">
+    <table>
+      <tr>
+        <td>Name</td>
+        <td><input type="text" name="name" value="{{ selected_group.name }}"/></td>
+      </tr>
+      <tr>
+        <td>Start (in UTC)</td>
+        <td><input type="text" name="start" value="{{ str(selected_group.start) }}"></td>
+      </tr>
+      <tr>
+        <td>End (in UTC)</td>
+        <td><input type="text" name="stop" value="{{ str(selected_group.stop) }}"></td>
+      </tr>
+      <tr>
+        <td>Maximum length of the contest for a user (in seconds)</td>
+        <td><input type="text" name="per_user_time" value="{{ int(selected_group.per_user_time.total_seconds()) if selected_group.per_user_time is not None else "" }}"></td>
+      </tr>
+    </table>
+    <input type="submit" value="Update" />
+    <input type="reset" value="Reset" />
+  </form>
+  <div class="hr"></div>
+</div>
+{% end %}

--- a/cms/server/templates/admin/grouplist.html
+++ b/cms/server/templates/admin/grouplist.html
@@ -1,0 +1,28 @@
+{% extends base.html %}
+
+{% block core %}
+<div class="core_title">
+  <h1>Groups list</h1>
+</div>
+<a href="{{ url_root }}/add_group/{{ contest.id }}">Add a new group</a>
+<table class="bordered">
+  <thead>
+    <tr>
+      <th style="width: 20%">Name</th>
+      <th style="width: 20%">Start (in UTC)</th>
+      <th style="width: 20%">End (in UTC)</th>
+      <th style="width: 40%">Max. contest length (in seconds)</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for g in sorted(contest.groups, cmp = lambda x, y: cmp(x.name, y.name)) %}
+    <tr>
+      <td><a href="{{ url_root }}/group/{{ g.id }}">{{ g.name }}</a></td>
+      <td>{{ str(g.start) }}</td>
+      <td>{{ str(g.stop) }}</td>
+      <td>{{ int(g.per_user_time.total_seconds()) if g.per_user_time is not None else "" }}</td>
+    </tr>
+    {% end %}
+  </tbody>
+</table>
+{% end %}

--- a/cms/server/templates/admin/user.html
+++ b/cms/server/templates/admin/user.html
@@ -171,6 +171,16 @@ function update_additional_answer(element, invoker)
         <td><input type="text" name="username" value="{{ selected_user.username }}"/></td>
       </tr>
       <tr>
+        <td>Group</td>
+        <td>
+          <select name="group">
+            {% for group in contest.groups %}
+            <option value="{{ group.id }}" {% if selected_user.group.id == group.id %}selected{% end %}>{{group.name}}</option>
+            {% end %}
+          </select>
+        </td>
+      </tr>
+      <tr>
         <td>Password</td>
         <!-- FIXME: Plain text? -->
         <td><input type="text" name="password" value="{{ selected_user.password }}"/></td>

--- a/cms/server/templates/admin/userlist.html
+++ b/cms/server/templates/admin/userlist.html
@@ -8,9 +8,10 @@
 <table class="bordered">
   <thead>
     <tr>
-      <th style="width: 25%">First name</th>
-      <th style="width: 27%">Last name</th>
-      <th style="width: 30%">Username</th>
+      <th style="width: 21%">First name</th>
+      <th style="width: 23%">Last name</th>
+      <th style="width: 23%">Username</th>
+      <th style="width: 15%">Group</th>
       <th style="width: 18%">Reevaluate</th>
     </tr>
   </thead>
@@ -20,6 +21,7 @@
       <td>{{ u.first_name }}</td>
       <td>{{ u.last_name }}</td>
       <td><a href="{{ url_root }}/user/{{ u.id }}">{{ u.username }}</a></td>
+      <td><a href="{{ url_root }}/group/{{ u.group.id }}">{{ u.group.name }}</a></td>
       <td>
         {% set reevaluation_par_name = "user" %}
         {% set reevaluation_par_value = u.id %}

--- a/cms/server/templates/contest/overview.html
+++ b/cms/server/templates/contest/overview.html
@@ -12,7 +12,7 @@
 
 <h2>{{ _("General information") }}</h2>
 <div class="row">
-{% if contest.per_user_time is not None %}
+{% if current_user.group.per_user_time is not None %}
     <div class="span5">
 {% else %}
     <div class="span9">
@@ -22,17 +22,17 @@
         {{ _("The contest hasn't started yet.") }}
         </p>
         <p>
-        {{ _("The contest will start at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start, timezone, locale=locale), "stop_time": format_datetime_smart(contest.stop, timezone, locale=locale)} }}
+        {{ _("The contest will start at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(current_user.group.start, timezone, locale=locale), "stop_time": format_datetime_smart(current_user.group.stop, timezone, locale=locale)} }}
 {% elif phase == 0 %}
         {{ _("The contest is currently running.") }}
         </p>
         <p>
-        {{ _("The contest started at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start, timezone, locale=locale), "stop_time": format_datetime_smart(contest.stop, timezone, locale=locale)} }}
+        {{ _("The contest started at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(current_user.group.start, timezone, locale=locale), "stop_time": format_datetime_smart(current_user.group.stop, timezone, locale=locale)} }}
 {% elif phase == +1 %}
         {{ _("The contest has already ended.") }}
         </p>
         <p>
-        {{ _("The contest started at %(start_time)s and ended at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start, timezone, locale=locale), "stop_time": format_datetime_smart(contest.stop, timezone, locale=locale)} }}
+        {{ _("The contest started at %(start_time)s and ended at %(stop_time)s.") % {"start_time": format_datetime_smart(current_user.group.start, timezone, locale=locale), "stop_time": format_datetime_smart(current_user.group.stop, timezone, locale=locale)} }}
 {% end %}
         </p>
 
@@ -113,12 +113,12 @@
 
 
     </div>
-{% if contest.per_user_time is not None %}
+{% if current_user.group.per_user_time is not None %}
     <div class="span4">
         <div class="well per_user_time">
             <p>
         {% comment TODO would be very nice to write something like "just for 3 consecutive hours"... %}
-        {{ _("Every user is allowed to compete (i.e. submit solutions) for a uninterrupted time frame of %(per_user_time)s.") % {"per_user_time": format_amount_of_time(contest.per_user_time.total_seconds(), precision=-1, locale=locale)} }}
+        {{ _("Every user is allowed to compete (i.e. submit solutions) for a uninterrupted time frame of %(per_user_time)s.") % {"per_user_time": format_amount_of_time(current_user.group.per_user_time.total_seconds(), precision=-1, locale=locale)} }}
             </p>
 
             <p>

--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -318,8 +318,8 @@ class ProxyService(Service):
             contest_id = encode_id(contest.name)
             contest_data = {
                 "name": contest.description,
-                "begin": int(make_timestamp(contest.start)),
-                "end": int(make_timestamp(contest.stop)),
+                "begin": int(make_timestamp(contest.main_group.start)),
+                "end": int(make_timestamp(contest.main_group.stop)),
                 "score_precision": contest.score_precision}
 
             users = dict()

--- a/cmscontrib/BaseLoader.py
+++ b/cmscontrib/BaseLoader.py
@@ -90,10 +90,11 @@ class Loader:
         """
         raise NotImplementedError("Please extend Loader")
 
-    def get_user(self, username):
+    def get_user(self, username, contest):
         """Produce a User object.
 
         username (string): the username.
+        contest (Contest): the contest.
 
         return (User): the User object.
 

--- a/cmscontrib/Importer.py
+++ b/cmscontrib/Importer.py
@@ -96,21 +96,22 @@ class Importer:
         # Get the users or, if asked, generate them
         if self.user_number is None:
             for user in users:
-                contest.users.append(self.loader.get_user(user))
+                contest.users.append(self.loader.get_user(user, contest))
         else:
             logger.info("Generating %s random users." % self.user_number)
             contest.users = [User("User %d" % i,
                                   "Last name %d" % i,
-                                  "user%03d" % i)
+                                  "user%03d" % i,
+                                  group=contest.main_group)
                              for i in xrange(self.user_number)]
 
         # Apply the modification flags
         if self.zero_time:
-            contest.start = datetime.datetime(1970, 1, 1)
-            contest.stop = datetime.datetime(1970, 1, 1)
+            contest.main_group.start = datetime.datetime(1970, 1, 1)
+            contest.main_group.stop = datetime.datetime(1970, 1, 1)
         elif self.test:
-            contest.start = datetime.datetime(1970, 1, 1)
-            contest.stop = datetime.datetime(2100, 1, 1)
+            contest.main_group.start = datetime.datetime(1970, 1, 1)
+            contest.main_group.stop = datetime.datetime(2100, 1, 1)
 
             for user in contest.users:
                 user.password = 'a'

--- a/cmscontrib/Reimporter.py
+++ b/cmscontrib/Reimporter.py
@@ -231,12 +231,12 @@ class Reimporter:
                 if old_user is None:
                     # Create a new user.
                     logger.info("Creating user %s" % username)
-                    new_user = self.loader.get_user(username)
+                    new_user = self.loader.get_user(username, contest)
                     old_contest.users.append(new_user)
                 elif username in new_users:
                     # Update an existing user.
                     logger.info("Updating user %s" % username)
-                    new_user = self.loader.get_user(username)
+                    new_user = self.loader.get_user(username, contest)
                     self._update_object(old_user, new_user)
                 else:
                     # Delete an existing user.

--- a/cmscontrib/updaters/update_6.py
+++ b/cmscontrib/updaters/update_6.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System
+# Copyright © 2013 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2013 Fabian Gundlach <320pointsguy@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A class to update a dump created by CMS.
+
+Used by ContestImporter and DumpUpdater.
+
+This adapts the dump to some changes in the model introduced in the
+commit that created this same file.
+
+"""
+
+from __future__ import unicode_literals
+
+
+def split_dict(src, *keys):
+    ret = dict()
+    for k in list(src.iterkeys()):
+        v = src[k]
+        if k in keys:
+            ret[k] = v
+            del src[k]
+    return ret
+
+
+class Updater(object):
+
+    def __init__(self, data):
+        assert data["_version"] == 5
+        self.objs = data
+        self.next_id = len(data)
+        self.groups = dict()
+
+    def get_id(self):
+        while unicode(self.next_id) in self.objs:
+            self.next_id += 1
+        return unicode(self.next_id)
+
+    def run(self):
+        for k in list(self.objs.iterkeys()):
+            if k.startswith("_"):
+                continue
+            v = self.objs[k]
+            if v["_class"] == "Contest":
+                contest_data = v
+
+                group_id = self.get_id()
+                group_data = split_dict(
+                    contest_data,
+                    "start", "stop",
+                    "per_user_time")
+                self.objs[group_id] = group_data
+
+                self.groups[k] = group_id
+
+                group_data["_class"] = "Group"
+                group_data["contest"] = k
+                group_data["name"] = "default"
+
+                contest_data["main_group"] = group_id
+
+        for k, v in self.objs.iteritems():
+            if k.startswith("_"):
+                continue
+            if v["_class"] == "User":
+                v["group"] = self.groups[v["contest"]]
+
+        return self.objs


### PR DESCRIPTION
I wanted to propose the introduction of "user groups". This means that the `start` and `stop` time and the `per_user_time` is not specified for a contest but for groups of users. This might be useful for two reasons:

1. In the German selection camps, we sometimes had some contestants which were unable to attend them. They were admitted to take part online, often after the exam at the camp.
2. It would be nice to have test users that are able to submit before the contest starts and after it ends.

As an exercise in understanding the CMS code, I already implemented this feature. It basically seems to work but it is missing documentation and the test suite has not been adapted. Before doing this, I wanted to ask for your opinions.

One problem that arises when introducing user groups is that there are some places in the interface, where user-independent contest start and stop times are needed, for example the "Time left: ..." message in the admin interface and on the rankings page. To this end, I added a `main_group_id` column to the contest table, which specifies which group's timing to use in such cases. This is of course not optimal. For example, the submission time shown on the rankings page is incorrect; that problem already arised with USACO timing, however.