### PR TITLE
Improve performance of counting statistics of submissions for contest overview page of AWS

### DIFF
--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -7,6 +7,7 @@
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2013 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
+# Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -815,30 +816,9 @@ class EvaluationService(Service):
             "invalid": 0}
         with SessionGen() as session:
             contest = Contest.get_from_id(self.contest_id, session)
-            for submission_result in contest.get_submission_results():
-                if submission_result.compilation_failed():
-                    stats["compilation_fail"] += 1
-                elif not submission_result.compiled():
-                    if submission_result.compilation_tries >= \
-                            EvaluationService.MAX_COMPILATION_TRIES:
-                        stats["max_compilations"] += 1
-                    else:
-                        stats["compiling"] += 1
-                elif submission_result.compilation_succeeded():
-                    if submission_result.evaluated():
-                        if submission_result.scored():
-                            stats["scored"] += 1
-                        else:
-                            stats["evaluated"] += 1
-                    else:
-                        if submission_result.evaluation_tries >= \
-                                EvaluationService.MAX_EVALUATION_TRIES:
-                            stats["max_evaluations"] += 1
-                        else:
-                            stats["evaluating"] += 1
-                else:
-                    # Should not happen.
-                    stats["invalid"] += 1
+            stats.update(contest.submissions_statistics(session,
+                         EvaluationService.MAX_COMPILATION_TRIES,
+                         EvaluationService.MAX_EVALUATION_TRIES))
         return stats
 
     @rpc_method


### PR DESCRIPTION
This is one we talked about in https://github.com/cms-dev/cms/issues/313 with advised changes (moved everything to contest.py and reformatted SQL statements).
