### PR TITLE
Fix for notifications showing repeatedly in admin web interface

### DIFF
--- a/cms/server/static/scripts.js
+++ b/cms/server/static/scripts.js
@@ -121,10 +121,11 @@
          * subject (string): subject.
          * text (string): body of notification.
          */
-        display_notification: function(type, timestamp, subject, text, contest_id)
+        display_notification: function(type, timestamp_raw, subject, text, contest_id)
         {
-            if (this.last_notification < timestamp)
-                this.last_notification = timestamp;
+            if (this.last_notification < timestamp_raw)
+                this.last_notification = timestamp_raw;
+            var timestamp = parseInt(timestamp_raw);
             var div = document.getElementById("notifications");
             var s = '<div class="notification notification_type_' + type + '">' +
                 '<div class="notification_close" ' +
@@ -211,7 +212,7 @@
                                           {
                                               display_notification(
                                                   response[i].type,
-                                                  parseInt(response[i].timestamp),
+                                                  response[i].timestamp,
                                                   response[i].subject,
                                                   response[i].text,
                                                   response[i].contest_id);


### PR DESCRIPTION
When a question is submitted by a contestant, the notification in admin web interface is showing more than once (see the screenshot).

![533404c438d38774e413c0b2](https://cloud.githubusercontent.com/assets/338159/2536409/8272862c-b59f-11e3-8206-685efd0af7be.png)

This is a fix for it.
