### PR TITLE
Add task score mode choosing

### DIFF
--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -38,6 +38,7 @@ __all__ = [
     "LANGUAGE_NAMES", "LANGUAGES", "DEFAULT_LANGUAGES",
     "SOURCE_EXT_TO_LANGUAGE_MAP",
     "LANGUAGE_TO_SOURCE_EXT_MAP", "LANGUAGE_TO_HEADER_EXT_MAP",
+    "SCORE_MODE_IOI_MAX", "SCORE_MODE_IOI_MAX_TOKENED_LAST",
     # log
     # Nothing intended for external use, no need to advertise anything.
     # util
@@ -103,6 +104,12 @@ LANGUAGE_TO_HEADER_EXT_MAP = {
     LANG_PASCAL: "lib.pas",
 }
 
+# Task score modes.
+
+# Maximum score amongst all submissions.
+SCORE_MODE_IOI_MAX = "ioi_max"
+# Maximum score among all tokened submissions and the last submission.
+SCORE_MODE_IOI_MAX_TOKENED_LAST = "ioi_max_tokened_last"
 
 from .util import ConfigError, mkdir, utf8_decoder, Address, ServiceCoord, \
     get_safe_shard, get_service_address, get_service_shards, \

--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -79,7 +79,7 @@ __all__ = [
 
 # Instantiate or import these objects.
 
-version = 13
+version = 14
 
 
 engine = create_engine(config.database, echo=config.database_debug,

--- a/cms/db/task.py
+++ b/cms/db/task.py
@@ -191,6 +191,14 @@ class Task(Base):
         nullable=False,
         default=0)
 
+    # Score mode for the task.
+    # - ioi_max_tokened_last: score = max(last_score, max_tokened_score).
+    # - ioi_max: score = max(scores).
+    score_mode = Column(
+        Enum("ioi_max_tokened_last", "ioi_max", name="score_mode"),
+        nullable=False,
+        default="ioi_max_tokened_last")
+
     # Active Dataset (id and object) currently being used for scoring.
     # The ForeignKeyConstraint for this column is set at table-level.
     active_dataset_id = Column(

--- a/cms/db/task.py
+++ b/cms/db/task.py
@@ -40,6 +40,7 @@ from sqlalchemy.ext.orderinglist import ordering_list
 
 from . import Base, Contest
 from .smartmappedcollection import smart_mapped_collection
+from cms import SCORE_MODE_IOI_MAX, SCORE_MODE_IOI_MAX_TOKENED_LAST
 
 
 class Task(Base):
@@ -192,12 +193,10 @@ class Task(Base):
         default=0)
 
     # Score mode for the task.
-    # - ioi_max_tokened_last: score = max(last_score, max_tokened_score).
-    # - ioi_max: score = max(scores).
     score_mode = Column(
-        Enum("ioi_max_tokened_last", "ioi_max", name="score_mode"),
+        Enum(SCORE_MODE_IOI_MAX_TOKENED_LAST, SCORE_MODE_IOI_MAX, name="score_mode"),
         nullable=False,
-        default="ioi_max_tokened_last")
+        default=SCORE_MODE_IOI_MAX_TOKENED_LAST)
 
     # Active Dataset (id and object) currently being used for scoring.
     # The ForeignKeyConstraint for this column is set at table-level.

--- a/cms/grading/__init__.py
+++ b/cms/grading/__init__.py
@@ -777,10 +777,10 @@ def task_score(user, task):
 
     score = 0.0
 
-    if task.score_mode == "ioi_max":
+    if task.score_mode == SCORE_MODE_IOI_MAX:
         # Modern IOI score mode: maximum score amongst all submissions.
 
-        # The maximum score amongst all submissions (invalid
+        # The maximum score amongst all submissions (not yet computed
         # scores count as 0.0).
         max_score = 0.0
 
@@ -796,9 +796,9 @@ def task_score(user, task):
         # Legacy IOI score mode: maximum score among all tokened submissions
         # and the last submission.
 
-        # The score of the last submission (if valid, otherwise 0.0).
+        # The score of the last submission (if computed, otherwise 0.0).
         last_score = 0.0
-        # The maximum score amongst the tokened submissions (invalid
+        # The maximum score amongst the tokened submissions (not yet computed
         # scores count as 0.0).
         max_tokened_score = 0.0
 

--- a/cms/server/AdminWebServer.py
+++ b/cms/server/AdminWebServer.py
@@ -1443,6 +1443,8 @@ class AddTaskHandler(BaseHandler):
 
             self.get_int(attrs, "score_precision")
 
+            self.get_string(attrs, "score_mode")
+
             # Create the task.
             attrs["num"] = len(self.contest.tasks)
             attrs["contest"] = self.contest
@@ -1534,6 +1536,8 @@ class TaskHandler(BaseHandler):
 
             self.get_int(attrs, "score_precision")
 
+            self.get_string(attrs, "score_mode")
+
             # Update the task.
             task.set_attrs(attrs)
 
@@ -1568,8 +1572,9 @@ class TaskHandler(BaseHandler):
                     "testcase_%s_public" % testcase.id, False))
 
         if try_commit(self.sql_session, self):
