### PR TITLE
Sandbox output cannot be truncated

### DIFF
--- a/isolate/isolate.c
+++ b/isolate/isolate.c
@@ -1197,6 +1197,7 @@ setup_credentials(void)
 static void
 setup_fds(void)
 {
+  umask(0);
   if (redir_stdin)
     {
       close(0);


### PR DESCRIPTION
When I submit a user test, I always get an error like the following:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/cms-1.1.0pre-py2.7.egg/cms/service/Worker.py", line 120, in execute_job_group
    task_type.execute_job(job, self.file_cacher)
  File "/usr/lib/python2.7/site-packages/cms-1.1.0pre-py2.7.egg/cms/grading/TaskType.py", line 237, in execute_job
    self.evaluate(job, file_cacher)
  File "/usr/lib/python2.7/site-packages/cms-1.1.0pre-py2.7.egg/cms/grading/tasktypes/Batch.py", line 271, in evaluate
    trunc_len=100 * 1024)
  File "/usr/lib/python2.7/site-packages/cms-1.1.0pre-py2.7.egg/cms/grading/Sandbox.py", line 288, in get_file_to_storage
    file_ = self.get_file(path, trunc_len=trunc_len)
  File "/usr/lib/python2.7/site-packages/cms-1.1.0pre-py2.7.egg/cms/grading/Sandbox.py", line 248, in get_file
    file_ = open(real_path, "ab")
IOError: [Errno 13] Permission denied: '/tmp/tmpjJNQju/tmp/output.txt'
```

The reason is that the sandbox calls `umask(022)` in the beginning. Therefore, the output.txt file is created read-only for users other than the sandbox user and the python code cannot truncate it.

This commit would set the umask to 0 after dropping privileges, so that files are generated with write permissions for other users.
