### PR TITLE
unify attribution names "questions" and "communication"

### DIFF
--- a/cms/server/templates/contest/communication.html
+++ b/cms/server/templates/contest/communication.html
@@ -29,7 +29,7 @@
 
 
 
-{% if config.allow_communication %}
+{% if config.allow_questions %}
 
 <h2>{{ _("Questions") }}</h2>
 <div class="well question_submit">

--- a/examples/cms.conf.sample
+++ b/examples/cms.conf.sample
@@ -114,7 +114,7 @@
     "stl_path": "/usr/share/doc/stl-manual/html/",
 
     "_help": "Whether questions and messages are enabled.",
-    "allow_communication": true,
+    "allow_questions": true,
 
 
 


### PR DESCRIPTION
"conf.questions" and "conf.communication" are mixed. It doesn't cause an error.
