### PR TITLE
Fix queue_status RPC method

### DIFF
--- a/cms/io/priorityqueue.py
+++ b/cms/io/priorityqueue.py
@@ -45,7 +45,7 @@ from __future__ import unicode_literals
 
 from gevent.event import Event
 
-from cmscommon.datetime import make_datetime
+from cmscommon.datetime import make_datetime, make_timestamp
 
 
 class QueueItem(object):
@@ -56,7 +56,9 @@ class QueueItem(object):
 
     """
 
-    pass
+    def to_dict(self):
+        """Return a dict() representation of the object."""
+        return self.__dict__
 
 
 class QueueEntry(object):
@@ -357,9 +359,9 @@ class PriorityQueue(object):
             timestamp.
 
         """
-        return [{'item': str(entry.item),
+        return [{'item': entry.item.to_dict(),
                  'priority': entry.priority,
-                 'timestamp': entry.timestamp}
+                 'timestamp': make_timestamp(entry.timestamp)}
                 for entry in self._queue]
 
 

--- a/cms/server/static/aws_utils.js
+++ b/cms/server/static/aws_utils.js
@@ -347,30 +347,30 @@ CMS.AWSUtils.prototype.repr_job = function(job) {
         return "N/A";
     } else if (job == "disabled") {
         return "Worker disabled";
-    } else if (job[0] == 'compile') {
+    } else if (job["type"] == 'compile') {
         job_type = 'Compiling';
         object_type = 'submission';
-    } else if (job[0] == 'evaluate') {
+    } else if (job["type"] == 'evaluate') {
         job_type = 'Evaluating';
         object_type = 'submission';
-    } else if (job[0] == 'compile_test') {
+    } else if (job["type"] == 'compile_test') {
         job_type = 'Compiling';
         object_type = 'user_test';
-    } else if (job[0] == 'evaluate_test') {
+    } else if (job["type"] == 'evaluate_test') {
         job_type = 'Evaluating';
         object_type = 'user_test';
     }
 
     if (object_type == 'submission') {
         return job_type + ' the <a href="' + this.url_root + '/submission/'
-            + job[1] + '/' + job[2] + '">result</a> of <a href="' + this.url_root
-            + '/submission/' + job[1] + '">submission ' + job[1]
-            + '</a> on <a href="' + this.url_root + '/dataset/' + job[2]
-            + '">dataset ' + job[2] + '</a>';
+            + job["object_id"] + '/' + job["dataset_id"] + '">result</a> of <a href="' + this.url_root
+            + '/submission/' + job["object_id"] + '">submission ' + job["object_id"]
+            + '</a> on <a href="' + this.url_root + '/dataset/' + job["dataset_id"]
+            + '">dataset ' + job["dataset_id"] + '</a>';
     } else {
-        return job_type + ' the result of user_test ' + job[1]
-            + ' on <a href="' + this.url_root + '/dataset/' + job[2]
-            + '">dataset ' + job[2] + '</a>';
+        return job_type + ' the result of user_test ' + job["object_id"]
+            + ' on <a href="' + this.url_root + '/dataset/' + job["dataset_id"]
+            + '">dataset ' + job["dataset_id"] + '</a>';
     }
 };
 

--- a/cms/server/templates/admin/welcome.html
+++ b/cms/server/templates/admin/welcome.html
@@ -52,7 +52,7 @@ function update_queue_status(response)
     var strings = [];
     for (var i = 0; i < l; i++)
     {
-        var job = utils.repr_job(response['data'][i]['job']);
+        var job = utils.repr_job(response['data'][i]['item']);
         var date = utils.repr_time_ago(response['data'][i]['timestamp']);
         strings.push('<tr><td style="text-align: center;">' + (i + 1) + '</td>');
         strings.push('<td>' + job + '</td>');
@@ -115,7 +115,7 @@ function update_workers_status(response)
     var strings = [];
     for (var i in response['data'])
     {
-        var job = utils.repr_job(response['data'][i]['job']);
+        var job = utils.repr_job(response['data'][i]['operation']);
         var start_time = utils.repr_time_ago(response['data'][i]['start_time']);
         var connected = "Yes";
         if (response['data'][i]['connected'] == false)
@@ -124,7 +124,7 @@ function update_workers_status(response)
         strings.push('<td style="text-align: center;">' + connected + '</td>');
         strings.push('<td>' + job + '</td>');
         strings.push('<td>' + start_time + '</td>');
-        if (response['data'][i]['job'] == "disabled") {
+        if (response['data'][i]['operation'] == "disabled") {
             strings.push('<td><button onclick="javascript:enable_worker(' + i + '); return true;">Enable</button></td></tr>');
         } else {
             strings.push('<td><button onclick="javascript:disable_worker(' + i + '); return true;">Disable</button></td></tr>');


### PR DESCRIPTION
Seems I've missed one issue in the last pull request by Stefano  - RPC method for getting queue status is not working. It's because timestamp field in queue items cannot be serialized to json directly. Also the format of queue_status response is changed. This pull request fixes it.

Shortly:
- the get_status method of PriorityQueue now returns raw item (to be able to use it in callers).
- the queue_status method of TriggeredService does default conversion to json-encodable format
- the queue_status method of EvaluationService replaces the default conversion with the one that needed for AWS
