### PR TITLE
use setitimer instead of alarm in isolate

### DIFF
--- a/isolate/isolate.c
+++ b/isolate/isolate.c
@@ -1101,7 +1101,7 @@ box_keeper(void)
     {
       sa.sa_handler = signal_alarm;
       sigaction(SIGALRM, &sa, NULL);
-      set_timer(timeout+100);
+      set_timer((wall_timeout<timeout ? timeout : wall_timeout) + 100);
     }
 
   for(;;)


### PR DESCRIPTION
The timer is now set to expire 100ms after timeout/wall_timeout.
