### PR TITLE
Fix an integer overflow in isolate

### DIFF
--- a/isolate/isolate.c
+++ b/isolate/isolate.c
@@ -1235,7 +1235,7 @@ setup_rlimits(void)
 #define RLIM(res, val) setup_rlim("RLIMIT_" #res, RLIMIT_##res, val)
 
   if (memory_limit)
-    RLIM(AS, memory_limit * 1024);
+    RLIM(AS, (rlim_t)memory_limit * 1024);
 
   RLIM(STACK, (stack_limit ? (rlim_t)stack_limit * 1024 : RLIM_INFINITY));
   RLIM(NOFILE, 64);


### PR DESCRIPTION
When using a high memory limit (2GB), an integer overflow can happen in the sandbox. This commit should fix that (in the way it was already done for the stack limit).