-            # Update the task on RWS.
-            self.application.service.proxy_service.reinitialize()
+            # Update the task and score on RWS.
+            self.application.service.proxy_service.dataset_updated(
+                task_id=task.id)
         self.redirect("/task/%s" % task_id)
 
 

--- a/cms/server/templates/admin/add_task.html
+++ b/cms/server/templates/admin/add_task.html
@@ -188,6 +188,23 @@ $("select[name=task_type]").change(showTaskTypeOption);
     </table>
     <div class="hr"></div>
   </div>
+
+  <h2 id="title_score_options" class="toggling_on">Score Options</h2>
+  <div id="score_options">
+    <table>
+      <tr>
+        <td>Score mode</td>
+        <td>
+          <select name="score_mode">
+            <option value="ioi_max_tokened_last" selected>Legacy IOI (maximum score among all tokened submissions and the last submission)</option>
+            <option value="ioi_max">Modern IOI (maximum score amongst all submissions)</option>
+          </select>
+        </td>
+      </tr>
+    </table>
+    <div class="hr"></div>
+  </div>
+
   <input type="submit"/><input type="reset"/>
 </form>
 {% end %}

--- a/cms/server/templates/admin/add_task.html
+++ b/cms/server/templates/admin/add_task.html
@@ -14,7 +14,7 @@ $("select[name=task_type]").change(showTaskTypeOption);
 {% end %}
 
 {% block core %}
-{% from cms import plugin_list %}
+{% from cms import plugin_list, SCORE_MODE_IOI_MAX_TOKENED_LAST, SCORE_MODE_IOI_MAX %}
 {% set task_type_list = plugin_list("cms.grading.tasktypes", "tasktypes") %}
 {% set score_type_list = plugin_list("cms.grading.scoretypes", "scoretypes") %}
 
@@ -196,8 +196,8 @@ $("select[name=task_type]").change(showTaskTypeOption);
         <td>Score mode</td>
         <td>
           <select name="score_mode">
-            <option value="ioi_max_tokened_last" selected>Legacy IOI (maximum score among all tokened submissions and the last submission)</option>
-            <option value="ioi_max">Modern IOI (maximum score amongst all submissions)</option>
+            <option value="{{ SCORE_MODE_IOI_MAX_TOKENED_LAST }}" selected>Legacy IOI (maximum score among all tokened submissions and the last submission)</option>
+            <option value="{{ SCORE_MODE_IOI_MAX }}">Modern IOI (maximum score amongst all submissions)</option>
           </select>
         </td>
       </tr>

--- a/cms/server/templates/admin/task.html
+++ b/cms/server/templates/admin/task.html
@@ -348,6 +348,23 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
     </table>
     <div class="hr"></div>
   </div>
+
+  <h2 id="title_score_options" class="toggling_on">Score Options</h2>
+  <div id="score_options">
+    <table>
+      <tr>
+        <td>Score mode</td>
+        <td>
+          <select name="score_mode">
+            <option value="ioi_max_tokened_last" {{ "selected" if task.score_mode == "ioi_max_tokened_last" else "" }}>Legacy IOI (maximum score among all tokened submissions and the last submission)</option>
+            <option value="ioi_max" {{ "selected" if task.score_mode == "ioi_max" else "" }}>Modern IOI (maximum score amongst all submissions)</option>
+          </select>
+        </td>
+      </tr>
+    </table>
+    <div class="hr"></div>
+  </div>
+
   <input type="submit" value="Update" />
   <input type="reset" value="Reset" />
 </form>

