### PR TITLE
Patrolling

### DIFF
--- a/cms/db/submission.py
+++ b/cms/db/submission.py
@@ -7,6 +7,7 @@
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2012-2013 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
+# Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -86,6 +87,17 @@ class Submission(Base):
     language = Column(
         String,
         nullable=True)
+
+    # Comment from the administrator on the submission.
+    comment = Column(
+        Unicode,
+        nullable=False,
+        default="")
+
+    @property
+    def short_comment(self):
+        """The first line of the comment."""
+        return self.comment.split("\n", 1)[0]
 
     # Follows the description of the fields automatically added by
     # SQLAlchemy.

--- a/cms/server/AdminWebServer.py
+++ b/cms/server/AdminWebServer.py
@@ -7,6 +7,7 @@
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2012-2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
+# Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -1352,14 +1353,14 @@ class AddTestcasesHandler(BaseHandler):
                     match = input_re.match(filename)
                     if match:
                         codename = match.group(1)
-                        if not codename in tests:
+                        if codename not in tests:
                             tests[codename] = [None, None]
                         tests[codename][0] = filename
                     else:
                         match = output_re.match(filename)
                         if match:
                             codename = match.group(1)
-                            if not codename in tests:
+                            if codename not in tests:
                                 tests[codename] = [None, None]
                             tests[codename][1] = filename
 
@@ -1429,7 +1430,7 @@ class AddTestcasesHandler(BaseHandler):
                             "")
                         self.redirect("/add_testcases/%s" % dataset_id)
                         return
-                    if not codename in overwritten_tc:
+                    if codename not in overwritten_tc:
                         added_tc.append(codename)
         except zipfile.BadZipfile:
             self.application.service.add_notification(
@@ -1877,6 +1878,36 @@ class SubmissionFileHandler(FileHandler):
         self.fetch(digest, "text/plain", real_filename)
 
 
+class SubmissionCommentHandler(BaseHandler):
+    """Called when the admin comments on a submission.
+
+    """
+    def post(self, submission_id, dataset_id=None):
+        submission = self.safe_get_item(Submission, submission_id)
+
+        try:
+            attrs = {"comment": submission.comment}
+            self.get_string(attrs, "comment")
+            submission.set_attrs(attrs)
+
+        except Exception as error:
+            self.application.service.add_notification(
+                make_datetime(), "Invalid field(s)", repr(error))
+            if dataset_id is None:
+                self.redirect("/submission/%s" % submission_id)
+            else:
+                self.redirect("/submission/%s/%s" % (submission_id,
+                                                     dataset_id))
+            return
+
+        try_commit(self.sql_session, self)
+        if dataset_id is None:
+            self.redirect("/submission/%s" % submission_id)
+        else:
+            self.redirect("/submission/%s/%s" % (submission_id,
+                                                 dataset_id))
+
+
 class QuestionsHandler(BaseHandler):
     """Page to see and send messages to all the contestants.
 
@@ -2044,6 +2075,7 @@ _aws_handlers = [
     (r"/remove_announcement/([0-9]+)", RemoveAnnouncementHandler),
     (r"/submission/([0-9]+)(?:/([0-9]+))?", SubmissionViewHandler),
     (r"/submission_file/([0-9]+)", SubmissionFileHandler),
+    (r"/submission_comment/([0-9]+)(?:/([0-9]+))?", SubmissionCommentHandler),
     (r"/file/([a-f0-9]+)/([a-zA-Z0-9_.-]+)", FileFromDigestHandler),
     (r"/message/([0-9]+)", MessageHandler),
     (r"/question/([0-9]+)", QuestionReplyHandler),

--- a/cms/server/templates/admin/submission.html
+++ b/cms/server/templates/admin/submission.html
@@ -112,6 +112,16 @@
 
 </div>
 
+<h2 id="title_comment" class="toggling_on">Comment</h2>
+
+<div id="comment">
+  <form enctype="multipart/form-data" action="{{ url_root }}/submission_comment/{{ s.id }}/{{ shown_dataset.id }}" method="POST">
+    <textarea name="comment" cols="40" rows="3">{{ s.comment }}</textarea></br>
+    <input type="submit"/>
+    <input type="reset" value="Reset" />
+  </form>
+</div>
+
   {% if sr is not None and sr.scored() %}
 
 <h2 id="title_evaluation_user" class="toggling_on">Evaluation (as seen by the user)</h2>

--- a/cms/server/templates/admin/submissionlist.html
+++ b/cms/server/templates/admin/submissionlist.html
@@ -28,6 +28,7 @@
         <th>Status</th>
         <th>Files</th>
         <th>Token</th>
+        <th>Comment</th>
         <th>Reevaluate</th>
       </tr>
     </thead>
@@ -120,6 +121,9 @@
           {% else %}
           Yes
           {% end %}
+        </td>
+        <td>
+          {{ s.short_comment }}
         </td>
         <td>
           {% set reevaluation_par_name = "submission" %}

--- a/cms/server/templates/admin/user.html
+++ b/cms/server/templates/admin/user.html
@@ -48,6 +48,7 @@ function update_additional_answer(element, invoker)
         <th>Status</th>
         <th>Files</th>
         <th>Token</th>
+        <th>Comment</th>
         <th>Reevaluate</th>
       </tr>
     </thead>
@@ -131,6 +132,9 @@ function update_additional_answer(element, invoker)
           {% else %}
           Yes
           {% end %}
+        </td>
+        <td>
+          {{ s.short_comment }}
         </td>
         <td>
           {% set reevaluation_par_name = "submission" %}

--- a/cmscontrib/updaters/update_13.py
+++ b/cmscontrib/updaters/update_13.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A class to update a dump created by CMS.
+
+Used by ContestImporter and DumpUpdater.
+
+This adapts the dump to some changes in the model introduced in the
+commit that created this same file.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+
+class Updater(object):
+
+    def __init__(self, data):
+        assert data["_version"] == 12
+        self.objs = data
+
+    def run(self):
+        for k, v in self.objs.iteritems():
+            if k.startswith("_"):
+                continue
+            if v["_class"] == "Submission":
+                v["comment"] = ""
+
+        return self.objs


### PR DESCRIPTION
This lets admins add a (secret) comment to submissions. It can be useful when looking at the submissions for example to:
- manually check that grading works as expected
- find interesting solution ideas
- find mistakes in the submissions to help the students after the contest

The first line of each comment is also displayed on the submission overview pages.
