### PR TITLE
Rewrite ScoringService

### DIFF
--- a/cms/db/submission.py
+++ b/cms/db/submission.py
@@ -367,7 +367,10 @@ class SubmissionResult(Base):
         return (bool): True if scored, False otherwise.
 
         """
-        return self.score is not None
+        return all(getattr(self, k) is not None for k in [
+            "score", "score_details",
+            "public_score", "public_score_details",
+            "ranking_score_details"])
 
     def invalidate_compilation(self):
         """Blank all compilation and evaluation outcomes, and the score.

--- a/scripts/cmsScoringService
+++ b/scripts/cmsScoringService
@@ -32,8 +32,7 @@ def main():
 
     """
     default_argument_parser("Score computer for CMS.",
-                            ScoringService,
-                            ask_contest=ask_for_contest).run()
+                            ScoringService).run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Taken from commit message:

```
ScoringService contained some "oddities". For example: at start it
loaded all submissions from the database, it scored them at a rate of
four each half a second, etc. These were remnants of the ScoreType
Relative, the blocking async loop and the RWS forwarding.

This commit removes all of them, making larger use of the features
provided by gevent. The performance boost is huge.

The RPC API has been left the same, only the internals were changed.

ScoringService has been made contest-agnostic, i.e. it now handles
submissions of all contests simultaneously.
```

To review `ScoringService.py` I suggest you to look just at the new version, as the diff isn't very helpful.
