### PR TITLE
Clarify when cmsInitDB must be run

### DIFF
--- a/docs/Running CMS.rst
+++ b/docs/Running CMS.rst
@@ -24,12 +24,11 @@ Moreover, you need to change the HBA (a sort of access control list for PostgreS
 
     host  database  cmsuser  192.168.0.0/24  md5
 
-Finally you have to create the database schema for CMS, by running:
+Finally, whether you are running CMS services and PostgreSQL on the same machine or not, you have to create the database schema for CMS, by running:
 
 .. sourcecode:: bash
 
     cmsInitDB
-
 
 Configuring CMS
 ===============


### PR DESCRIPTION
I didn't run cmsInitDB when I first tried CMS, because the docs made it sound like it should only be run if I was "going to use CMS services on different hosts from the one where PostgreSQL is running", because of the structure of the text ("Finally" sounds like a continuation of "Moreover").
