### PR TITLE
Fix permission issue when sandbox truncates output files

### DIFF
--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -5,6 +5,7 @@
 # Copyright © 2010-2013 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
 # Copyright © 2010-2013 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
+# Copyright © 2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -19,6 +20,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import io
 import logging
 import os
 import re
@@ -72,7 +74,7 @@ def pretty_print_cmdline(cmdline):
     spaces.
 
     """
-    return " ".join(["'%s'" % (x) for x in cmdline])
+    return " ".join(["'%s'" % (x.replace("'", "'\"'\"'")) for x in cmdline])
 
 
 def wait_without_std(procs):
@@ -121,20 +123,68 @@ def wait_without_std(procs):
     return [process.wait() for process in procs]
 
 
-def my_truncate(ff, size):
-    """Truncate file-like object ff at specified size. If file is
-    shorter than size, it is not modified (this is different from
-    using ff.truncate(), which doesn't mandate any specific behavior
-    in this case).
+class Truncator(io.RawIOBase):
+    """Wrap a file-like object to simulate truncation.
 
-    After truncations, the file position is reset to 0.
+    This file-like object provides read-only access to a limited prefix
+    of a wrapped file-like object. It provides a truncated version of
+    the file without ever touching the object on the filesystem.
 
     """
-    ff.seek(0, os.SEEK_END)
-    cur_size = ff.tell()
-    if cur_size > size:
-        ff.truncate(size)
-    ff.seek(0, os.SEEK_SET)
+    def __init__(self, fobj, size):
+        """Wrap fobj and give access to its first size bytes.
+
+        fobj (fileobj): a file-like object to wrap.
+        size (int): the number of bytes that will be accessible.
+
+        """
+        self.fobj = fobj
+        self.size = size
+
+    def close(self):
+        """See io.IOBase.close."""
+        self.fobj.close()
+
+    @property
+    def closed(self):
+        """See io.IOBase.closed."""
+        return self.fobj.closed
+
+    def readable(self):
+        """See io.IOBase.readable."""
+        return True
+
+    def seekable(self):
+        """See io.IOBase.seekable."""
+        return True
+
+    def readinto(self, b):
+        """See io.RawIOBase.readinto."""
+        # This is the main "trick": we clip (i.e. mask, reduce, slice)
+        # the given buffer so that it doesn't overflow into the area we
+        # want to hide (that is, out of the prefix) and then we forward
+        # it to the wrapped file-like object.
+        b = memoryview(b)[:max(0, self.size - self.fobj.tell())]
+        return self.fobj.readinto(b)
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        """See io.IOBase.seek."""
+        # We have to catch seeks relative to the end of the file and
+        # adjust them to the new "imposed" size.
+        if whence == io.SEEK_END:
+            if self.fobj.seek(0, io.SEEK_END) > self.size:
+                self.fobj.seek(self.size, io.SEEK_SET)
+            return self.fobj.seek(offset, io.SEEK_CUR)
+        else:
+            return self.fobj.seek(offset, whence)
+
+    def tell(self):
+        """See io.IOBase.tell."""
+        return self.fobj.tell()
+
+    def write(self, b):
+        """See io.RawIOBase.write."""
+        raise io.UnsupportedOperation('write')
 
 
 class SandboxBase(object):
@@ -223,7 +273,6 @@ class SandboxBase(object):
         """
         return os.path.join(self.get_root_path(), path)
 
-    # TODO - Rewrite it as context manager
     def create_file(self, path, executable=False):
         """Create an empty file in the sandbox and open it in write
         binary mode.
@@ -238,7 +287,7 @@ class SandboxBase(object):
         else:
             logger.debug("Creating plain file %s in sandbox." % path)
         real_path = self.relative_path(path)
-        file_ = open(real_path, "wb")
+        file_ = io.open(real_path, "wb")
         mod = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH | stat.S_IWUSR
         if executable:
             mod |= stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
@@ -282,7 +331,6 @@ class SandboxBase(object):
         copyfileobj(file_obj, dest)
         dest.close()
 
-    # TODO - Rewrite it as context manager
     def get_file(self, path, trunc_len=None):
         """Open a file in the sandbox given its relative path.
 
@@ -295,11 +343,9 @@ class SandboxBase(object):
         """
         logger.debug("Retrieving file %s from sandbox" % (path))
         real_path = self.relative_path(path)
+        file_ = io.open(real_path, "rb")
         if trunc_len is not None:
-            file_ = open(real_path, "ab")
-            my_truncate(file_, trunc_len)
-            file_.close()
-        file_ = open(real_path, "rb")
+            file_ = Truncator(file_, trunc_len)
         return file_
 
     def get_file_to_string(self, path, maxlen=1024):
@@ -531,7 +577,7 @@ class StupidSandbox(SandboxBase):
         self.log = None
         logger.debug("Executing program in sandbox with command: %s" %
                      " ".join(command))
-        with open(self.relative_path(self.cmd_file), 'a') as commands:
+        with io.open(self.relative_path(self.cmd_file), 'at') as commands:
             commands.write("%s\n" % (pretty_print_cmdline(command)))
         try:
             p = subprocess.Popen(command,
@@ -1065,7 +1111,7 @@ class IsolateSandbox(SandboxBase):
         args = [self.box_exec] + self.build_box_options() + ["--"] + command
         logger.debug("Executing program in sandbox with command: %s" %
                      pretty_print_cmdline(args))
-        with open(self.relative_path(self.cmd_file), 'a') as commands:
+        with io.open(self.relative_path(self.cmd_file), 'at') as commands:
             commands.write("%s\n" % (pretty_print_cmdline(args)))
         return self.translate_box_exitcode(subprocess.call(args))
 
@@ -1091,7 +1137,7 @@ class IsolateSandbox(SandboxBase):
         args = [self.box_exec] + self.build_box_options() + ["--"] + command
         logger.debug("Executing program in sandbox with command: %s" %
                      pretty_print_cmdline(args))
-        with open(self.relative_path(self.cmd_file), 'a') as commands:
+        with io.open(self.relative_path(self.cmd_file), 'at') as commands:
             commands.write("%s\n" % (pretty_print_cmdline(args)))
         try:
             p = subprocess.Popen(args,


### PR DESCRIPTION
By wrapping the file object in a custom file-like truncator we avoid touching the on-disk instance.

Using the io module gives us context managers for free.

Also improved escaping of command line arguments and made command files be opened in text mode (i.e. accepting unicode) with default encoding (i.e. UTF-8).

Fixes #183 and #243.
