### PR TITLE
Add submissions page for viewing all submissions in a contest

### DIFF
--- a/cms/server/AdminWebServer.py
+++ b/cms/server/AdminWebServer.py
@@ -1635,6 +1635,26 @@ class RankingHandler(BaseHandler):
             self.render("ranking.html", **self.r_params)
 
 
+class ContestSubmissionsHandler(BaseHandler):
+    """Shows all submissions for this contest.
+
+    """
+    def get(self, contest_id):
+        contest = self.safe_get_item(Contest, contest_id)
+        self.contest = contest
+
+        self.r_params = self.render_params()
+        self.r_params["submissions"] = \
+            self.sql_session.query(Submission).join(Task)\
+                            .filter(Task.contest == contest)\
+                            .options(joinedload(Submission.user))\
+                            .options(joinedload(Submission.files))\
+                            .options(joinedload(Submission.token))\
+                            .options(joinedload(Submission.results))\
+                            .order_by(Submission.timestamp.desc()).all()
+        self.render("contest_submissions.html", **self.r_params)
+
+
 class AddAnnouncementHandler(BaseHandler):
     """Called to actually add an announcement
 
@@ -1983,6 +2003,7 @@ _aws_handlers = [
     (r"/contest/add", AddContestHandler),
     (r"/ranking/([0-9]+)", RankingHandler),
     (r"/ranking/([0-9]+)/([a-z]+)", RankingHandler),
+    (r"/submissions/([0-9]+)", ContestSubmissionsHandler),
     (r"/task/([0-9]+)", TaskHandler),
     (r"/dataset/([0-9]+)", DatasetSubmissionsHandler),
     (r"/add_task/([0-9]+)", AddTaskHandler),

--- a/cms/server/static/aws_utils.js
+++ b/cms/server/static/aws_utils.js
@@ -556,8 +556,11 @@ CMS.AWSUtils.prototype.switch_contest = function() {
 };
 
 
-CMS.AWSUtils.prototype.show_page = function(item, page) {
-    var elements_per_page = 5;
+CMS.AWSUtils.prototype.show_page = function(item, page, elements_per_page) {
+
+    if(typeof elements_per_page === 'undefined')
+        elements_per_page = 5;
+
     var children = $("#paged_content_" + item).children();
     var npages = Math.ceil(children.length / elements_per_page);
     var final_page = Math.min(page, npages) - 1;
@@ -579,7 +582,7 @@ CMS.AWSUtils.prototype.show_page = function(item, page) {
             selector.append($("<a>").text(i + " ")
                             .click(function(j) {
                                 return function() {
-                                    self.show_page('questions', j);
+                                    self.show_page(item, j, elements_per_page);
                                     return false;
                                 }
                             }(i)));

--- a/cms/server/templates/admin/base.html
+++ b/cms/server/templates/admin/base.html
@@ -99,6 +99,7 @@ $(document).ready(init);
           <ul class="menu">
             <li class="menu_entry"><a class="menu_link" href="{{ url_root }}/contest/{{ contest.id }}">General</a></li>
             <li class="menu_entry"><a class="menu_link" href="{{ url_root }}/ranking/{{ contest.id }}">Ranking</a></li>
+            <li class="menu_entry"><a class="menu_link" href="{{ url_root }}/submissions/{{ contest.id }}">Submissions</a></li>
             <li class="menu_entry"><a class="menu_link" href="{{ url_root }}/userlist/{{ contest.id }}">Users</a></li>
             <li class="menu_entry"><a class="menu_link" href="{{ url_root }}/tasklist/{{ contest.id }}">Tasks</a></li>
             <li class="menu_entry"><a class="menu_link" href="{{ url_root }}/announcements/{{ contest.id }}">Announcements</a></li>

--- a/cms/server/templates/admin/contest_submissions.html
+++ b/cms/server/templates/admin/contest_submissions.html
@@ -1,0 +1,130 @@
+{% extends base.html %}
+
+{% block js_init %}
+utils.show_page("submissions", 1, 50);
+{% end %}
+
+{% block core %}
+{% from cms.grading.scoretypes import get_score_type %}
+{% set score_types = {} %}
+
+<h1>All Submissions</h1>
+
+<div id="submissions">
+
+  {% if submissions == [] %}
+  <p>No submissions found.</p>
+
+  {% else %}
+  {# TODO: implement a more useful pagination for a large contest #}
+  <div id="page_selector_submissions"></div>
+  <table class="bordered">
+    <thead>
+      <tr>
+        <th>Time</th>
+        <th>User</th>
+        <th>Task</th>
+        <th>Status</th>
+        <th>Files</th>
+        <th>Token</th>
+        <th>Comment</th>
+        <th>Reevaluate</th>
+      </tr>
+    </thead>
+    <tbody id="paged_content_submissions">
+      {% for s in sorted(submissions, key=lambda s: s.timestamp, reverse=True) %}
+        {% set dataset = s.task.active_dataset %}
+        {% set sr = s.get_result(dataset) %}
+        {% if s.task.name in score_types %}
+          {% set score_type = score_types[s.task.name] %}
+        {% else %}
+          {% set score_type = get_score_type(dataset=dataset) %}
+          {% set score_types[s.task.name] = score_type %}
+        {% end %}
+      <tr>
+        <td><a href="{{ url_root }}/submission/{{ s.id }}">{{ str(s.timestamp) }}</a></td>
+        <td><a href="{{ url_root }}/user/{{ s.user.id }}">{{ s.user.username }}</a></td>
+        <td><a href="{{ url_root }}/task/{{ s.task.id }}">{{ s.task.name }}</a></td>
+        <td>
+          {% if sr is None or sr.compilation_outcome is None %}
+          Compiling...
+          {% else %}
+          <div id="title_evaluation_{{ s.id }}" class="toggling_off">
+            {% if sr.compilation_outcome == "fail" %}
+            Compilation failed
+            <div id="evaluation_{{ s.id }}" style="display: none;">
+            {% elif not sr.evaluated() %}
+            Evaluating...
+            <div id="evaluation_{{ s.id }}" style="display: none;">
+            {% else %}
+              {% try %}
+                {% set max_score = score_type.max_score %}
+              {% except %}
+                {% set max_score = "[Cannot get score type - see logs]" %}
+              {% end %}
+            Evaluated ({{ sr.score }} / {{ max_score }})
+            <div  id="evaluation_{{ s.id }}" class="score_details" style="display: none;">
+              {% raw score_type.get_html_details(sr.score_details) %}
+            <div id="evaluation_{{ s.id }}" style="display: none;">
+              {% if sr.evaluated() %}
+              <h3>Testcases</h3>
+              <table class="nested bordered">
+                <thead>
+                  <tr>
+                    <th>Outcome</th>
+                    <th></th>
+                    <th>Details</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for idx, ev in sorted((ev.codename, ev) for ev in sr.evaluations) %}
+                  <tr>
+                    <td>{{ ev.outcome }}</td>
+                    {% if s.token is not None or ev.testcase.public %}
+                    <td style="align: center;">&bullet;</td>
+                    {% else %}
+                    <td></td>
+                    {% end %}
+                    <td>{{ ev.text }}</td>
+                  </tr>
+                  {% end %}
+                </tbody>
+              </table>
+              {% end %}
+            {% end %}
+              <h3>Compilation output</h3>{% comment TODO: trim long outputs and add facility to see raw %}
+              <pre>{% if sr.compilation_text is not None %}{{ escape(sr.compilation_text) }}{% end %}</pre>
+            </div>
+          </div>
+
+          {% end %}
+        </td>
+        <td>
+          {% for filename, sub_file in s.files.items() %}
+          <a href="javascript:void(0);" onclick="utils.show_file('{{ filename.replace("%l", s.language) if s.language else filename }}','{{ url_root }}/submission_file/{{ sub_file.id }}')">{{ filename.replace("%l", s.language) if s.language else filename }}<br/>
+          {% end %}
+        </td>
+        <td>
+          {% if s.token is None %}
+          No
+          {% else %}
+          Yes
+          {% end %}
+        </td>
+        <td>
+          {{ s.short_comment }}
+        </td>
+        <td>
+          {% set reevaluation_par_name = "submission" %}
+          {% set reevaluation_par_value = s.id %}
+          {% set reevaluation_par_dataset_id = None %}
+          {% include reevaluation_buttons.html %}
+        </td>
+      </tr>
+      {% end %}
+    </tbody>
+  </table>
+  {% end %}
+</div>
+
+{% end %}

--- a/cms/server/templates/admin/contest_submissions.html
+++ b/cms/server/templates/admin/contest_submissions.html
@@ -124,6 +124,22 @@ utils.show_page("submissions", 1, 50);
       {% end %}
     </tbody>
   </table>
+  <p>
+    {# TODO: use reevaluation_buttons.html #}
+    Reevaluate all {{ len(submissions) }} submissions:
+  <button onclick="cmsrpc_request('{{ url_root }}', 'EvaluationService', 0,
+                   'invalidate_submission', {'level': 'compilation'},
+                   function(response) { utils.redirect_if_ok('{{ url_root }}/submissions/{{ contest.id }}', response); });"
+          title="Compilation" >C</button>
+  <button onclick="cmsrpc_request('{{ url_root }}', 'EvaluationService', 0,
+                   'invalidate_submission', {'level': 'evaluation'},
+                   function(response) { utils.redirect_if_ok('{{ url_root }}/submissions/{{ contest.id }}', response); });"
+          title="Evaluation" >E</button>
+  <button onclick="cmsrpc_request('{{ url_root }}', 'EvaluationService', 0,
+                   'invalidate_submission', {'level': 'score'},
+                   function(response) { utils.redirect_if_ok('{{ url_root }}/submissions/{{ contest.id }}', response); });"
+          title="Score" >S</button>
+  </p>
   {% end %}
 </div>
 


### PR DESCRIPTION
Currently, an admin can view all submissions of a user or a task separately in the admin page.
With this commit, an admin can view all submissions in a contest at once.