### PR TITLE
AWS: fix AJAX RPC calls when the server is proxied with a prefix.

### DIFF
--- a/cms/server/static/web_rpc.js
+++ b/cms/server/static/web_rpc.js
@@ -25,9 +25,9 @@
  * callback: a function to call with the result of the request.
  */
 function cmsrpc_request (service, shard, method, arguments, callback) {
-    var url = "/rpc/" + encodeURIComponent(service) +
-                  "/" + encodeURIComponent(shard) +
-                  "/" + encodeURIComponent(method);
+    var url = url_root + "/rpc/" + encodeURIComponent(service) +
+                             "/" + encodeURIComponent(shard) +
+                             "/" + encodeURIComponent(method);
     var jqxhr = $.ajax({
         type: "POST",
         url: url,


### PR DESCRIPTION
RPC request used an absolute URL, which doesn't work when server is accessible with a prefix (e.g. http://myserver/admin/).
