### PR TITLE
Some small improvements to RWS

### DIFF
--- a/cmsranking/static/Ranking.css
+++ b/cmsranking/static/Ranking.css
@@ -115,10 +115,12 @@ abbr {
             user-select: none;
 }
 
-/* #TimeView:not(.post_cont) #TimeView_selector:hover */
-#TimeView.pre_cont #TimeView_selector:hover,
-#TimeView.cont #TimeView_selector:hover,
-#TimeView_selector.open {
+#TimeView:not(.post_cont) #TimeView_selector {
+    cursor: pointer;
+}
+
+#TimeView:not(.post_cont) #TimeView_selector:hover,
+#TimeView:not(.post_cont) #TimeView_selector.open {
     margin: 2px;
     background-color: #EAEAEC;
     border: 2px solid #FAFAFA;
@@ -145,7 +147,6 @@ abbr {
     width: 8px;
     height: 28px;
     vertical-align: top;
-    cursor: pointer;
     margin: 0 4px 0 2px;
 }
 
@@ -191,9 +192,9 @@ abbr {
     cursor: pointer;
 }
 
-#TimeView.pre_cont #TimeView_selector_elapsed,
-#TimeView.post_cont #TimeView_selector_elapsed,
-#TimeView.post_cont #TimeView_selector_remaining {
+#TimeView:not(.cont) #TimeView_selector_elapsed,
+#TimeView.post_cont #TimeView_selector_remaining,
+#TimeView.post_cont #TimeView_selector_current {
     display: none;
 }
 

--- a/cmsranking/static/TimeView.js
+++ b/cmsranking/static/TimeView.js
@@ -45,29 +45,19 @@ var TimeView = new function () {
         }, 1000);
         self.on_timer();
 
-        $("#TimeView_selector_elapsed").click(function () {
-            self.status = 0;
-            self.on_timer();
-            $("#TimeView_selector").removeClass("open");
-        });
+        var bindStatusTo = function(status, id) {
+            $(id).click(function() {
+                self.status = status;
+                self.on_timer();
+            });
+        };
 
-        $("#TimeView_selector_remaining").click(function () {
-            self.status = 1;
-            self.on_timer();
-            $("#TimeView_selector").removeClass("open");
-        });
-
-        $("#TimeView_selector_current").click(function () {
-            self.status = 2;
-            self.on_timer();
-            $("#TimeView_selector").removeClass("open");
-        });
-
-        $("#TimeView_expand").click(function () {
-            $("#TimeView_selector").toggleClass("open");
-        });
+        bindStatusTo(0, "#TimeView_selector_elapsed");
+        bindStatusTo(1, "#TimeView_selector_remaining");
+        bindStatusTo(2, "#TimeView_selector_current");
 
         $("#TimeView_selector").click(function (event) {
+            $(this).toggleClass("open");
             event.stopPropagation();
             return false;
         });
@@ -92,7 +82,7 @@ var TimeView = new function () {
         }
 
         if (c == null) {
-            $("#TimeView_name").text();
+            $("#TimeView_name").text("");
         } else {
             $("#TimeView_name").text(c["name"]);
         }
@@ -107,6 +97,7 @@ var TimeView = new function () {
             // no "next contest": always show the clock
             $("#TimeView").removeClass("elapsed remaining pre_cont cont");
             $("#TimeView").addClass("current post_cont");
+            $("#TimeView_selector").removeClass("open");
             full_time = true;
         } else {
             if (cur_time < c['begin']) {
@@ -141,6 +132,10 @@ var TimeView = new function () {
                 }
             }
         }
+
+        // if the contest has just ended (or has just started) then the chart
+        // on the left is bad positioned: "simulate" window resizing to fix it
+        $(window).trigger('resize');
 
         var time_str = format_time(Math.abs(Math.floor(time)), full_time);
         if (time < 0) {


### PR DESCRIPTION
These are two quite old commits which I never posted as a PR, so I'm posting them now (to see if they can be useful or to get rid of them :smile:).

The first commit updates the time view so that it's *all* clickable (no more trying to click the little arrow)
![Time view](https://cloud.githubusercontent.com/assets/1285361/6548322/9611b00c-c5f4-11e4-8bce-97c5123e4f18.png)

The second commit (which is arguably quite ugly) introduces a little animation from "old_score" to "new_score" when a score change happens (that helps spectators to understand, when a contestant receives a score change, which is the task that the change relate to).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/412)
<!-- Reviewable:end -->
