### PR TITLE
Add option to allow / disallow submissions download

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -79,7 +79,7 @@ __all__ = [
 
 # Instantiate or import these objects.
 
-version = 15
+version = 16
 
 
 engine = create_engine(config.database, echo=config.database_debug,

--- a/cms/db/contest.py
+++ b/cms/db/contest.py
@@ -32,7 +32,8 @@ from __future__ import unicode_literals
 from datetime import datetime, timedelta
 
 from sqlalchemy.schema import Column, ForeignKey, CheckConstraint
-from sqlalchemy.types import Integer, Unicode, DateTime, Interval, Enum
+from sqlalchemy.types import Integer, Unicode, DateTime, Interval, Enum, \
+    Boolean
 from sqlalchemy.orm import relationship, backref
 
 from . import Base, RepeatedUnicode
@@ -80,6 +81,12 @@ class Contest(Base):
         RepeatedUnicode(),
         nullable=False,
         default=DEFAULT_LANGUAGES)
+
+    # Whether contestants allowed to download their submissions.
+    submissions_download_allowed = Column(
+        Boolean,
+        nullable=False,
+        default=True)
 
     # The parameters that control contest-tokens follow. Note that
     # their effect during the contest depends on the interaction with

--- a/cms/server/admin/handlers/contest.py
+++ b/cms/server/admin/handlers/contest.py
@@ -63,6 +63,8 @@ class AddContestHandler(SimpleHandler("add_contest.html")):
 
             attrs["languages"] = self.get_arguments("languages")
 
+            self.get_bool(attrs, "submissions_download_allowed")
+
             self.get_string(attrs, "token_mode")
             self.get_int(attrs, "token_max_number")
             self.get_timedelta_sec(attrs, "token_min_interval")
@@ -123,6 +125,8 @@ class ContestHandler(SimpleContestHandler("contest.html")):
                 attrs["allowed_localizations"] = []
 
             attrs["languages"] = self.get_arguments("languages")
+
+            self.get_bool(attrs, "submissions_download_allowed")
 
             self.get_string(attrs, "token_mode")
             self.get_int(attrs, "token_max_number")

--- a/cms/server/admin/templates/add_contest.html
+++ b/cms/server/admin/templates/add_contest.html
@@ -43,6 +43,12 @@
       </td>
     </tr>
     <tr>
+      <td><label for="submissions_download_allowed">Submissions download allowed</label></td>
+      <td>
+        <input type="checkbox" id="submissions_download_allowed" name="submissions_download_allowed" checked/>
+      </td>
+    </tr>
+    <tr>
       <td>[only if finite] Maximum number of tokens a contestant can use</td>
       <td><input type="text" name="token_max_number" size="3" value=""></td>
     </tr>

--- a/cms/server/admin/templates/contest.html
+++ b/cms/server/admin/templates/contest.html
@@ -37,6 +37,12 @@
       </td>
     </tr>
     <tr>
+      <td><label for="submissions_download_allowed">Submissions download allowed</label></td>
+      <td>
+        <input type="checkbox" id="submissions_download_allowed" name="submissions_download_allowed" {{ "checked" if contest.submissions_download_allowed else "" }}/>
+      </td>
+    </tr>
+    <tr>
       <td>Token mode</td>
       <td>
         <select name="token_mode">

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -413,7 +413,10 @@ class TaskSubmissionsHandler(BaseHandler):
 
         self.render("task_submissions.html",
                     task=task, submissions=submissions,
-                    submissions_left=submissions_left, **self.r_params)
+                    submissions_left=submissions_left,
+                    submissions_download_allowed=
+                    self.contest.submissions_download_allowed,
+                    **self.r_params)
 
 
 class SubmissionStatusHandler(BaseHandler):
@@ -524,6 +527,9 @@ class SubmissionFileHandler(FileHandler):
     @tornado.web.authenticated
     @actual_phase_required(0)
     def get(self, task_name, submission_num, filename):
+        if not self.contest.submissions_download_allowed:
+            raise tornado.web.HTTPError(404)
+
         participation = self.current_user
 
         try:

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -84,6 +84,7 @@
         {% end %}
     {% end %}
 {% end %}
+{% if submissions_download_allowed %}
     <td class="files">
         {% comment We replace '%l' with the actual language only when it occurs as an extension at the end of the string and only when %}
         {% comment there isn't another file with that name. This allows to securily reverse the replacement and should work great in %}
@@ -124,6 +125,7 @@
         </div>
         {% end %}
     </td>
+{% end %}
 {% if tokens_contest != 0 and tokens_tasks != 0 %}
     <td class="token">
         {% if s.token is not None %}

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -211,7 +211,9 @@ $(document).ready(function () {
 {% else %}
         <col class="total_score"/>
 {% end %}
+{% if submissions_download_allowed %}
         <col class="files"/>
+{% end %}
 {% if tokens_contest != 0 and tokens_tasks != 0 %}
         <col class="token"/>
 {% end %}
@@ -230,7 +232,9 @@ $(document).ready(function () {
 {% else %}
             <th class="total_score">{{ _("Score") }}</th>
 {% end %}
+{% if submissions_download_allowed %}
             <th class="files">{{ _("Files") }}</th>
+{% end %}
 {% if tokens_contest != 0 and tokens_tasks != 0 %}
             <th class="token">{{ _("Token") }}</th>
 {% end %}

--- a/cmscontrib/updaters/update_16.py
+++ b/cmscontrib/updaters/update_16.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A class to update a dump created by CMS.
+
+Used by ContestImporter and DumpUpdater.
+
+This updater is no-op as the new field (score mode) has a proper
+default value.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+
+class Updater(object):
+
+    def __init__(self, data):
+        assert data["_version"] == 15
+        self.objs = data
+
+    def run(self):
+        return self.objs


### PR DESCRIPTION
Admins can control from AWS whether contestants are allowed to download their submissions. This option maybe useful for security reasons.