### PR TITLE
Security Bug - Privilege escalation attack

### DIFF
--- a/isolate/isolate.c
+++ b/isolate/isolate.c
@@ -94,7 +94,9 @@ meta_open(const char *name)
       metafile = stdout;
       return;
     }
+  setreuid(geteuid(), getuid());
   metafile = fopen(name, "w");
+  setreuid(geteuid(), getuid());
   if (!metafile)
     die("Failed to open metafile '%s'",name);
 }
@@ -1251,6 +1253,7 @@ box_inside(void *arg)
   char **args = arg;
   write_errors_to_fd = error_pipes[1];
   close(error_pipes[0]);
+  meta_close();
 
   cg_enter();
   setup_root();


### PR DESCRIPTION
There exists a security issue where any user on the system can obtain root privileges, because isolate is vulnerable to a privilege escalation attack.

The default setup installs isolate with the permissions of 4755, so any user can execute isolate and perform this attack. A corresponding pull request for MOE is at https://github.com/bblackham/moe-cms/pull/3. A demonstration of how it might be performed (without actually performing it), is at https://github.com/ronalchn/isolate-cheater, in the test which uses `system-cronjob-writer/main.cpp`.

To protect your system against the attack immediately, you can do one of the following:
- delete the isolate executable
- chmod to 4754, chgrp to a new group, and only add to the group users who already have root access
- or just apply this commit

Note that any old copy of the isolate executable can be used as an attack vector - check to see if any old versions are used

isolate: Update from https://github.com/NZOI/moe-cms/commit/ee98549208e24ab9e4c1ce414c09c202f96d8405
