### PR TITLE
Use source and object files from managers file list when compiling solution

### DIFF
--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -38,6 +38,7 @@ __all__ = [
     "LANGUAGE_NAMES", "LANGUAGES", "DEFAULT_LANGUAGES",
     "SOURCE_EXT_TO_LANGUAGE_MAP",
     "LANGUAGE_TO_SOURCE_EXT_MAP", "LANGUAGE_TO_HEADER_EXT_MAP",
+    "LANGUAGE_TO_OBJ_EXT_MAP",
     # log
     # Nothing intended for external use, no need to advertise anything.
     # util
@@ -101,6 +102,11 @@ LANGUAGE_TO_HEADER_EXT_MAP = {
     LANG_C: ".h",
     LANG_CPP: ".h",
     LANG_PASCAL: "lib.pas",
+}
+LANGUAGE_TO_OBJ_EXT_MAP = {
+    LANG_C: ".o",
+    LANG_CPP: ".o",
+    LANG_PASCAL: ".o",
 }
 
 

--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -27,7 +27,7 @@ from __future__ import unicode_literals
 import logging
 
 from cms import LANGUAGES, LANGUAGE_TO_SOURCE_EXT_MAP, \
-    LANGUAGE_TO_HEADER_EXT_MAP
+    LANGUAGE_TO_HEADER_EXT_MAP, LANGUAGE_TO_OBJ_EXT_MAP
 from cms.grading import get_compilation_commands, get_evaluation_commands, \
     compilation_step, evaluation_step, human_evaluation_message, \
     is_evaluation_passed, extract_outcome_and_text, white_diff_step
@@ -175,6 +175,14 @@ class Batch(TaskType):
         for filename in job.managers.iterkeys():
             if any(filename.endswith(header)
                    for header in LANGUAGE_TO_HEADER_EXT_MAP.itervalues()):
+                files_to_get[filename] = \
+                    job.managers[filename].digest
+            elif any(filename.endswith(source)
+                   for source in LANGUAGE_TO_SOURCE_EXT_MAP.itervalues()):
+                files_to_get[filename] = \
+                    job.managers[filename].digest
+            elif any(filename.endswith(obj)
+                   for obj in LANGUAGE_TO_OBJ_EXT_MAP.itervalues()):
                 files_to_get[filename] = \
                     job.managers[filename].digest
 

--- a/cms/grading/tasktypes/Communication.py
+++ b/cms/grading/tasktypes/Communication.py
@@ -29,7 +29,7 @@ import os
 import tempfile
 
 from cms import LANGUAGES, LANGUAGE_TO_SOURCE_EXT_MAP, \
-    LANGUAGE_TO_HEADER_EXT_MAP, config
+    LANGUAGE_TO_HEADER_EXT_MAP, LANGUAGE_TO_OBJ_EXT_MAP, config
 from cms.grading.Sandbox import wait_without_std
 from cms.grading import get_compilation_commands, compilation_step, \
     human_evaluation_message, is_evaluation_passed, \

--- a/cms/grading/tasktypes/Communication.py
+++ b/cms/grading/tasktypes/Communication.py
@@ -134,6 +134,14 @@ class Communication(TaskType):
                    for header in LANGUAGE_TO_HEADER_EXT_MAP.itervalues()):
                 files_to_get[filename] = \
                     job.managers[filename].digest
+            elif any(filename.endswith(source)
+                   for source in LANGUAGE_TO_SOURCE_EXT_MAP.itervalues()):
+                files_to_get[filename] = \
+                    job.managers[filename].digest
+            elif any(filename.endswith(obj)
+                   for obj in LANGUAGE_TO_OBJ_EXT_MAP.itervalues()):
+                files_to_get[filename] = \
+                    job.managers[filename].digest
 
         for filename, digest in files_to_get.iteritems():
             sandbox.create_file_from_storage(filename, digest)


### PR DESCRIPTION
Now only header files are being copied to the compilation directory. Sometimes it's required to copy source and object files also. For example, when creating a cross-language grader for C++ and Pascal, someone may compile the C++ version to an object file and link it to the Pascal grader to avoid code duplication.