### PR TITLE
Fix small Javascript bugs (make AWS queue and worker status work)

### DIFF
--- a/cms/server/static/scripts.js
+++ b/cms/server/static/scripts.js
@@ -303,7 +303,7 @@
          * Represent in a nice looking way a couple (job_type,
          * submission_id) coming from the backend.
          *
-         * job (array): a couple (job_type, submission_id)
+         * job (array): a tuple (job_type, submission_id, dataset_id)
          * returns (string): nice representation of job
          */
         repr_job: function(job)
@@ -315,28 +315,28 @@
             else if (job == "disabled") {
                 return "Worker disabled";
             }
-            else if (job.job_type == 'compile') {
+            else if (job[0] == 'compile') {
                 job_type = 'Compiling';
                 object_type = 'submission';
             }
-            else if (job.job_type == 'evaluate') {
+            else if (job[0] == 'evaluate') {
                 job_type = 'Evaluating';
                 object_type = 'submission';
             }
-            else if (job.job_type == 'compile_test') {
+            else if (job[0] == 'compile_test') {
                 job_type = 'Compiling';
                 object_type = 'user_test';
             }
-            else if (job.job_type == 'evaluate_test') {
+            else if (job[0] == 'evaluate_test') {
                 job_type = 'Evaluating';
                 object_type = 'user_test';
             }
 
             if (object_type == 'submission') {
-                return job_type + ' the <a href="' + url_root + '/submission/' + job.object_id + '/' + job.dataset_id + '">result</a> of <a href="' + url_root + '/submission/' + job.object_id + '">submission ' + job.object_id + '</a> on <a href="' + url_root + '/dataset/' + job.dataset_id + '">dataset ' + job.dataset_id + '</a>';
+                return job_type + ' the <a href="' + url_root + '/submission/' + job[1] + '/' + job[2] + '">result</a> of <a href="' + url_root + '/submission/' + job[1] + '">submission ' + job[1] + '</a> on <a href="' + url_root + '/dataset/' + job[2] + '">dataset ' + job[2] + '</a>';
             }
             else {
-                return job_type + ' the result of user_test ' + job.object_id + ' on <a href="' + url_root + '/dataset/' + job.dataset_id + '">dataset ' + job.dataset_id + '</a>';
+                return job_type + ' the result of user_test ' + job[1] + ' on <a href="' + url_root + '/dataset/' + job[2] + '">dataset ' + job[2] + '</a>';
             }
         },
 

--- a/cms/server/templates/admin/welcome.html
+++ b/cms/server/templates/admin/welcome.html
@@ -44,7 +44,10 @@ function update_queue_status(response)
 
     var l = response['data'].length;
     if (l == 0)
+    {
         table.html('<tr><td colspan="100">Queue empty.</td></tr>');
+        return;
+    }
 
     var strings = [];
     for (var i = 0; i < l; i++)
@@ -72,7 +75,10 @@ function update_workers_status(response)
 
     var l = response['data'].length;
     if (l == 0)
+    {
         table.html('<tr><td colspan="100">No workers found.</td>');
+        return;
+    }
 
     var strings = [];
     for (var i in response['data'])
@@ -109,7 +115,10 @@ function update_logs(response)
 
     var l = response['data'].length;
     if (l == 0)
+    {
         table.html('<tr><td colspan="100">No log entries.</td>');
+        return;
+    }
 
     var strings = [];
     response['data'] = response['data'].reverse()


### PR DESCRIPTION
Currently, the queue and worker status sections inside AWS often display a "loading" spinning wheel instead of the actual information (at least while the queue is non-empty). This is due to some trivial bugs in the javascript code. This pull request (which I somehow managed to forget about for 4 months...) should fix these issues.
