### PR TITLE
Fix misdetection of score_mode in rankings.

### DIFF
--- a/cmsranking/Scoring.py
+++ b/cmsranking/Scoring.py
@@ -77,7 +77,7 @@ class Score(object):
     # but cms assures that the order in which the subchanges have to
     # be processed is the ascending order of their keys (actually,
     # this is enforced only for subchanges with the same time).
-    def __init__(self, score_mode="ioi_max_tokened_last"):
+    def __init__(self, score_mode="max_tokened_last"):
         # The submissions in their current status.
         self._submissions = dict()
 
@@ -117,7 +117,7 @@ class Score(object):
                  self._submissions[s_id].time > self._last.time):
             self._last = self._submissions[s_id]
 
-        if self._score_mode == "ioi_max":
+        if self._score_mode == "max":
             score = max([0.0] +
                         [submission.score
                          for submission in self._submissions.values()])

--- a/cmsranking/Task.py
+++ b/cmsranking/Task.py
@@ -55,7 +55,7 @@ class Task(Entity):
         self.max_score = None
         self.extra_headers = None
         self.order = None
-        self.score_mode = "ioi_max_tokened_last"
+        self.score_mode = "max_tokened_last"
 
     @staticmethod
     def validate(data):


### PR DESCRIPTION
cms-dev/cms@573b9e7c3e85d178c442101a78901962fcc1b3e1 changes names in cms-dev/cms@a169a580634978f1c06bf8662b571aad21be4e54, but names in cmsranking are left unchanged, and  this leads to misunderstanding of score modes in RankingWebServer.

This commit fixes the problem.