--- a/cms/server/templates/admin/task.html
+++ b/cms/server/templates/admin/task.html
@@ -19,7 +19,7 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
 
 {% block core %}
 {% from cms.server import format_dataset_attrs %}
-{% from cms import plugin_list %}
+{% from cms import plugin_list, SCORE_MODE_IOI_MAX_TOKENED_LAST, SCORE_MODE_IOI_MAX %}
 {% set task_type_list = plugin_list("cms.grading.tasktypes", "tasktypes") %}
 {% set score_type_list = plugin_list("cms.grading.scoretypes", "scoretypes") %}
 
@@ -356,8 +356,8 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
         <td>Score mode</td>
         <td>
           <select name="score_mode">
-            <option value="ioi_max_tokened_last" {{ "selected" if task.score_mode == "ioi_max_tokened_last" else "" }}>Legacy IOI (maximum score among all tokened submissions and the last submission)</option>
-            <option value="ioi_max" {{ "selected" if task.score_mode == "ioi_max" else "" }}>Modern IOI (maximum score amongst all submissions)</option>
+            <option value="{{ SCORE_MODE_IOI_MAX_TOKENED_LAST }}" {{ "selected" if task.score_mode == SCORE_MODE_IOI_MAX_TOKENED_LAST else "" }}>Legacy IOI (maximum score among all tokened submissions and the last submission)</option>
+            <option value="{{ SCORE_MODE_IOI_MAX }}" {{ "selected" if task.score_mode == SCORE_MODE_IOI_MAX else "" }}>Modern IOI (maximum score amongst all submissions)</option>
           </select>
         </td>
       </tr>

--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -341,7 +341,8 @@ class ProxyService(TriggeredService):
                      "order": task.num,
                      "max_score": score_type.max_score,
                      "extra_headers": score_type.ranking_headers,
-                     "score_precision": task.score_precision}
+                     "score_precision": task.score_precision,
+                     "score_mode": task.score_mode}
 
         self.enqueue(ProxyOperation(ProxyExecutor.CONTEST_TYPE,
                                     {contest_id: contest_data}))

--- a/cmsranking/Scoring.py
+++ b/cmsranking/Scoring.py
@@ -76,7 +76,7 @@ class Score(object):
     # On the other hand, different subchanges may have the same time
     # but cms assures that the order in which the subchanges have to
     # be processed is the ascending order of their keys (actually,
-    # this is enforced only for suchanges with the same time).
+    # this is enforced only for subchanges with the same time).
     def __init__(self, score_mode="ioi_max_tokened_last"):
         # The submissions in their current status.
         self._submissions = dict()

--- a/cmsranking/Task.py
+++ b/cmsranking/Task.py
@@ -55,6 +55,7 @@ class Task(Entity):
         self.max_score = None
         self.extra_headers = None
         self.order = None
+        self.score_mode = "ioi_max_tokened_last"
 
     @staticmethod
     def validate(data):
@@ -80,6 +81,8 @@ class Task(Entity):
                 "Field 'score_precision' is negative"
             assert isinstance(data['extra_headers'], list), \
                 "Field 'extra_headers' isn't a list of strings"
+            assert isinstance(data['score_mode'], six.text_type), \
+                "Field 'score_mode' isn't a string"
             for i in data['extra_headers']:
                 assert isinstance(i, six.text_type), \
                     "Field 'extra_headers' isn't a list of strings"
@@ -99,6 +102,7 @@ class Task(Entity):
         self.score_precision = data['score_precision']
         self.extra_headers = data['extra_headers']
         self.order = data['order']
+        self.score_mode = data['score_mode']
 
     def get(self):
         result = self.__dict__.copy()


### PR DESCRIPTION
This adds a "modern IOI" score mode, when all submissions are automatically tokened (https://github.com/cms-dev/cms/issues/360, https://github.com/cms-dev/cms/issues/246). Admins can switch mode for each task separately.