### PR TITLE
Fix first sweeper run

### DIFF
--- a/cms/io/triggeredservice.py
+++ b/cms/io/triggeredservice.py
@@ -212,15 +212,13 @@ class TriggeredService(Service):
 
         self._executors = []
 
-        # Set up and spawn the sweeper.
-        #
-        # TODO: link to greenlet and react to its death.
         self._sweeper_start = None
         self._sweeper_event = Event()
-        gevent.spawn(self._sweeper_loop)
+        # We can't spawn the sweeper here, because there are no executors yet.
+        self._sweeper_spawned = False
 
     def add_executor(self, executor):
-        """Add an executor for the service.
+        """Add an executor for the service and spawn the sweeper.
 
         """
         # Set up and spawn the executors.
@@ -228,6 +226,12 @@ class TriggeredService(Service):
         # TODO: link to greenlet and react to deaths.
         self._executors.append(executor)
         gevent.spawn(executor.run)
+
+        if not self._sweeper_spawned:
+            self._sweeper_spawned = True
+
+            # TODO: link to greenlet and react to its death.
+            gevent.spawn(self._sweeper_loop)
 
     def get_executor(self):
         """Return the first executor (without checking it is unique).

--- a/cms/io/triggeredservice.py
+++ b/cms/io/triggeredservice.py
@@ -262,7 +262,7 @@ class TriggeredService(Service):
         for executor in self._executors:
             executor.dequeue(operation)
 
-    def _start_sweeper(self, timeout):
+    def start_sweeper(self, timeout):
         """Start sweeper loop with given timeout.
 
         timeout (float): timeout in seconds.

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -847,6 +847,7 @@ class EvaluationService(TriggeredService):
             ServiceCoord("ScoringService", 0))
 
         self.add_executor(EvaluationExecutor(self))
+        self._start_sweeper(117.0)
 
         self.add_timeout(self.check_workers_timeout, None,
                          EvaluationService.WORKER_TIMEOUT_CHECK_TIME
@@ -856,9 +857,6 @@ class EvaluationService(TriggeredService):
                          EvaluationService.WORKER_CONNECTION_CHECK_TIME
                          .total_seconds(),
                          immediately=False)
-
-    def _sweeper_timeout(self):
-        return 117.0
 
     def submission_enqueue_operations(self, submission, check_again=False):
         """Push in queue the operations required by a submission.

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -847,7 +847,7 @@ class EvaluationService(TriggeredService):
             ServiceCoord("ScoringService", 0))
 
         self.add_executor(EvaluationExecutor(self))
-        self._start_sweeper(117.0)
+        self.start_sweeper(117.0)
 
         self.add_timeout(self.check_workers_timeout, None,
                          EvaluationService.WORKER_TIMEOUT_CHECK_TIME

--- a/cms/service/PrintingService.py
+++ b/cms/service/PrintingService.py
@@ -231,7 +231,7 @@ class PrintingService(TriggeredService):
         self.file_cacher = FileCacher(self)
 
         self.add_executor(PrintingExecutor(self.file_cacher))
-        self._start_sweeper(61.0)
+        self.start_sweeper(61.0)
 
         if config.printer is None:
             logger.info("Printing is disabled, so the PrintingService is "

--- a/cms/service/PrintingService.py
+++ b/cms/service/PrintingService.py
@@ -231,14 +231,12 @@ class PrintingService(TriggeredService):
         self.file_cacher = FileCacher(self)
 
         self.add_executor(PrintingExecutor(self.file_cacher))
+        self._start_sweeper(61.0)
 
         if config.printer is None:
             logger.info("Printing is disabled, so the PrintingService is "
                         "idle.")
             return
-
-    def _sweeper_timeout(self):
-        return 61.0
 
     def _missing_operations(self):
         """Enqueue unprinted print jobs.

--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -261,12 +261,10 @@ class ProxyService(TriggeredService):
         self.rankings = list()
         for ranking in config.rankings:
             self.add_executor(ProxyExecutor(ranking.encode('utf-8')))
+        self._start_sweeper(347.0)
 
         # Send some initial data to rankings.
         self.initialize()
-
-    def _sweeper_timeout(self):
-        return 347.0
 
     def _missing_operations(self):
         """Return a generator of data to be sent to the rankings..

--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -261,7 +261,7 @@ class ProxyService(TriggeredService):
         self.rankings = list()
         for ranking in config.rankings:
             self.add_executor(ProxyExecutor(ranking.encode('utf-8')))
-        self._start_sweeper(347.0)
+        self.start_sweeper(347.0)
 
         # Send some initial data to rankings.
         self.initialize()

--- a/cms/service/ScoringService.py
+++ b/cms/service/ScoringService.py
@@ -153,7 +153,7 @@ class ScoringService(TriggeredService):
             must_be_present=ranking_enabled)
 
         self.add_executor(ScoringExecutor(self.proxy_service))
-        self._start_sweeper(347.0)
+        self.start_sweeper(347.0)
 
     def _missing_operations(self):
         """Return a generator of unscored submission results.

--- a/cms/service/ScoringService.py
+++ b/cms/service/ScoringService.py
@@ -153,9 +153,7 @@ class ScoringService(TriggeredService):
             must_be_present=ranking_enabled)
 
         self.add_executor(ScoringExecutor(self.proxy_service))
-
-    def _sweeper_timeout(self):
-        return 347.0
+        self._start_sweeper(347.0)
 
     def _missing_operations(self):
         """Return a generator of unscored submission results.

--- a/cmstestsuite/unit_tests/io/triggeredservice_test.py
+++ b/cmstestsuite/unit_tests/io/triggeredservice_test.py
@@ -86,9 +86,6 @@ class FakeTriggeredService(TriggeredService):
     def add_missing_operation(self, operation):
         self._operations.append(operation)
 
-    def _sweeper_timeout(self):
-        return self._timeout
-
     def _missing_operations(self):
         counter = 0
         while self._operations != []:
@@ -114,6 +111,7 @@ class TestTriggeredService(unittest.TestCase):
         self.service = FakeTriggeredService(0, timeout)
         for notifier in self.notifiers:
             self.service.add_executor(FakeExecutor(notifier))
+        self.service.start_sweeper(timeout)
 
     def test_success(self):
         """Test a simple success case."""


### PR DESCRIPTION
If we have some missed operations when started ES or SS, these operations are not executed. You can check this by shutting down SS, re-evaluating a submission and starting SS after evaluation is complete. The submission will not be scored. Similar thing happens with ES.

This commit tries to fix this by starting the sweeper only after at least one executor was added.