### PR TITLE
Make French translation compile correctly.

### DIFF
--- a/cms/server/po/fr.po
+++ b/cms/server/po/fr.po
@@ -787,8 +787,8 @@ msgstr "Soumettre"
 
 msgid ""
 "You cannot print anything any more as you have used up your printing quota."
-msgstr "Vous ne pouvez plus imprimer car vous avez épuisé votre
-quota d'impression."
+msgstr "Vous ne pouvez plus imprimer car vous avez épuisé votre "
+"quota d'impression."
 
 msgid "Previous print jobs"
 msgstr "Impressions précédentes"


### PR DESCRIPTION
There is a newline at an incorrect position. This commit fixes the syntax error.