### PR TITLE
Fix array overflow, improve tests fairness

### DIFF
--- a/cmstestsuite/code/oom-heap.c
+++ b/cmstestsuite/code/oom-heap.c
@@ -6,7 +6,7 @@ int main() {
     big = malloc(128 * 1024 * 1024);
     // If we don't do this cycle, the compiler is smart enough not to
     // map the array into resident memory.
-    for (i = 0; i < 128 * 1024 * 1024; i++) {
+    for (i = 0; i < 128 * 1024 * 1024 / sizeof(int); i++) {
       big[i] = 0;
     }
     scanf("%d", &big[10000]);

--- a/cmstestsuite/code/oom-heap.cpp
+++ b/cmstestsuite/code/oom-heap.cpp
@@ -2,10 +2,10 @@
 
 int main() {
     int *big;
-    big = new int[128 * 1024 * 1024];
+    big = new int[128 * 1024 * 1024 / sizeof(int)];
     // If we don't do this cycle, the compiler is smart enough not to
     // map the array into resident memory.
-    for (int i = 0; i < 128 * 1024 * 1024; i++) {
+    for (int i = 0; i < 128 * 1024 * 1024 / sizeof(int); i++) {
       big[i] = 0;
     }
     std::cin >> big[10000];

--- a/cmstestsuite/code/oom-heap.java
+++ b/cmstestsuite/code/oom-heap.java
@@ -3,7 +3,7 @@ import java.util.Scanner;
 public class batchstdio {
 
     public static void main(String[] args) {
-    	int[] big = new int[128 * 1024 * 1024];
+    	int[] big = new int[128 * 1024 * 1024 / 4];
         Scanner scanner = new Scanner(System.in);
         big[10000] = scanner.nextInt();
         System.out.println("correct "+big[10000]);

--- a/cmstestsuite/code/oom-heap.pas
+++ b/cmstestsuite/code/oom-heap.pas
@@ -4,7 +4,7 @@ var
    big: array of integer;
 
 begin
-    setlength(big, 128 * 1024 * 1024);
+    setlength(big, 128 * 1024 * 1024 div sizeof(integer));
     readln(big[10000]);
     writeln('correct ', big[10000]);
 end.

--- a/cmstestsuite/code/oom-static.c
+++ b/cmstestsuite/code/oom-static.c
@@ -1,12 +1,12 @@
 #include <stdio.h>
 
-int big[132108864];
+int big[128 * 1024 * 1024 / sizeof(int)];
 
 int main() {
     int i;
     // If we don't do this cycle, the compiler is smart enough not to
     // map the array into resident memory.
-    for (i = 0; i < 132108864; i++) {
+    for (i = 0; i < 128 * 1024 * 1024 / sizeof(int); i++) {
       big[i] = 0;
     }
     scanf("%d", &big[10000]);

--- a/cmstestsuite/code/oom-static.cpp
+++ b/cmstestsuite/code/oom-static.cpp
@@ -1,11 +1,11 @@
 #include <iostream>
 
-int big[132108864];
+int big[128 * 1024 * 1024 / sizeof(int)];
 
 int main() {
     // If we don't do this cycle, the compiler is smart enough not to
     // map the array into resident memory.
-    for (int i = 0; i < 132108864; i++) {
+    for (int i = 0; i < 128 * 1024 * 1024 / sizeof(int); i++) {
       big[i] = 0;
     }
     std::cin >> big[10000];

--- a/cmstestsuite/code/oom-static.pas
+++ b/cmstestsuite/code/oom-static.pas
@@ -1,11 +1,11 @@
 program correct;
 
 var
-   big: array[0..132108864] of integer;
+   big: array[0..128 * 1024 * 1024 div sizeof(integer)] of integer;
    i: longint;
 
 begin
-     for i := 1 to 132108864 do
+     for i := 1 to 128 * 1024 * 1024 div sizeof(integer) do
        big[i] := 0;
     readln(big[10000]);
     writeln('correct ', big[10000]);


### PR DESCRIPTION
Fixed array overflow for C-tests.
Improved tests fairness by allocating about ~128MB of memory rather than 128 \* 2^20 ints
