### PR TITLE
Add desktop notification support to AWS and CWS

### DIFF
--- a/cms/server/static/aws_utils.js
+++ b/cms/server/static/aws_utils.js
@@ -40,7 +40,9 @@ CMS.AWSUtils = function(url_root, timestamp,
     this.file_asked_url = "";
 
     // Ask permission for desktop notifications
-    Notification.requestPermission();
+    if ("Notification" in window) {
+        Notification.requestPermission();
+    }
 };
 
 

--- a/cms/server/static/aws_utils.js
+++ b/cms/server/static/aws_utils.js
@@ -38,6 +38,9 @@ CMS.AWSUtils = function(url_root, timestamp,
     this.remaining_div = null;
     this.file_asked_name = "";
     this.file_asked_url = "";
+
+    // Ask permission for desktop notifications
+    Notification.requestPermission();
 };
 
 
@@ -176,6 +179,32 @@ CMS.AWSUtils.prototype.display_notification = function(type, timestamp,
                     .append($("<div>").addClass("notification_text").text(text))
                    );
     outer.append(inner);
+
+    // Trigger a desktop notification as well
+    this.desktop_notification(type, timestamp, subject, text, contest_id);
+};
+
+
+CMS.AWSUtils.prototype.desktop_notification = function(type, timestamp,
+                                                       subject, text,
+                                                       contest_id) {
+    // Check desktop notifications support
+    if (!("Notification" in window)) {
+        return;
+    }
+
+    // Ask again, if it was not explicitly denied
+    if (Notification.permission !== "granted" && Notification.permission !== "denied") {
+        Notification.requestPermission();
+    }
+
+    // Create notification
+    if (Notification.permission === "granted") {
+        var notification = new Notification(subject, {
+            "body": text,
+            "icon": "/favicon.ico"
+        });
+    }
 };
 
 

--- a/cms/server/static/cws_utils.js
+++ b/cms/server/static/cws_utils.js
@@ -39,7 +39,9 @@ CMS.CWSUtils = function(url_root, timestamp, timezoned_timestamp,
     this.unread_count = 0;
 
     // Ask permission for desktop notifications
-    Notification.requestPermission();
+    if ("Notification" in window) {
+        Notification.requestPermission();
+    }
 };
 
 

--- a/cms/server/static/cws_utils.js
+++ b/cms/server/static/cws_utils.js
@@ -37,6 +37,9 @@ CMS.CWSUtils = function(url_root, timestamp, timezoned_timestamp,
     this.phase = phase;
     this.remaining_div = null;
     this.unread_count = 0;
+
+    // Ask permission for desktop notifications
+    Notification.requestPermission();
 };
 
 
@@ -63,8 +66,9 @@ CMS.CWSUtils.prototype.update_notifications = function() {
 };
 
 
-CMS.CWSUtils.prototype.display_notification = function(
-    type, timestamp, subject, text, level) {
+CMS.CWSUtils.prototype.display_notification = function(type, timestamp,
+                                                       subject, text,
+                                                       level) {
     if (this.last_notification < timestamp) {
         this.last_notification = timestamp;
     }
@@ -95,6 +99,32 @@ CMS.CWSUtils.prototype.display_notification = function(
     }
 
     $("#notifications").prepend(alert);
+
+    // Trigger a desktop notification as well
+    this.desktop_notification(type, timestamp, subject, text, level);
+};
+
+
+CMS.CWSUtils.prototype.desktop_notification = function(type, timestamp,
+                                                       subject, text,
+                                                       level) {
+    // Check desktop notifications support
+    if (!("Notification" in window)) {
+        return;
+    }
+
+    // Ask again, if it was not explicitly denied
+    if (Notification.permission !== "granted" && Notification.permission !== "denied") {
+        Notification.requestPermission();
+    }
+
+    // Create notification
+    if (Notification.permission === "granted") {
+        var notification = new Notification(subject, {
+            "body": text,
+            "icon": "/favicon.ico"
+        });
+    }
 };
 
 


### PR DESCRIPTION
![notif](https://cloud.githubusercontent.com/assets/1285361/7960939/80a64f4e-0a04-11e5-8189-8a4ceb19a486.png)

Currently, it's kinda annoying because every operation in AWS triggers a notification (you will get a lot of "Operation successful"). However is very handy for contestants (and for admins who may forget to look at the "questions" page).