### PR TITLE
Ranking Server: Contest header abbreviated

### DIFF
--- a/cmsranking/static/Scoreboard.js
+++ b/cmsranking/static/Scoreboard.js
@@ -189,7 +189,7 @@ var Scoreboard = new function () {
             }
 
             result += " \
-    <th colspan=\"4\" class=\"score contest\" data-contest=\"" + c_id + "\" data-sort_key=\"c_" + c_id + "\">" + contest["name"] + "</th>";
+    <th colspan=\"4\" class=\"score contest\" data-contest=\"" + c_id + "\" data-sort_key=\"c_" + c_id + "\"><abbr title=\"" + contest["name"]+"\">" + contest["name"] + "</abbr></th>";
         }
 
         result += " \


### PR DESCRIPTION
The contest name headers in the ranking webpage are now abbreviated (with `<abbr>`) which endows them with tooltips (like the problem names) if they are too long.