### PR TITLE
Fix untrusted input

### DIFF
--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -319,6 +319,15 @@ class Batch(TaskType):
                                 manager_filename,
                                 job.managers[manager_filename].digest,
                                 executable=True)
+                            # Rewrite input file, since the untrusted
+                            # contestant program may have tampered
+                            # with it; moreover, sometimes the grader
+                            # may destroy the input file in order to
+                            # prevent the contestant's program from
+                            # directly accessing it.
+                            sandbox.create_file_from_storage(
+                                input_filename,
+                                job.input)
                             success, _ = evaluation_step(
                                 sandbox,
                                 [["./%s" % manager_filename,

--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -324,7 +324,12 @@ class Batch(TaskType):
                             # with it; moreover, sometimes the grader
                             # may destroy the input file in order to
                             # prevent the contestant's program from
-                            # directly accessing it.
+                            # directly accessing it. The file is first
+                            # unlinked and then copied again;
+                            # otherwise, if the user running CMS
+                            # cannot write it, this would trigger an
+                            # exception.
+                            sandbox.remove_file(input_filename)
                             sandbox.create_file_from_storage(
                                 input_filename,
                                 job.input)

--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -307,7 +307,7 @@ class Batch(TaskType):
                     elif self.parameters[2] == "comparator":
                         manager_filename = "checker"
 
-                        if not manager_filename in job.managers:
+                        if manager_filename not in job.managers:
                             logger.error("Configuration error: missing or "
                                          "invalid comparator (it must be "
                                          "named 'checker')",

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -1319,6 +1319,7 @@ class EvaluationService(TriggeredService):
                          submission_result.compilation_outcome)
 
         # Enqueue next steps to be done
+        submission_result.sa_session.commit()
         self.submission_enqueue_operations(submission)
 
     def evaluation_ended(self, submission_result):
@@ -1358,6 +1359,7 @@ class EvaluationService(TriggeredService):
                              submission_result.dataset_id)
 
         # Enqueue next steps to be done (e.g., if evaluation failed).
+        submission_result.sa_session.commit()
         self.submission_enqueue_operations(submission)
 
     def user_test_compilation_ended(self, user_test_result):
@@ -1400,6 +1402,7 @@ class EvaluationService(TriggeredService):
                          user_test_result.compilation_outcome)
 
         # Enqueue next steps to be done
+        user_test_result.sa_session.commit()
         self.user_test_enqueue_operations(user_test)
 
     def user_test_evaluation_ended(self, user_test_result):
@@ -1432,6 +1435,7 @@ class EvaluationService(TriggeredService):
                              user_test_result.dataset_id)
 
         # Enqueue next steps to be done (e.g., if evaluation failed).
+        user_test_result.sa_session.commit()
         self.user_test_enqueue_operations(user_test)
 
     @rpc_method

--- a/cmstestsuite/Tests.py
+++ b/cmstestsuite/Tests.py
@@ -195,4 +195,9 @@ ALL_TESTS = [
          languages=(LANG_C,),
          checks=[CheckOverallScore(0, 100)]),
 
+    Test('delete-write-input',
+         task=batch_fileio_managed, filename='delete-write-input.%l',
+         languages=(LANG_C,),
+         checks=[CheckOverallScore(0, 100)]),
+
 ]

--- a/cmstestsuite/Tests.py
+++ b/cmstestsuite/Tests.py
@@ -188,4 +188,11 @@ ALL_TESTS = [
          languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA),
          checks=[CheckOverallScore(0, 100)]),
 
+    # Rewrite input in the solution.
+
+    Test('rewrite-input',
+         task=batch_fileio_managed, filename='rewrite-input.%l',
+         languages=(LANG_C,),
+         checks=[CheckOverallScore(0, 100)]),
+
 ]

--- a/cmstestsuite/code/delete-write-input.c
+++ b/cmstestsuite/code/delete-write-input.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <unistd.h>
+
+/*
+ * This returns the wrong result, but deletes and writes again the
+ * input file so that a wrong result appears as a correct one. CMS is
+ * expected not to be fooled by this cheat attempt.
+ *
+ * CMS can counter this attack by rewriting the input file again
+ * before calling the checker. This test is here to check that this is
+ * done.
+ */
+
+int userfunc(int x) {
+    unlink("input.txt");
+    FILE *fin = fopen("input.txt", "w");
+    fprintf(fin, "%d\n", x+1);
+    fclose(fin);
+    return x+1;
+}

--- a/cmstestsuite/code/rewrite-input.c
+++ b/cmstestsuite/code/rewrite-input.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+
+/*
+ * This returns the wrong result, but overwrites the input file so
+ * that a wrong result appears as a correct one. CMS is expected not
+ * to be fooled by this cheat attempt.
+ *
+ * CMS can counter this attack by making input.txt not writable or by
+ * rewriting it again before calling the checker. Both things should
+ * happen at the moment. This test is here to check that at least one
+ * is functional.
+ */
+
+int userfunc(int x) {
+    FILE *fin = fopen("input.txt", "w");
+    fprintf(fin, "%d\n", x+1);
+    fclose(fin);
+    return x+1;
+}


### PR DESCRIPTION
During the execution of a task of Batch type, the contestant program could tamper with the input file (usually input.txt). We check it out again from the database to be sure.