### PR TITLE
Fix name of ParameterType form entry.

### DIFF
--- a/cms/grading/ParameterTypes.py
+++ b/cms/grading/ParameterTypes.py
@@ -100,7 +100,7 @@ class ParameterTypeString(ParameterType):
 class ParameterTypeFloat(ParameterType):
     """Numeric parameter type."""
 
-    TEMPLATE = "<input type=\"text\" name=\"{{parameter_name}} \"" \
+    TEMPLATE = "<input type=\"text\" name=\"{{parameter_name}}\" " \
         "value=\"{{parameter_value}}\" />"
 
     def parse_string(self, value):
@@ -118,7 +118,7 @@ class ParameterTypeFloat(ParameterType):
 class ParameterTypeInt(ParameterType):
     """Numeric parameter type."""
 
-    TEMPLATE = "<input type=\"text\" name=\"{{parameter_name}} \"" \
+    TEMPLATE = "<input type=\"text\" name=\"{{parameter_name}}\" " \
         "value=\"{{parameter_value}}\" />"
 
     def parse_string(self, value):
@@ -137,7 +137,7 @@ class ParameterTypeBoolean(ParameterType):
     """Boolean parameter type.
     """
 
-    TEMPLATE = "<input type=\"checkbox\" name=\"{{parameter_name}} \"" \
+    TEMPLATE = "<input type=\"checkbox\" name=\"{{parameter_name}}\" " \
         "{% if checked %}checked{% end %} />"
 
     def parse_string(self, value):


### PR DESCRIPTION
HTML Templates of some ParameterTypes have whitespaces at wrong positions, and it leads to MissingArgumentError when the form is submitted. This commit fixes the problem.