### PR TITLE
Allow easy inclusion of sample inputs in gen/GEN

### DIFF
--- a/cmscontrib/YamlLoader.py
+++ b/cmscontrib/YamlLoader.py
@@ -516,24 +516,21 @@ class YamlLoader(Loader):
                     splitted = line.split('#', 1)
 
                     if len(splitted) == 1:
-                        # This line represents a testcase, otherwise it's
-                        # just a blank
+                        # This line represents a testcase, otherwise
+                        # it's just a blank
                         if splitted[0] != '':
                             testcases += 1
 
                     else:
                         testcase, comment = splitted
-                        testcase_detected = False
-                        subtask_detected = False
-                        if testcase.strip() != '':
-                            testcase_detected = True
+                        testcase_detected = testcase.strip() != '' or \
+                            comment.startswith("COPY:")
                         comment = comment.strip()
-                        if comment.startswith('ST:'):
-                            subtask_detected = True
+                        subtask_detected = comment.startswith('ST:')
 
                         if testcase_detected and subtask_detected:
-                            raise Exception("No testcase and subtask in the"
-                                            " same line allowed")
+                            raise Exception("No testcase and subtask in"
+                                            " the same line allowed")
 
                         # This line represents a testcase and contains a
                         # comment, but the comment doesn't start a new


### PR DESCRIPTION
It's common to have 1 or 2 input files copied from the task statement. Often we just allow that from the generator. For example, if the seed is <= 0, then we call a python module which "greps" the (-seed)th input from the tex file.This has led to code duplication among generators and a lot of symlinks to that little python module.

This PR enables the inclusion of a local text file without having to touch the generator. Example gen/GEN:

```
# N    type     seed
#ST: 0
#COPY: testo/example0.txt
#COPY: testo/example1.txt
#ST: 20
20      0          10
500     1          11
...
```
