### PR TITLE
Fixed stress test complaining about unicode

### DIFF
--- a/cmstestsuite/web/__init__.py
+++ b/cmstestsuite/web/__init__.py
@@ -180,19 +180,19 @@ class TestRequest(object):
         pass
 
     def store_to_file(self, fd):
-        print("Test type: %s" % (self.__class__.__name__), file=fd)
-        print("Execution start time: %s" %
+        print(u"Test type: %s" % (self.__class__.__name__), file=fd)
+        print(u"Execution start time: %s" %
               (datetime.datetime.fromtimestamp(self.start_time).
                strftime("%d/%m/%Y %H:%M:%S.%f")), file=fd)
-        print("Execution stop time: %s" %
+        print(u"Execution stop time: %s" %
               (datetime.datetime.fromtimestamp(self.stop_time).
                strftime("%d/%m/%Y %H:%M:%S.%f")), file=fd)
-        print("Duration: %f seconds" % (self.duration), file=fd)
-        print("Outcome: %s" % (self.outcome), file=fd)
+        print(u"Duration: %f seconds" % (self.duration), file=fd)
+        print(u"Outcome: %s" % (self.outcome), file=fd)
         fd.write(self.specific_info())
         if self.exception_data is not None:
             print(file=fd)
-            print("EXCEPTION CASTED", file=fd)
+            print(u"EXCEPTION CASTED", file=fd)
             fd.write(self.exception_data)
 
     def specific_info(self):


### PR DESCRIPTION
This fixes the stress test stopped working after this commit: https://github.com/cms-dev/cms/commit/6d694207d78e6ea1434f8104e2eaded97376cf39

The exception was:

Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 808, in __bootstrap_inner
    self.run()
  File "cmstestsuite/StressTest.py", line 141, in run
    self.act()
  File "cmstestsuite/StressTest.py", line 205, in act
    base_url=self.base_url))
  File "cmstestsuite/StressTest.py", line 172, in do_step
    self.log.store_to_file(request)
  File "cmstestsuite/StressTest.py", line 94, in store_to_file
    request.store_to_file(fd)
  File "/usr/local/lib/python2.7/dist-packages/cms-1.1.0pre-py2.7.egg/cmstestsuite/web/__init__.py", line 183, in store_to_file
    print("Test type: %s" % (self.__class__.__name__), file=fd)
TypeError: must be unicode, not str
