### PR TITLE
Display testcases' codenames in submission results for admin.

### DIFF
--- a/cms/server/templates/admin/submission.html
+++ b/cms/server/templates/admin/submission.html
@@ -136,7 +136,8 @@
   <table class="bordered">
     <thead>
       <tr>
-        <th style="width: 10%">Outcome</th>
+        <th style="width: 5%">Codename</th>
+        <th style="width: 5%">Outcome</th>
         <th style="width: 2%"></th>
         <th style="width: 45%">Details</th>
         <th style="width: 8%">Shard</th>
@@ -147,6 +148,7 @@
     <tbody>
       {% for idx, ev in sorted((ev.codename, ev) for ev in sr.evaluations) %}
       <tr>
+        <td id="eval_codename_{{ idx }}">{{ ev.codename }}</td>
         <td id="eval_outcome_{{ idx }}">{{ ev.outcome }}</td>
         {% if s.token is not None or ev.testcase.public %}
         <td style="align: center;">&bullet;</td>


### PR DESCRIPTION
When testing a dataset or searching for a problem during contest preparation, it's useful to see the testcase codename in evaluation results (previously had to count it manually :-( ).
