### PR TITLE
Administrative accounts

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -107,6 +107,7 @@ class Config(object):
         # AdminWebServer.
         self.admin_listen_address = ""
         self.admin_listen_port = 8889
+        self.admin_cookie_duration = 10 * 60 * 60  # 10 hours
 
         # ProxyService.
         self.rankings = ["http://usern4me:passw0rd@localhost:8890/"]

--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -54,6 +54,8 @@ __all__ = [
     "Contest", "Announcement",
     # user
     "User", "Team", "Participation", "Message", "Question",
+    # admin
+    "Admin",
     # task
     "Task", "Statement", "Attachment", "SubmissionFormatElement", "Dataset",
     "Manager", "Testcase",
@@ -93,6 +95,7 @@ from .types import RepeatedUnicode
 from .base import metadata, Base
 from .contest import Contest, Announcement
 from .user import User, Team, Participation, Message, Question
+from .admin import Admin
 from .task import Task, Statement, Attachment, SubmissionFormatElement, \
     Dataset, Manager, Testcase
 from .submission import Submission, File, Token, SubmissionResult, \

--- a/cms/db/admin.py
+++ b/cms/db/admin.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Admin-related database interfaces for SQLAlchemy.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from sqlalchemy.schema import Column
+from sqlalchemy.types import Boolean, Integer, Unicode
+
+from . import Base
+
+
+class Admin(Base):
+    """Class to store information for a person able to access AWS.
+
+    An enabled account always has read access to all of AWS. For
+    changing data and perform actions, additional permission bits
+    need to be set.
+
+    """
+
+    __tablename__ = 'admins'
+
+    # Auto increment primary key.
+    id = Column(
+        Integer,
+        primary_key=True)
+
+    # Real name (human readable) of the user.
+    name = Column(
+        Unicode,
+        nullable=False)
+
+    # Username used to log in in AWS.
+    username = Column(
+        Unicode,
+        nullable=False,
+        unique=True)
+
+    # String used to authenticate the user, in the format
+    # <authentication type>:<authentication_string>
+    authentication = Column(
+        Unicode,
+        nullable=False)
+
+    # Whether the account is enabled. Disabled accounts have their
+    # info kept in the database, but for all other purposes it is like
+    # they did not exist.
+    enabled = Column(
+        Boolean,
+        nullable=False,
+        default=True)
+
+    # All-access bit. If this is set, the admin can do any operation
+    # in AWS, regardless of the value of the other access bits.
+    permission_all = Column(
+        Boolean,
+        nullable=False,
+        default=False)
+
+    # Messaging-access bit. If this is set, the admin can communicate
+    # with the contestants via announcement, private messages and
+    # questions.
+    permission_messaging = Column(
+        Boolean,
+        nullable=False,
+        default=False)

--- a/cms/db/user.py
+++ b/cms/db/user.py
@@ -30,7 +30,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from datetime import timedelta
-from string import ascii_lowercase
 
 from sqlalchemy.schema import Column, ForeignKey, CheckConstraint, \
     UniqueConstraint
@@ -38,17 +37,9 @@ from sqlalchemy.types import Boolean, Integer, String, Unicode, DateTime, \
     Interval
 from sqlalchemy.orm import relationship, backref
 
+from cmscommon.crypto import generate_random_password
+
 from . import Base, Contest
-
-
-def generate_random_password():
-    """Utility method to generate a random password.
-
-    return (string): a random string.
-
-    """
-    import random
-    return "".join((random.choice(ascii_lowercase) for _ in range(6)))
 
 
 class User(Base):

--- a/cms/io/web_service.py
+++ b/cms/io/web_service.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2010-2013 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
-# Copyright © 2010-2012 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2013-2015 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 #
@@ -33,7 +33,7 @@ import tornado.wsgi
 from gevent.pywsgi import WSGIServer
 
 from werkzeug.wsgi import DispatcherMiddleware, SharedDataMiddleware
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.contrib.fixers import HeaderRewriterFix, ProxyFix
 
 from .service import Service
 from .web_rpc import RPCMiddleware
@@ -46,16 +46,40 @@ class WebService(Service):
     """RPC service with Web server capabilities.
 
     """
+
+    # TODO: the following are headers used to communicate between
+    # middlewares inside CMS. If this list grows more, it would be
+    # better to have an easy way to remove all X-Cms headers at once,
+    # to make sure there are no such headers injected from the
+    # outside.
+
+    # A WSGI application receiving this header can assume that the
+    # user with the given id is authenticated.
+    AUTHENTICATED_USER_HEADER = "X-Cms-Authenticated-User"
+
+    # A WSGI application can set this header to ask to create a new
+    # authentication cookie, refresh an existing cookie, or delete it.
+    AUTHENTICATED_COOKIE_HEADER = "X-Cms-Authenticated-Cookie"
+
     def __init__(self, listen_port, handlers, parameters, shard=0,
                  listen_address=""):
         super(WebService, self).__init__(shard)
 
         static_files = parameters.pop('static_files', [])
         rpc_enabled = parameters.pop('rpc_enabled', False)
+        auth_middleware = parameters.pop('auth_middleware', None)
         is_proxy_used = parameters.pop('is_proxy_used', False)
 
         self.wsgi_app = tornado.wsgi.WSGIApplication(handlers, **parameters)
         self.wsgi_app.service = self
+
+        # Remove any authentication header that a user may try to fake.
+        self.wsgi_app = HeaderRewriterFix(
+            self.wsgi_app,
+            remove_headers=[WebService.AUTHENTICATED_USER_HEADER])
+
+        if auth_middleware is not None:
+            self.wsgi_app = auth_middleware(self.wsgi_app)
 
         for entry in static_files:
             self.wsgi_app = SharedDataMiddleware(

--- a/cms/io/web_service.py
+++ b/cms/io/web_service.py
@@ -67,11 +67,20 @@ class WebService(Service):
 
         static_files = parameters.pop('static_files', [])
         rpc_enabled = parameters.pop('rpc_enabled', False)
+        rpc_auth = parameters.pop('rpc_auth', None)
         auth_middleware = parameters.pop('auth_middleware', None)
         is_proxy_used = parameters.pop('is_proxy_used', False)
 
         self.wsgi_app = tornado.wsgi.WSGIApplication(handlers, **parameters)
         self.wsgi_app.service = self
+
+        for entry in static_files:
+            self.wsgi_app = SharedDataMiddleware(
+                self.wsgi_app, {"/static": entry})
+
+        if rpc_enabled:
+            self.wsgi_app = DispatcherMiddleware(
+                self.wsgi_app, {"/rpc": RPCMiddleware(self, rpc_auth)})
 
         # Remove any authentication header that a user may try to fake.
         self.wsgi_app = HeaderRewriterFix(
@@ -80,14 +89,6 @@ class WebService(Service):
 
         if auth_middleware is not None:
             self.wsgi_app = auth_middleware(self.wsgi_app)
-
-        for entry in static_files:
-            self.wsgi_app = SharedDataMiddleware(
-                self.wsgi_app, {"/static": entry})
-
-        if rpc_enabled:
-            self.wsgi_app = DispatcherMiddleware(
-                self.wsgi_app, {"/rpc": RPCMiddleware(self)})
 
         # If is_proxy_used is set to True we'll use the content of the
         # X-Forwarded-For HTTP header (if provided) to determine the

--- a/cms/server/admin/handlers/__init__.py
+++ b/cms/server/admin/handlers/__init__.py
@@ -25,6 +25,8 @@ from .base import \
     SimpleHandler, \
     SimpleContestHandler
 from .main import \
+    LoginHandler, \
+    LogoutHandler, \
     ResourcesHandler, \
     NotificationsHandler
 from .contest import \
@@ -91,6 +93,8 @@ from .submission import \
 
 HANDLERS = [
     (r"/", OverviewHandler),
+    (r"/login", LoginHandler),
+    (r"/logout", LogoutHandler),
     (r"/resourceslist", ResourcesListHandler),
     (r"/resources", ResourcesHandler),
     (r"/resources/([0-9]+|all)", ResourcesHandler),

--- a/cms/server/admin/handlers/__init__.py
+++ b/cms/server/admin/handlers/__init__.py
@@ -78,6 +78,10 @@ from .user import \
     EditParticipationHandler, \
     AddTeamHandler, \
     TeamHandler
+from .admin import \
+    AddAdminHandler, \
+    AdminsHandler, \
+    AdminHandler
 from .submission import \
     SubmissionHandler, \
     SubmissionCommentHandler, \
@@ -170,6 +174,12 @@ HANDLERS = [
     (r"/team/([0-9]+)", TeamHandler),
     (r"/user/([0-9]+)/add_participation", AddParticipationHandler),
     (r"/user/([0-9]+)/edit_participation", EditParticipationHandler),
+
+    # Admins
+
+    (r"/admins", AdminsHandler),
+    (r"/admins/add", AddAdminHandler),
+    (r"/admin/([0-9]+)", AdminHandler),
 
     # Submissions
 

--- a/cms/server/admin/handlers/admin.py
+++ b/cms/server/admin/handlers/admin.py
@@ -31,7 +31,7 @@ from cms.db import Admin
 from cmscommon.crypto import hash_password
 from cmscommon.datetime import make_datetime
 
-from .base import BaseHandler, SimpleHandler
+from .base import BaseHandler, SimpleHandler, require_permission
 
 
 logger = logging.getLogger(__name__)
@@ -69,6 +69,7 @@ def _admin_attrs(handler):
 
 
 class AddAdminHandler(SimpleHandler("add_admin.html")):
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self):
         fallback_page = "/admins/add"
 
@@ -96,6 +97,7 @@ class AdminsHandler(BaseHandler):
     """Page to see all admins.
 
     """
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self):
         self.r_params = self.render_params()
         self.r_params["admins"] = self.sql_session.query(Admin)\
@@ -108,6 +110,7 @@ class AdminHandler(BaseHandler):
     """Admin handler, with a POST method to edit the admin.
 
     """
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, admin_id):
         admin = self.safe_get_item(Admin, admin_id)
 
@@ -115,7 +118,9 @@ class AdminHandler(BaseHandler):
         self.r_params["admin"] = admin
         self.render("admin.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, admin_id):
+        # TODO: allow admins to edit themselves.
         admin = self.safe_get_item(Admin, admin_id)
 
         try:
@@ -133,6 +138,7 @@ class AdminHandler(BaseHandler):
         else:
             self.redirect("/admin/%s" % admin_id)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def delete(self, admin_id):
         admin = self.safe_get_item(Admin, admin_id)
 

--- a/cms/server/admin/handlers/admin.py
+++ b/cms/server/admin/handlers/admin.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Admin-related handlers for AWS.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+
+from cms.db import Admin
+from cmscommon.crypto import hash_password
+from cmscommon.datetime import make_datetime
+
+from .base import BaseHandler, SimpleHandler
+
+
+logger = logging.getLogger(__name__)
+
+
+def _admin_attrs(handler):
+    """Return a dictionary with the arguments to define an admin
+
+    handler (BaseHandler): the handler receiving the arguments.
+
+    return (dict): a dictionary with the arguments to define an admin,
+        based on those passed to handler.
+
+    """
+    attrs = {}
+
+    handler.get_string(attrs, "username", empty=None)
+    handler.get_string(attrs, "name", empty=None)
+
+    assert attrs.get("username") is not None, "No username specified."
+    assert attrs.get("name") is not None, "No admin name specified."
+
+    # Get the password and translate it to an authentication, if present.
+    handler.get_string(attrs, "password", empty=None)
+    if attrs['password'] is not None:
+        attrs["authentication"] = hash_password(attrs["password"])
+    del attrs["password"]
+
+    handler.get_bool(attrs, "permission_all")
+    handler.get_bool(attrs, "permission_messaging")
+
+    handler.get_bool(attrs, "enabled")
+
+    return attrs
+
+
+class AddAdminHandler(SimpleHandler("add_admin.html")):
+    def post(self):
+        fallback_page = "/admins/add"
+
+        try:
+            attrs = _admin_attrs(self)
+            assert attrs.get("authentication") is not None, \
+                "Empty password not permitted."
+
+            admin = Admin(**attrs)
+            self.sql_session.add(admin)
+
+        except Exception as error:
+            self.application.service.add_notification(
+                make_datetime(), "Invalid field(s)", repr(error))
+            self.redirect(fallback_page)
+            return
+
+        if self.try_commit():
+            self.redirect("/admins")
+        else:
+            self.redirect(fallback_page)
+
+
+class AdminsHandler(BaseHandler):
+    """Page to see all admins.
+
+    """
+    def get(self):
+        self.r_params = self.render_params()
+        self.r_params["admins"] = self.sql_session.query(Admin)\
+            .order_by(Admin.enabled.desc())\
+            .order_by(Admin.username).all()
+        self.render("admins.html", **self.r_params)
+
+
+class AdminHandler(BaseHandler):
+    """Admin handler, with a POST method to edit the admin.
+
+    """
+    def get(self, admin_id):
+        admin = self.safe_get_item(Admin, admin_id)
+
+        self.r_params = self.render_params()
+        self.r_params["admin"] = admin
+        self.render("admin.html", **self.r_params)
+
+    def post(self, admin_id):
+        admin = self.safe_get_item(Admin, admin_id)
+
+        try:
+            admin.set_attrs(_admin_attrs(self))
+
+        except Exception as error:
+            self.application.service.add_notification(
+                make_datetime(), "Invalid field(s)", repr(error))
+            self.redirect("/admin/%s" % admin_id)
+            return
+
+        if self.try_commit():
+            logger.info("Admin %s updated.", admin.id)
+            self.redirect("/admins")
+        else:
+            self.redirect("/admin/%s" % admin_id)
+
+    def delete(self, admin_id):
+        admin = self.safe_get_item(Admin, admin_id)
+
+        self.sql_session.delete(admin)
+        self.try_commit()
+
+        # Page to redirect to.
+        self.write("/admins")

--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -131,14 +131,17 @@ def parse_ip_address_or_subnet(value):
     return value
 
 
-def require_permission(permission="authenticated"):
+def require_permission(permission="authenticated", self_allowed=False):
     """Return a decorator requiring a specific admin permission level
 
     The default value, "authenticated", just checkes that the admin is
     logged in. All other values also implicitly require it. Therefore,
     there is no need to use tornado.web.authenticated if using this.
 
-    permission (string): one of the permission levels
+    permission (string): one of the permission levels.
+    self_allowed (bool): if true, interpret the first argument as the
+       admin id that can execute the method regardless of their
+       permission.
 
     """
     if permission not in [BaseHandler.PERMISSION_ALL,
@@ -164,7 +167,13 @@ def require_permission(permission="authenticated"):
             if user.permission_all or user.__getattribute__(permission_key):
                 return func(self, *args, **kwargs)
             else:
-                raise tornado.web.HTTPError(403, "Admin is not authorized")
+                if self_allowed and len(args) > 0 and int(args[0]) == user.id:
+                    # First argument is assumed to be the admin id,
+                    # encoded as a unicode object, and should match
+                    # the current user id.
+                    return func(self, *args, **kwargs)
+                else:
+                    raise tornado.web.HTTPError(403, "Admin is not authorized")
 
         return newfunc
 

--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -287,6 +287,8 @@ class BaseHandler(CommonRequestHandler):
         params["timestamp"] = make_datetime()
         params["contest"] = self.contest
         params["url_root"] = get_url_root(self.request.path)
+        if self.current_user is not None:
+            params["current_user"] = self.current_user
         if self.contest is not None:
             params["phase"] = self.contest.phase(params["timestamp"])
             # Keep "== None" in filter arguments. SQLAlchemy does not

--- a/cms/server/admin/handlers/contest.py
+++ b/cms/server/admin/handlers/contest.py
@@ -34,13 +34,15 @@ from cms import ServiceCoord, get_service_shards, get_service_address
 from cms.db import Contest
 from cmscommon.datetime import make_datetime
 
-from .base import BaseHandler, SimpleContestHandler, SimpleHandler
+from .base import BaseHandler, SimpleContestHandler, SimpleHandler, \
+    require_permission
 
 
 class AddContestHandler(SimpleHandler("add_contest.html")):
     """Adds a new contest.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self):
         fallback_page = "/contests/add"
 
@@ -107,6 +109,7 @@ class AddContestHandler(SimpleHandler("add_contest.html")):
 
 
 class ContestHandler(SimpleContestHandler("contest.html")):
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, contest_id):
         contest = self.safe_get_item(Contest, contest_id)
 
@@ -173,7 +176,7 @@ class OverviewHandler(BaseHandler):
     """Home page handler, with queue and workers statuses.
 
     """
-
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, contest_id=None):
         if contest_id is not None:
             self.contest = self.safe_get_item(Contest, contest_id)
@@ -183,6 +186,7 @@ class OverviewHandler(BaseHandler):
 
 
 class ResourcesListHandler(BaseHandler):
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, contest_id=None):
         if contest_id is not None:
             self.contest = self.safe_get_item(Contest, contest_id)

--- a/cms/server/admin/handlers/contestannouncement.py
+++ b/cms/server/admin/handlers/contestannouncement.py
@@ -35,13 +35,14 @@ import tornado.web
 from cms.db import Contest, Announcement
 from cmscommon.datetime import make_datetime
 
-from .base import BaseHandler
+from .base import BaseHandler, require_permission
 
 
 class AddAnnouncementHandler(BaseHandler):
     """Called to actually add an announcement
 
     """
+    @require_permission(BaseHandler.PERMISSION_MESSAGING)
     def post(self, contest_id):
         self.contest = self.safe_get_item(Contest, contest_id)
 
@@ -64,6 +65,7 @@ class AnnouncementHandler(BaseHandler):
     """
     # No page to show a single attachment.
 
+    @require_permission(BaseHandler.PERMISSION_MESSAGING)
     def delete(self, contest_id, ann_id):
         ann = self.safe_get_item(Announcement, ann_id)
         self.contest = self.safe_get_item(Contest, contest_id)

--- a/cms/server/admin/handlers/contestquestion.py
+++ b/cms/server/admin/handlers/contestquestion.py
@@ -37,7 +37,7 @@ import tornado.web
 from cms.db import Contest, Question, Participation
 from cmscommon.datetime import make_datetime
 
-from .base import BaseHandler
+from .base import BaseHandler, require_permission
 
 
 logger = logging.getLogger(__name__)
@@ -47,6 +47,7 @@ class QuestionsHandler(BaseHandler):
     """Page to see and send messages to all the contestants.
 
     """
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, contest_id):
         self.contest = self.safe_get_item(Contest, contest_id)
 
@@ -71,6 +72,7 @@ class QuestionReplyHandler(BaseHandler):
         "nocomment": "No comment",
     }
 
+    @require_permission(BaseHandler.PERMISSION_MESSAGING)
     def post(self, contest_id, question_id):
         ref = self.get_argument("ref", "/")
         question = self.safe_get_item(Question, question_id)
@@ -110,6 +112,7 @@ class QuestionIgnoreHandler(BaseHandler):
     question.
 
     """
+    @require_permission(BaseHandler.PERMISSION_MESSAGING)
     def post(self, contest_id, question_id):
         ref = self.get_argument("ref", "/")
         question = self.safe_get_item(Question, question_id)

--- a/cms/server/admin/handlers/contestranking.py
+++ b/cms/server/admin/handlers/contestranking.py
@@ -40,13 +40,14 @@ from sqlalchemy.orm import joinedload
 from cms.db import Contest
 from cms.grading import task_score
 
-from .base import BaseHandler
+from .base import BaseHandler, require_permission
 
 
 class RankingHandler(BaseHandler):
     """Shows the ranking for a contest.
 
     """
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, contest_id, format="online"):
         # This validates the contest id.
         self.safe_get_item(Contest, contest_id)

--- a/cms/server/admin/handlers/contestsubmission.py
+++ b/cms/server/admin/handlers/contestsubmission.py
@@ -31,13 +31,15 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from cms.db import Contest, Submission, Task
-from .base import BaseHandler
+
+from .base import BaseHandler, require_permission
 
 
 class ContestSubmissionsHandler(BaseHandler):
     """Shows all submissions for this contest.
 
     """
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, contest_id):
         contest = self.safe_get_item(Contest, contest_id)
         self.contest = contest

--- a/cms/server/admin/handlers/contesttask.py
+++ b/cms/server/admin/handlers/contesttask.py
@@ -33,7 +33,7 @@ from __future__ import unicode_literals
 from cms.db import Contest, Task
 from cmscommon.datetime import make_datetime
 
-from .base import BaseHandler
+from .base import BaseHandler, require_permission
 
 
 class ContestTasksHandler(BaseHandler):
@@ -41,6 +41,7 @@ class ContestTasksHandler(BaseHandler):
     MOVE_UP = "Move up"
     MOVE_DOWN = "Move down"
 
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, contest_id):
         self.contest = self.safe_get_item(Contest, contest_id)
 
@@ -52,6 +53,7 @@ class ContestTasksHandler(BaseHandler):
                 .all()  # noqa
         self.render("contest_tasks.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, contest_id):
         fallback_page = "/contest/%s/tasks" % contest_id
 
@@ -117,6 +119,7 @@ class ContestTasksHandler(BaseHandler):
 
 
 class AddContestTaskHandler(BaseHandler):
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, contest_id):
         fallback_page = "/contest/%s/tasks" % contest_id
 

--- a/cms/server/admin/handlers/contestuser.py
+++ b/cms/server/admin/handlers/contestuser.py
@@ -38,7 +38,7 @@ import tornado.web
 from cms.db import Contest, Message, Participation, Submission, User, Team
 from cmscommon.datetime import make_datetime
 
-from .base import BaseHandler
+from .base import BaseHandler, require_permission
 
 
 logger = logging.getLogger(__name__)
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 class ContestUsersHandler(BaseHandler):
     REMOVE_FROM_CONTEST = "Remove from contest"
 
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, contest_id):
         self.contest = self.safe_get_item(Contest, contest_id)
 
@@ -61,6 +62,7 @@ class ContestUsersHandler(BaseHandler):
                 .all()
         self.render("contest_users.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, contest_id):
         fallback_page = "/contest/%s/users" % contest_id
 
@@ -97,6 +99,7 @@ class ContestUsersHandler(BaseHandler):
 
 
 class AddContestUserHandler(BaseHandler):
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, contest_id):
         fallback_page = "/contest/%s/users" % contest_id
 
@@ -130,6 +133,7 @@ class ParticipationHandler(BaseHandler):
     questions, messages (and allows to send the latters).
 
     """
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, contest_id, user_id):
         self.contest = self.safe_get_item(Contest, contest_id)
         participation = self.sql_session.query(Participation)\
@@ -151,6 +155,7 @@ class ParticipationHandler(BaseHandler):
         self.r_params["teams"] = self.sql_session.query(Team).all()
         self.render("participation.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, contest_id, user_id):
         fallback_page = "/contest/%s/user/%s" % (contest_id, user_id)
 
@@ -201,6 +206,7 @@ class MessageHandler(BaseHandler):
 
     """
 
+    @require_permission(BaseHandler.PERMISSION_MESSAGING)
     def post(self, contest_id, user_id):
         user = self.safe_get_item(User, user_id)
         self.contest = self.safe_get_item(Contest, contest_id)

--- a/cms/server/admin/handlers/dataset.py
+++ b/cms/server/admin/handlers/dataset.py
@@ -43,7 +43,7 @@ from cms.db import Dataset, Manager, Message, Participation, \
 from cms.grading import compute_changes_for_dataset
 from cmscommon.datetime import make_datetime
 
-from .base import BaseHandler
+from .base import BaseHandler, require_permission
 
 
 logger = logging.getLogger(__name__)
@@ -54,6 +54,7 @@ class DatasetSubmissionsHandler(BaseHandler):
     view the results under different datasets.
 
     """
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, dataset_id):
         dataset = self.safe_get_item(Dataset, dataset_id)
         task = dataset.task
@@ -81,7 +82,9 @@ class CloneDatasetHandler(BaseHandler):
 
     If referred by GET, this handler will return a HTML form.
     If referred by POST, this handler will create the dataset.
+
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, dataset_id_to_copy):
         dataset = self.safe_get_item(Dataset, dataset_id_to_copy)
         task = self.safe_get_item(Task, dataset.task_id)
@@ -102,6 +105,7 @@ class CloneDatasetHandler(BaseHandler):
         self.r_params["default_description"] = description
         self.render("add_dataset.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, dataset_id_to_copy):
         fallback_page = "/dataset/%s/clone" % dataset_id_to_copy
 
@@ -170,6 +174,7 @@ class RenameDatasetHandler(BaseHandler):
     """Rename the descripton of a dataset.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, dataset_id):
         dataset = self.safe_get_item(Dataset, dataset_id)
         task = dataset.task
@@ -179,6 +184,7 @@ class RenameDatasetHandler(BaseHandler):
         self.r_params["dataset"] = dataset
         self.render("rename_dataset.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, dataset_id):
         fallback_page = "/dataset/%s/rename" % dataset_id
 
@@ -209,6 +215,7 @@ class DeleteDatasetHandler(BaseHandler):
     """Delete a dataset from a task.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, dataset_id):
         dataset = self.safe_get_item(Dataset, dataset_id)
         task = dataset.task
@@ -218,6 +225,7 @@ class DeleteDatasetHandler(BaseHandler):
         self.r_params["dataset"] = dataset
         self.render("delete_dataset.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, dataset_id):
         dataset = self.safe_get_item(Dataset, dataset_id)
         task = dataset.task
@@ -234,6 +242,7 @@ class ActivateDatasetHandler(BaseHandler):
     """Set a given dataset to be the active one for a task.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, dataset_id):
         dataset = self.safe_get_item(Dataset, dataset_id)
         task = dataset.task
@@ -258,6 +267,7 @@ class ActivateDatasetHandler(BaseHandler):
         self.r_params["default_notify_participations"] = notify_participations
         self.render("activate_dataset.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, dataset_id):
         dataset = self.safe_get_item(Dataset, dataset_id)
         task = dataset.task
@@ -304,6 +314,7 @@ class ToggleAutojudgeDatasetHandler(BaseHandler):
     """Toggle whether a given dataset is judged automatically or not.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, dataset_id):
         dataset = self.safe_get_item(Dataset, dataset_id)
 
@@ -326,6 +337,7 @@ class AddManagerHandler(BaseHandler):
     """Add a manager to a dataset.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, dataset_id):
         dataset = self.safe_get_item(Dataset, dataset_id)
         task = dataset.task
@@ -335,6 +347,7 @@ class AddManagerHandler(BaseHandler):
         self.r_params["dataset"] = dataset
         self.render("add_manager.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, dataset_id):
         fallback_page = "/dataset/%s/managers/add" % dataset_id
 
@@ -374,6 +387,7 @@ class DeleteManagerHandler(BaseHandler):
     """Delete a manager.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, dataset_id, manager_id):
         manager = self.safe_get_item(Manager, manager_id)
         dataset = self.safe_get_item(Dataset, dataset_id)
@@ -394,6 +408,7 @@ class AddTestcaseHandler(BaseHandler):
     """Add a testcase to a dataset.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, dataset_id):
         dataset = self.safe_get_item(Dataset, dataset_id)
         task = dataset.task
@@ -403,6 +418,7 @@ class AddTestcaseHandler(BaseHandler):
         self.r_params["dataset"] = dataset
         self.render("add_testcase.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, dataset_id):
         fallback_page = "/dataset/%s/testcases/add" % dataset_id
 
@@ -463,6 +479,7 @@ class AddTestcasesHandler(BaseHandler):
     """Add several testcases to a dataset.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, dataset_id):
         dataset = self.safe_get_item(Dataset, dataset_id)
         task = dataset.task
@@ -472,6 +489,7 @@ class AddTestcasesHandler(BaseHandler):
         self.r_params["dataset"] = dataset
         self.render("add_testcases.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, dataset_id):
         fallback_page = "/dataset/%s/testcases/add_multiple" % dataset_id
 
@@ -618,6 +636,7 @@ class DeleteTestcaseHandler(BaseHandler):
     """Delete a testcase.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, dataset_id, testcase_id):
         testcase = self.safe_get_item(Testcase, testcase_id)
         dataset = self.safe_get_item(Dataset, dataset_id)

--- a/cms/server/admin/handlers/submission.py
+++ b/cms/server/admin/handlers/submission.py
@@ -33,7 +33,7 @@ from __future__ import unicode_literals
 from cms.db import Dataset, File, Submission
 from cmscommon.datetime import make_datetime
 
-from .base import BaseHandler, FileHandler
+from .base import BaseHandler, FileHandler, require_permission
 
 
 class SubmissionHandler(BaseHandler):
@@ -43,6 +43,7 @@ class SubmissionHandler(BaseHandler):
     compile please check'.
 
     """
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, submission_id, dataset_id=None):
         submission = self.safe_get_item(Submission, submission_id)
         task = submission.task
@@ -69,6 +70,7 @@ class SubmissionFileHandler(FileHandler):
 
     """
     # FIXME: Replace with FileFromDigestHandler?
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, file_id):
         sub_file = self.safe_get_item(File, file_id)
         submission = sub_file.submission
@@ -86,6 +88,7 @@ class SubmissionCommentHandler(BaseHandler):
     """Called when the admin comments on a submission.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, submission_id, dataset_id=None):
         submission = self.safe_get_item(Submission, submission_id)
 
@@ -110,6 +113,7 @@ class SubmissionCommentHandler(BaseHandler):
 
 class FileFromDigestHandler(FileHandler):
 
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, digest, filename):
         # TODO: Accept a MIME type
         self.sql_session.close()

--- a/cms/server/admin/handlers/task.py
+++ b/cms/server/admin/handlers/task.py
@@ -38,13 +38,14 @@ import tornado.web
 from cms.db import Attachment, Dataset, Session, Statement, Submission, Task
 from cmscommon.datetime import make_datetime
 
-from .base import BaseHandler, SimpleHandler
+from .base import BaseHandler, SimpleHandler, require_permission
 
 
 logger = logging.getLogger(__name__)
 
 
 class AddTaskHandler(SimpleHandler("add_task.html")):
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self):
         fallback_page = "/tasks/add"
 
@@ -123,6 +124,7 @@ class TaskHandler(BaseHandler):
     """Task handler, with a POST method to edit the task.
 
     """
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, task_id):
         task = self.safe_get_item(Task, task_id)
 
@@ -134,6 +136,7 @@ class TaskHandler(BaseHandler):
                 .order_by(Submission.timestamp.desc()).all()
         self.render("task.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, task_id):
         task = self.safe_get_item(Task, task_id)
 
@@ -210,6 +213,7 @@ class AddStatementHandler(BaseHandler):
     """Add a statement to a task.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, task_id):
         task = self.safe_get_item(Task, task_id)
 
@@ -217,6 +221,7 @@ class AddStatementHandler(BaseHandler):
         self.r_params["task"] = task
         self.render("add_statement.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, task_id):
         fallback_page = "/task/%s/statements/add" % task_id
 
@@ -275,6 +280,7 @@ class StatementHandler(BaseHandler):
     """
     # No page for single statements.
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def delete(self, task_id, statement_id):
         statement = self.safe_get_item(Statement, statement_id)
         task = self.safe_get_item(Task, task_id)
@@ -294,6 +300,7 @@ class AddAttachmentHandler(BaseHandler):
     """Add an attachment to a task.
 
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, task_id):
         task = self.safe_get_item(Task, task_id)
 
@@ -301,6 +308,7 @@ class AddAttachmentHandler(BaseHandler):
         self.r_params["task"] = task
         self.render("add_attachment.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, task_id):
         fallback_page = "/task/%s/attachments/add" % task_id
 
@@ -343,6 +351,7 @@ class AttachmentHandler(BaseHandler):
     """
     # No page for single attachments.
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def delete(self, task_id, attachment_id):
         attachment = self.safe_get_item(Attachment, attachment_id)
         task = self.safe_get_item(Task, task_id)
@@ -366,7 +375,9 @@ class AddDatasetHandler(BaseHandler):
 
     If referred by GET, this handler will return a HTML form.
     If referred by POST, this handler will create the dataset.
+
     """
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def get(self, task_id):
         task = self.safe_get_item(Task, task_id)
 
@@ -381,6 +392,7 @@ class AddDatasetHandler(BaseHandler):
         self.r_params["default_description"] = description
         self.render("add_dataset.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, task_id):
         fallback_page = "/task/%s/add_dataset" % task_id
 

--- a/cms/server/admin/handlers/user.py
+++ b/cms/server/admin/handlers/user.py
@@ -33,10 +33,11 @@ from __future__ import unicode_literals
 from cms.db import Contest, Participation, User, Team
 from cmscommon.datetime import make_datetime
 
-from .base import BaseHandler, SimpleHandler
+from .base import BaseHandler, SimpleHandler, require_permission
 
 
 class UserHandler(BaseHandler):
+    @require_permission(BaseHandler.AUTHENTICATED)
     def get(self, user_id):
         user = self.safe_get_item(User, user_id)
 
@@ -55,6 +56,7 @@ class UserHandler(BaseHandler):
                 .all()
         self.render("user.html", **self.r_params)
 
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, user_id):
         fallback_page = "/user/%s" % user_id
 
@@ -163,6 +165,7 @@ class AddTeamHandler(SimpleHandler("add_team.html")):
 
 
 class AddUserHandler(SimpleHandler("add_user.html")):
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self):
         fallback_page = "/users/add"
 
@@ -201,6 +204,7 @@ class AddUserHandler(SimpleHandler("add_user.html")):
 
 
 class AddParticipationHandler(BaseHandler):
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, user_id):
         fallback_page = "/user/%s" % user_id
 
@@ -235,6 +239,7 @@ class AddParticipationHandler(BaseHandler):
 
 
 class EditParticipationHandler(BaseHandler):
+    @require_permission(BaseHandler.PERMISSION_ALL)
     def post(self, user_id):
         fallback_page = "/user/%s" % user_id
 

--- a/cms/server/admin/rpc_authorization.py
+++ b/cms/server/admin/rpc_authorization.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Handle authorization for the RPC calls coming from AWS.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from cms.db import Admin, SessionGen
+from cms.io import WebService
+
+
+AUTHENTICATED_USER_HEADER_IN_ENV = "HTTP_" + \
+    WebService.AUTHENTICATED_USER_HEADER.upper().replace('-', '_')
+
+
+RPCS_ALLOWED_FOR_AUTHENTICATED = [
+    ("ResourceService", "get_resources"),
+    ("EvaluationService", "workers_status"),
+    ("EvaluationService", "submissions_status"),
+    ("EvaluationService", "queue_status"),
+    ("LogService", "last_messages"),
+]
+
+
+RPCS_ALLOWED_FOR_MESSAGING = RPCS_ALLOWED_FOR_AUTHENTICATED + []
+
+
+RPCS_ALLOWED_FOR_ALL = RPCS_ALLOWED_FOR_MESSAGING + [
+    ("ResourceService", "kill_resources"),
+    ("ResourceService", "toggle_autorestart"),
+    ("EvaluationService", "enable_worker"),
+    ("EvaluationService", "disable_worker"),
+    ("EvaluationService", "invalidate_submission"),
+]
+
+
+def rpc_authorization_checker(environ):
+    """Return whether to accept the request.
+
+    environ ({}): WSGI environ object with the request metadata.
+
+    return (bool): whether to accept the request or not.
+
+    """
+    admin_id = int(environ.get(AUTHENTICATED_USER_HEADER_IN_ENV, None))
+    path_info = environ.get("PATH_INFO", "").strip("/").split("/")
+
+    if admin_id is None or len(path_info) < 3:
+        return False
+
+    service = path_info[-3]
+    # We don't check on shard = path_info[-2].
+    method = path_info[-1]
+
+    with SessionGen() as session:
+        # Load admin.
+        admin = session.query(Admin)\
+            .filter(Admin.id == admin_id)\
+            .first()
+        if admin is None:
+            return False
+
+        if admin.permission_all:
+            return (service, method) in RPCS_ALLOWED_FOR_ALL
+
+        elif admin.permission_messaging:
+            return (service, method) in RPCS_ALLOWED_FOR_MESSAGING
+
+        else:
+            return (service, method) in RPCS_ALLOWED_FOR_AUTHENTICATED

--- a/cms/server/admin/server.py
+++ b/cms/server/admin/server.py
@@ -31,12 +31,17 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import base64
+import json
 import logging
 import pkg_resources
 
+from werkzeug.contrib.securecookie import SecureCookie
+from werkzeug.wrappers import Request, Response
+
 from cms import config, ServiceCoord, get_service_shards
-from cms.io import WebService
 from cms.db.filecacher import FileCacher
+from cms.io import WebService
+from cmscommon.datetime import make_timestamp
 
 from .handlers import HANDLERS
 from .handlers import views
@@ -52,13 +57,14 @@ class AdminWebServer(WebService):
     def __init__(self, shard):
         parameters = {
             "ui_modules": views,
-            "login_url": "/",
+            "login_url": "/login",
             "template_path": pkg_resources.resource_filename(
                 "cms.server.admin", "templates"),
             "static_files": [("cms.server", "static"),
                              ("cms.server.admin", "static")],
             "cookie_secret": base64.b64encode(config.secret_key),
             "debug": config.tornado_debug,
+            "auth_middleware": AWSAuthMiddleware,
             "rpc_enabled": True,
         }
         super(AdminWebServer, self).__init__(
@@ -98,3 +104,127 @@ class AdminWebServer(WebService):
 
         """
         self.notifications.append((timestamp, subject, text))
+
+
+class JSONSecureCookie(SecureCookie):
+    serialization_method = json
+
+
+class AWSAuthMiddleware(object):
+    """Authentication layer for AWS.
+
+    For incoming requests, check if the user's cookies grant them
+    access as a specific admin, and in that case adds
+    "X-Cms-Authenticated-User" header with value the id of the admin
+    (as an int). For outgoing requests, looks for the
+    "X-Cms-Authenticated-Cookie" header: if its value is "delete", it
+    deletes the user's cookie; if it is "refresh" it refreshes is,
+    extending its validity (maybe this implies creating it).
+
+    """
+
+    AUTHENTICATED_USER_HEADER_IN_ENV = "HTTP_" + \
+        WebService.AUTHENTICATED_USER_HEADER.upper().replace('-', '_')
+
+    # Name of the cookie containing the authentication for AWS.
+    COOKIE = "awslogin"
+
+    def __init__(self, app):
+        """Create an authentication wrapper.
+
+        auth (function|None): underlying WSGI application..
+
+        """
+        self._app = app
+
+    def __call__(self, environ, start_response):
+        """Execute this instance as a WSGI application."""
+        request = Request(environ)
+        admin_id = self._authenticate(request)
+        if admin_id is not None:
+            environ[
+                AWSAuthMiddleware.AUTHENTICATED_USER_HEADER_IN_ENV] = admin_id
+        response = self._app(
+            environ,
+            self._build_start_response(environ, start_response, admin_id))
+        return response
+
+    def _build_start_response(self, environ, start_response, admin_id=None):
+        """Return a modified start_response function handling cookies.
+
+        environ ({}): WSGI environ object.
+        start_response (function): original start_response function
+        admin_id (int|None): id of the admin in the cookie, if present.
+
+        return (function): modified start_response function that sets,
+            change or delete the cookie based on the decision of the
+            underlying application
+
+        """
+        def my_start_response(status, headers, exc_info=None):
+            cookie = ""
+            for i, header in enumerate(headers):
+                if header[0] == WebService.AUTHENTICATED_COOKIE_HEADER:
+                    cookie = header[1]
+                    del headers[i]
+                    break
+            response = Response(status=status, headers=headers)
+            remote_addr = environ.get("REMOTE_ADDR")
+            if cookie == "delete":
+                response.delete_cookie(AWSAuthMiddleware.COOKIE)
+            elif cookie == "refresh":
+                response.set_cookie(
+                    AWSAuthMiddleware.COOKIE,
+                    self._get_cookie(admin_id, remote_addr),
+                    httponly=True)
+            elif cookie.startswith("create:"):
+                response.set_cookie(
+                    AWSAuthMiddleware.COOKIE,
+                    self._get_cookie(int(cookie.replace("create:", "")),
+                                     remote_addr),
+                    httponly=True)
+            return response(environ, start_response)
+
+        return my_start_response
+
+    def _authenticate(self, request):
+        """Check if the cookie exists and is valid
+
+        request (werkzeug.wrappers.Request): werkzeug request object.
+
+        return (int|None): admin id in the cookie, if it is valid.
+
+        """
+        cookie = JSONSecureCookie.load_cookie(
+            request, AWSAuthMiddleware.COOKIE, config.secret_key)
+
+        admin_id = cookie.get("id", None)
+        remote_addr = cookie.get("ip", None)
+        timestamp = cookie.get("timestamp", None)
+        if admin_id is None or remote_addr is None or timestamp is None:
+            return None
+
+        if remote_addr != request.remote_addr:
+            return None
+
+        if make_timestamp() - timestamp > config.admin_cookie_duration:
+            return None
+
+        return int(admin_id)
+
+    def _get_cookie(self, admin_id, remote_addr):
+        """Return the cookie for the given admin.
+
+        admin_id (int): id to save in the cookie.
+        remote_addr (unicode): ip of the host making the request.
+
+        return (bytes): secure cookie for the given admin id and the
+            current time.
+
+        """
+        data = {
+            "id": admin_id,
+            "ip": remote_addr,
+            "timestamp": make_timestamp(),
+        }
+        return JSONSecureCookie(data, config.secret_key).serialize()

--- a/cms/server/admin/server.py
+++ b/cms/server/admin/server.py
@@ -45,9 +45,14 @@ from cmscommon.datetime import make_timestamp
 
 from .handlers import HANDLERS
 from .handlers import views
+from .rpc_authorization import rpc_authorization_checker
 
 
 logger = logging.getLogger(__name__)
+
+
+AUTHENTICATED_USER_HEADER_IN_ENV = "HTTP_" + \
+    WebService.AUTHENTICATED_USER_HEADER.upper().replace('-', '_')
 
 
 class AdminWebServer(WebService):
@@ -66,6 +71,7 @@ class AdminWebServer(WebService):
             "debug": config.tornado_debug,
             "auth_middleware": AWSAuthMiddleware,
             "rpc_enabled": True,
+            "rpc_auth": rpc_authorization_checker,
         }
         super(AdminWebServer, self).__init__(
             config.admin_listen_port,
@@ -123,9 +129,6 @@ class AWSAuthMiddleware(object):
 
     """
 
-    AUTHENTICATED_USER_HEADER_IN_ENV = "HTTP_" + \
-        WebService.AUTHENTICATED_USER_HEADER.upper().replace('-', '_')
-
     # Name of the cookie containing the authentication for AWS.
     COOKIE = "awslogin"
 
@@ -142,8 +145,7 @@ class AWSAuthMiddleware(object):
         request = Request(environ)
         admin_id = self._authenticate(request)
         if admin_id is not None:
-            environ[
-                AWSAuthMiddleware.AUTHENTICATED_USER_HEADER_IN_ENV] = admin_id
+            environ[AUTHENTICATED_USER_HEADER_IN_ENV] = admin_id
         response = self._app(
             environ,
             self._build_start_response(environ, start_response, admin_id))

--- a/cms/server/admin/static/aws_style.css
+++ b/cms/server/admin/static/aws_style.css
@@ -185,6 +185,15 @@ ul.normal_list {
     color: red;
 }
 
+.login_notice {
+    font-size: 0.8em;
+    line-height: 1.125em;
+    text-align: left;
+    width: 200px;
+    margin-left: 15px;
+    margin-top: 15px;
+}
+
 .cr_notice {
     font-size: 0.6em;
     line-height: 1.125em;
@@ -609,6 +618,49 @@ body.admin .notifications .notification_close:hover {
     background-color: #F7CBFE;
 }
 
+
+
+/* LOGIN PAGE */
+#login-content {
+    padding: 20px;
+    width: 400px;
+}
+
+#login-content h1 {
+    font-size: 24px;
+}
+
+#login-content h4 {
+    font-size: 18px;
+    font-weight: bold;
+    padding: 15px 0;
+}
+
+#login-content .alert {
+    color: red;
+}
+
+#login-content .section {
+    padding: 10px;
+}
+
+#login-content .section:last-child {
+    float: right;
+    clear: both;
+}
+
+#login-content form label {
+    display: flex;
+}
+
+#login-content form label span {
+    flex-grow: 1;
+    display: flex;
+}
+
+#login-content form label input {
+    width: 200px;
+}
 
 
 

--- a/cms/server/admin/templates/add_admin.html
+++ b/cms/server/admin/templates/add_admin.html
@@ -1,0 +1,19 @@
+{% extends base.html %}
+
+{% block core %}
+
+<div class="core_title">
+  <h1>New admin</h1>
+</div>
+
+<!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
+<form enctype="multipart/form-data" action="{{ url_root }}/admins/add" method="post" >
+  <h2>Admin information</h2>
+
+  {% include fragments/admin_form.html %}
+
+  <input type="submit" value="Create" />
+  <input type="reset" value="Reset" />
+</form>
+{% end %}
+

--- a/cms/server/admin/templates/admin.html
+++ b/cms/server/admin/templates/admin.html
@@ -1,0 +1,27 @@
+{% extends base.html %}
+
+{% block core %}
+
+<div class="core_title">
+  <h1>{{ admin.username }} ({{ admin.name }})</h1>
+</div>
+
+<!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
+<form enctype="multipart/form-data" action="{{ url_root }}/admin/{{ admin.id }}" method="POST">
+  <h2>Admin information</h2>
+
+  {% include fragments/admin_form.html %}
+
+  <input type="submit" value="Update" />
+  <input type="reset" value="Reset" />
+
+  <br/>
+
+  Leaving the password field empty will keep the previous password.
+</form>
+
+<hr/>
+
+<a onclick="CMS.AWSUtils.ajax_delete('{{ url_root }}/admin/{{ admin.id }}'); ">Delete this admin</a>
+
+{% end %}

--- a/cms/server/admin/templates/admin.html
+++ b/cms/server/admin/templates/admin.html
@@ -20,8 +20,10 @@
   Leaving the password field empty will keep the previous password.
 </form>
 
+{% if current_user.permission_all %}
 <hr/>
 
 <a onclick="CMS.AWSUtils.ajax_delete('{{ url_root }}/admin/{{ admin.id }}'); ">Delete this admin</a>
+{% end %}
 
 {% end %}

--- a/cms/server/admin/templates/admins.html
+++ b/cms/server/admin/templates/admins.html
@@ -1,0 +1,50 @@
+{% extends base.html %}
+
+{% block core %}
+
+<div class="core_title">
+  <h1>Admins list</h1>
+</div>
+
+<div id="details">
+  <table class="bordered">
+    <thead>
+      <tr>
+        <th>Enabled</th>
+        <th>Username</th>
+        <th>Name</th>
+        <th>All permissions</th>
+        <th>Messaging permissions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for a in admins %}
+      <tr>
+        <td>{{ a.enabled }}</td>
+        <td><a href="{{ url_root}}/admin/{{ a.id }}">{{ a.username }}</a></td>
+        <td>{{ a.name }}</td>
+        <td>{{ a.permission_all }}</td>
+        <td>{{ a.permission_messaging }}</td>
+      </tr>
+      {% end %}
+    </tbody>
+  </table>
+</div>
+
+<hr/>
+
+<a href="{{ url_root }}/admins/add">Add a new admin</a>
+
+<hr/>
+
+<ul>
+  <li>Disabled admins cannot log in.</li>
+  <li>Admins with the "All permissions" bit set can do any
+    operation, regardless of the status of the other permission
+    bits.</li>
+  <li>The "Messaging" permissions allow the admin to communicate with
+    the contestants, answering questions, sending private messages
+    and announcements.</li>
+</ul>
+
+{% end %}

--- a/cms/server/admin/templates/admins.html
+++ b/cms/server/admin/templates/admins.html
@@ -21,7 +21,13 @@
       {% for a in admins %}
       <tr>
         <td>{{ a.enabled }}</td>
-        <td><a href="{{ url_root}}/admin/{{ a.id }}">{{ a.username }}</a></td>
+        <td>
+          {% if current_user.permission_all or current_user.id == a.id %}
+          <a href="{{ url_root}}/admin/{{ a.id }}">{{ a.username }}</a>
+          {% else %}
+          {{ a.username }}
+          {% end %}
+        </td>
         <td>{{ a.name }}</td>
         <td>{{ a.permission_all }}</td>
         <td>{{ a.permission_messaging }}</td>
@@ -31,9 +37,11 @@
   </table>
 </div>
 
+{% if current_user.permission_all %}
 <hr/>
 
 <a href="{{ url_root }}/admins/add">Add a new admin</a>
+{% end %}
 
 <hr/>
 

--- a/cms/server/admin/templates/announcements.html
+++ b/cms/server/admin/templates/announcements.html
@@ -8,6 +8,7 @@
 <h2 id="title_announcements" class="toggling_on">Announcements</h2>
 <div id="announcements">
   <div class="notifications">
+{% if current_user.permission_all or current_user.permission_messaging %}
     <div class="notification communication">
       <div class="notification_msg">
         <form method="post" action="{{ url_root }}/contest/{{ contest.id }}/announcements/add">
@@ -18,10 +19,12 @@
             <label for="new_text">Text</label>
             <textarea name="text" id="new_text" style="width: 100%" ></textarea>
           </div>
-          <input type="submit" value="Add announcement" />
+          <input type="submit"
+                 value="Add announcement" />
         </form>
       </div>
     </div>
+{% end %}
     {% if contest.announcements != [] %}
       {% for msg in reversed(contest.announcements) %}
       <div class="notification communication">

--- a/cms/server/admin/templates/base.html
+++ b/cms/server/admin/templates/base.html
@@ -121,11 +121,13 @@ $(document).ready(init);
           </li>
           {% end %}
 
+{% if current_user.permission_all %}
           <li class="menu_entry">
             <a class="menu_link" href="{{ url_root }}/contests/add">
               (create new contest...)
             </a>
           </li>
+{% end %}
         </ul>
 
         <h1>Tasks</h1>
@@ -152,11 +154,13 @@ $(document).ready(init);
           </li>
           {% end %}
 
+{% if current_user.permission_all %}
           <li class="menu_entry">
             <a class="menu_link" href="{{ url_root }}/tasks/add">
               (create new task...)
             </a>
           </li>
+{% end %}
         </ul>
 
         <h1>Users</h1>
@@ -202,11 +206,13 @@ $(document).ready(init);
             </li>
           {% end %}
 
+{% if current_user.permission_all %}
           <li class="menu_entry">
             <a class="menu_link" href="{{ url_root }}/teams/add">
               (create new team...)
             </a>
           </li>
+{% end %}
         </ul>
         {% else %}
           <ul class="menu">

--- a/cms/server/admin/templates/base.html
+++ b/cms/server/admin/templates/base.html
@@ -66,7 +66,16 @@ $(document).ready(init);
   <body class="admin">
     <div id="global">
       <div id="sidebar">
+{% if current_user is None %}
         <div id="sidebar_header">
+          <h1 class="parent">Administration</h1>
+        </div>
+{% else %}
+        <div id="sidebar_header">
+          <div class="login_notice">
+            Hello, <a href="{{ url_root }}/admins">{{ current_user.name }}</a>.
+              Logout <a href="{{ url_root }}/logout">here</a>.
+          </div>
           {% if contest is None %}
           <h1 class="parent">Administration</h1>
           {% else %}
@@ -220,6 +229,7 @@ $(document).ready(init);
           <div class="footer">Time left: <span id="remaining"></span></div>
           {% end %}
         {% end %}
+{% end %}
         <div class="cr_notice">CMS <a href="http://github.com/cms-dev/cms/">codebase</a> is released under the<br/><a href="http://www.gnu.org/licenses/agpl.txt">GNU Affero General Public License</a>.</div>
       </div>
 

--- a/cms/server/admin/templates/contest.html
+++ b/cms/server/admin/templates/contest.html
@@ -131,7 +131,12 @@
       <td><input type="text" name="score_precision" value="{{ contest.score_precision }}"></td>
     </tr>
   </table>
-  <input type="submit" value="Update">
+  <input type="submit"
+         value="Update"
+{% if not current_user.permission_all %}
+         disabled
+{% end %}
+         >
   <input type="reset" value="Reset">
 </form>
 

--- a/cms/server/admin/templates/contest_tasks.html
+++ b/cms/server/admin/templates/contest_tasks.html
@@ -15,14 +15,30 @@
     </option>
     {% end %}
   </select>
-  <input type="submit" value="Add task" />
+  <input type="submit"
+{% if not current_user.permission_all %}
+         disabled
+{% end %}
+         value="Add task" />
 </form>
 
 <form action="{{ url_root }}/contest/{{ contest.id }}/tasks" method="POST">
   Edit selected task:
-  <input type="submit" name="operation" value="Move up" />
-  <input type="submit" name="operation" value="Move down" />
-  <input type="submit" name="operation" value="Remove from contest" />
+  <input type="submit" name="operation"
+{% if not current_user.permission_all %}
+         disabled
+{% end %}
+         value="Move up" />
+  <input type="submit" name="operation"
+{% if not current_user.permission_all %}
+         disabled
+{% end %}
+         value="Move down" />
+  <input type="submit" name="operation"
+{% if not current_user.permission_all %}
+         disabled
+{% end %}
+         value="Remove from contest" />
   <table class="bordered">
     <thead>
       <tr>

--- a/cms/server/admin/templates/contest_users.html
+++ b/cms/server/admin/templates/contest_users.html
@@ -23,12 +23,22 @@
     </option>
     {% end %}
   </select>
-  <input type="submit" value="Add user" />
+  <input type="submit"
+{% if not current_user.permission_all %}
+         disabled
+{% end %}
+         value="Add user" />
 </form>
 
 <form action="{{ url_root }}/contest/{{ contest.id }}/users" method="POST">
   Edit selected user:
-  <input type="submit" name="operation" value="Remove from contest" />
+  <input type="submit"
+         name="operation"
+         value="Remove from contest"
+{% if not current_user.permission_all %}
+         disabled
+{% end %}
+         />
   <table class="bordered">
     <thead>
       <tr>

--- a/cms/server/admin/templates/fragments/admin_form.html
+++ b/cms/server/admin/templates/fragments/admin_form.html
@@ -13,6 +13,7 @@
   {% set admin_permission_messaging = False %}
   {% set admin_enabled = True %}
 {% end %}
+
 <div>
   <table>
     <tr>
@@ -27,6 +28,7 @@
       <td>Name</td>
       <td><input type="text" name="name" value="{{ admin_name }}"/></td>
     </tr>
+    {% if current_user.permission_all %}
     <tr>
       <td>All permissions</td>
       <td>
@@ -45,5 +47,6 @@
         <input type="checkbox" name="enabled" {% if admin_enabled %}checked{% end %} />
       </td>
     </tr>
+    {% end %}
   </table>
 </div>

--- a/cms/server/admin/templates/fragments/admin_form.html
+++ b/cms/server/admin/templates/fragments/admin_form.html
@@ -1,0 +1,49 @@
+{# This snippet shows a form to add/edit an admin; if admin is set, its data will be used as defaults. #}
+
+{% try %}
+  {% set admin_username = admin.username %}
+  {% set admin_name = admin.name %}
+  {% set admin_permission_all = admin.permission_all %}
+  {% set admin_permission_messaging = admin.permission_messaging %}
+  {% set admin_enabled = admin.enabled %}
+{% except %}
+  {% set admin_username = "" %}
+  {% set admin_name = "" %}
+  {% set admin_permission_all = True %}
+  {% set admin_permission_messaging = False %}
+  {% set admin_enabled = True %}
+{% end %}
+<div>
+  <table>
+    <tr>
+      <td>Username</td>
+      <td><input type="text" name="username" value="{{ admin_username }}"/></td>
+    </tr>
+    <tr>
+      <td>Password</td>
+      <td><input type="password" name="password" value=""/></td>
+    </tr>
+    <tr>
+      <td>Name</td>
+      <td><input type="text" name="name" value="{{ admin_name }}"/></td>
+    </tr>
+    <tr>
+      <td>All permissions</td>
+      <td>
+        <input type="checkbox" name="permission_all" {% if admin_permission_all %}checked{% end %} />
+      </td>
+    </tr>
+    <tr>
+      <td>Messaging permissions</td>
+      <td>
+        <input type="checkbox" name="permission_messaging" {% if admin_permission_messaging %}checked{% end %} />
+      </td>
+    </tr>
+    <tr>
+      <td>Enabled</td>
+      <td>
+        <input type="checkbox" name="enabled" {% if admin_enabled %}checked{% end %} />
+      </td>
+    </tr>
+  </table>
+</div>

--- a/cms/server/admin/templates/login.html
+++ b/cms/server/admin/templates/login.html
@@ -1,0 +1,46 @@
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <link rel="shortcut icon" href="{{ url_root }}/static/favicon.ico" />
+    <link rel="stylesheet" type="text/css" href="{{ url_root }}/static/reset.css">
+    <link rel="stylesheet" type="text/css" href="{{ url_root }}/static/aws_style.css">
+    <title>Admin</title>
+  </head>
+  <body class="admin">
+    <div id="login-content">
+
+{% if current_user is None %}
+<h1>Welcome</h1>
+    {% if handler.get_argument("login_error", "") != "" %}
+<h4 class="alert">Failed to log in.</h4>
+    {% end %}
+<p>Please log in:</p>
+<form action="{{ url_root }}/login" method="POST">
+  <input type="hidden" name="next" value="{{ handler.get_argument("next", "/") }}">
+  <div class="section">
+    <label>
+      <span>Username</span>
+      <input type="text" name="username">
+    </label>
+  </div>
+  <div class="section">
+    <label class="control-label">
+      <span>Password</span>
+      <input type="password" name="password">
+    </label>
+  </div>
+  <div class="section">
+    <button type="submit">Login</button>
+    <button type="reset">Reset</button>
+  </div>
+</form>
+{% else %}
+
+You are already logged in. <a href="{{ url_root }}/logout">Logout</a>
+or go to the <a href="{{ url_root }}/">overview</a>.
+
+{% end %}
+
+    </div>
+  </body>
+</html>

--- a/cms/server/admin/templates/overview.html
+++ b/cms/server/admin/templates/overview.html
@@ -125,10 +125,19 @@ function update_workers_status(response)
         strings.push('<td>' + job + '</td>');
         strings.push('<td>' + start_time + '</td>');
         if (response['data'][i]['operation'] == "disabled") {
-            strings.push('<td><button onclick="javascript:enable_worker(' + i + '); return true;">Enable</button></td></tr>');
+            strings.push('<td><button onclick="javascript:enable_worker(' + i + '); return true;"' +
+{% if not current_user.permission_all %}
+                         ' disabled' +
+{% end %}
+                         '>Enable</button></td>');
         } else {
-            strings.push('<td><button onclick="javascript:disable_worker(' + i + '); return true;">Disable</button></td></tr>');
+            strings.push('<td><button onclick="javascript:disable_worker(' + i + '); return true;"' +
+{% if not current_user.permission_all %}
+                         ' disabled' +
+{% end %}
+                         '>Disable</button></td>');
         }
+        strings.push('</tr>');
     }
 
     table.html(strings.join(""));

--- a/cms/server/admin/templates/questions.html
+++ b/cms/server/admin/templates/questions.html
@@ -56,6 +56,7 @@ utils.show_page("questions", 1);
       {% else %}
       <div class="notification_subject">Not yet replied.</div>
       {% end %}
+{% if current_user.permission_all or current_user.permission_messaging %}
       {% if msg.reply_timestamp is None %}
       <div class="ignore_reply">
         <form class="ignore_question_form" action="{{ url_root }}/contest/{{ contest.id }}/question/{{ msg.id }}/ignore" name="ignore{{ msg.id }}" method="POST">
@@ -94,6 +95,7 @@ utils.show_page("questions", 1);
           <input type="submit" value="Send"/>
         </form>
       </div>
+{% end %}
     </div>
   </div>
   {% end %}

--- a/cms/server/admin/templates/resources.html
+++ b/cms/server/admin/templates/resources.html
@@ -161,9 +161,11 @@ var getters = [];
                 {
                     strings.push('</td><td>');
                     strings.push(utils.repr_time_ago_short((new Date()).getTime()/1000 - response['data'][l-1][1]['services'][s]['since']));
+{% if current_user.permission_all %}
                     if (s.lastIndexOf("LogService,", 0) !== 0 &&
                         s.lastIndexOf("ResourceService,", 0) !== 0)
                       strings.push(" <a onclick='window.getters[" + this.shard + "].kill_service(\"" + s + "\", this);'>[Kill]</a>");
+{% end %}
                     strings.push('</td><td style="text-align: center;">');
                     strings.push(response['data'][l-1][1]['services'][s]['threads']);
                     strings.push('</td><td style="text-align: center;">');
@@ -177,14 +179,23 @@ var getters = [];
                 }
                 strings.push('</td><td style="text-align: center;">');
                 if (s.lastIndexOf("LogService,", 0) === 0 ||
-                    s.lastIndexOf("ResourceService,", 0) === 0)
+                    s.lastIndexOf("ResourceService,", 0) === 0) {
                   strings.push('N/A');
-                else if (response['data'][l-1][1]['services'][s]['autorestart'] == true)
-                  strings.push(" <input type='checkbox' checked onchange='window.getters[" + this.shard + "].toggle_autorestart(\"" + s + "\", this);' />");
-                else if (response['data'][l-1][1]['services'][s]['autorestart'] == false)
-                  strings.push(" <input type='checkbox' onchange='window.getters[" + this.shard + "].toggle_autorestart(\"" + s + "\", this);' />");
-                else
+                } else if (response['data'][l-1][1]['services'][s]['autorestart'] == true) {
+                  strings.push(" <input type='checkbox' checked onchange='window.getters[" + this.shard + "].toggle_autorestart(\"" + s + "\", this);'");
+{% if not current_user.permission_all %}
+                  strings.push(" disabled");
+{% end %}
+                  strings.push(" />");
+                } else if (response['data'][l-1][1]['services'][s]['autorestart'] == false) {
+                  strings.push(" <input type='checkbox' onchange='window.getters[" + this.shard + "].toggle_autorestart(\"" + s + "\", this);'");
+{% if not current_user.permission_all %}
+                  strings.push(" disabled");
+{% end %}
+                  strings.push(" />");
+                } else {
                   strings.push('N/A');
+                }
                 strings.push('</td></tr>');
             }
             table.html(strings.join(""));

--- a/cms/server/admin/templates/submission.html
+++ b/cms/server/admin/templates/submission.html
@@ -123,7 +123,11 @@
 <div id="comment">
   <form enctype="multipart/form-data" action="{{ url_root }}/submission/{{ s.id }}/{{ shown_dataset.id }}/comment" method="POST">
     <textarea name="comment" cols="40" rows="3">{{ s.comment }}</textarea></br>
-    <input type="submit"/>
+    <input
+{% if not current_user.permission_all %}
+       disabled
+{% end %}
+       type="submit"/>
     <input type="reset" value="Reset" />
   </form>
 </div>

--- a/cms/server/admin/templates/task.html
+++ b/cms/server/admin/templates/task.html
@@ -115,7 +115,9 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
 {% if len(task.datasets) == 0 %}
     No datasets have been created for this task.<br/>
 {% end %}
+{% if current_user.permission_all %}
     <a href="{{ url_root }}/task/{{ task.id }}/add_dataset">Create a new dataset</a><br/>
+{% end %}
     </p>
 
 {% for dataset in sorted(task.datasets, key=lambda d: d.description) %}
@@ -124,6 +126,7 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
   <div id="dataset_{{ dataset.id }}" class="task_dataset">
 
     <p>
+{% if current_user.permission_all %}
       {% if dataset is task.active_dataset %}
       [Make Live ...]
       {% else %}
@@ -139,6 +142,7 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
       {% if dataset is not task.active_dataset %}
         <a href="{{ url_root }}/dataset/{{ dataset.id }}/autojudge">[{% if dataset.autojudge %}Disable{% else %}Enable{% end %} background judging]</a>
       {% end %}
+{% end %}
       <a href="{{ url_root }}/dataset/{{ dataset.id }}">[View results]</a>
     </p>
 
@@ -215,7 +219,9 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
         <tr>
           <td>Managers</td>
           <td>
+{% if current_user.permission_all %}
             <a href="{{ url_root }}/dataset/{{ dataset.id }}/managers/add">Add a manager</a></br>
+{% end %}
             {% if len(dataset.managers) == 0 %}
               No managers.
             {% else %}
@@ -250,8 +256,10 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
 
   <h4 id="title_testcases_{{ dataset.id }}" class="toggling_on">Test cases</h4>
     <div id="testcases_{{ dataset.id }}" class="task_dataset_testcases">
+{% if current_user.permission_all %}
       <a href="{{ url_root }}/dataset/{{ dataset.id }}/testcases/add">Add a testcase</a>
       <a href="{{ url_root }}/dataset/{{ dataset.id }}/testcases/add_multiple">Add multiple testcases</a>
+{% end %}
       <table class="bordered" style="text-align:center">
         <thead>
           <tr>
@@ -365,7 +373,11 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
     <div class="hr"></div>
   </div>
 
-  <input type="submit" value="Update" />
+  <input type="submit"
+{% if not current_user.permission_all %}
+         disabled
+{% end %}
+         value="Update" />
   <input type="reset" value="Reset" />
 </form>
 {% end %}

--- a/cms/server/admin/templates/views/reevaluation_buttons.html
+++ b/cms/server/admin/templates/views/reevaluation_buttons.html
@@ -7,6 +7,9 @@
                   'level': 'compilation'},
                  function(response) { utils.redirect_if_ok('{{ url }}', response); }
                  );"
+{% if not current_user.permission_all %}
+        disabled
+{% end %}
         title="Compilation" >C</button>
 <button onclick="cmsrpc_request('{{ url_root }}',
                  'EvaluationService', 0,
@@ -17,6 +20,9 @@
                   'level': 'evaluation'},
                  function(response) { utils.redirect_if_ok('{{ url }}', response); }
                   );"
+{% if not current_user.permission_all %}
+        disabled
+{% end %}
         title="Evaluation" >E</button>
 <button onclick="cmsrpc_request('{{ url_root }}',
                  'ScoringService', 0,
@@ -27,4 +33,7 @@
                  },
                  function(response) { utils.redirect_if_ok('{{ url }}', response); }
                  );"
+{% if not current_user.permission_all %}
+        disabled
+{% end %}
         title="Score" >S</button>

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -46,7 +46,7 @@ from werkzeug.datastructures import LanguageAccept
 from werkzeug.http import parse_accept_header
 
 from cms import config
-from cms.db import Contest, Participation, Session, User
+from cms.db import Contest, Participation, User
 from cms.server import CommonRequestHandler, compute_actual_phase, \
     file_handler_gen, get_url_root
 from cms.locale import filter_language_codes

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -89,14 +89,8 @@ class BaseHandler(CommonRequestHandler):
 
     """
 
-    # Whether the login cookie duration has to be refreshed when
-    # this handler is called. Useful to filter asynchronous
-    # requests.
-    refresh_cookie = True
-
     def __init__(self, *args, **kwargs):
         super(BaseHandler, self).__init__(*args, **kwargs)
-        self.timestamp = None
         self.cookie_lang = None
         self.browser_lang = None
         self.langs = None
@@ -106,11 +100,7 @@ class BaseHandler(CommonRequestHandler):
         """This method is executed at the beginning of each request.
 
         """
-        self.timestamp = make_datetime()
-
-        self.set_header("Cache-Control", "no-cache, must-revalidate")
-
-        self.sql_session = Session()
+        super(BaseHandler, self).prepare()
         self.contest = Contest.get_from_id(self.application.service.contest,
                                            self.sql_session)
 

--- a/cmscontrib/AddAdmin.py
+++ b/cmscontrib/AddAdmin.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This script creates a new admin in the database.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+# We enable monkey patching to make many libraries gevent-friendly
+# (for instance, urllib3, used by requests)
+import gevent.monkey
+gevent.monkey.patch_all()
+
+import argparse
+import logging
+import sys
+
+from cms import utf8_decoder
+from cms.db import Admin, SessionGen
+from cmscommon.crypto import generate_random_password, hash_password
+
+from sqlalchemy.exc import IntegrityError
+
+
+logger = logging.getLogger(__name__)
+
+
+def add_admin(username, password=None):
+    logger.info("Creating the admin on the database.")
+    if password is None:
+        password = generate_random_password()
+    admin = Admin(username=username,
+                  authentication=hash_password(password.encode("utf-8")),
+                  name=username,
+                  permission_all=True)
+    try:
+        with SessionGen() as session:
+            session.add(admin)
+            session.commit()
+    except IntegrityError:
+        logger.error("An admin with the given username already exists.")
+        return False
+
+    logger.info("Admin with complete access added. "
+                "Login with username %s and password %s",
+                username, password)
+    return True
+
+
+def main():
+    """Parse arguments and launch process.
+
+    """
+    parser = argparse.ArgumentParser(description="Add an admin to CMS.")
+    parser.add_argument("username", action="store", type=utf8_decoder,
+                        nargs=1)
+    parser.add_argument("-p", "--password", action="store", type=utf8_decoder)
+
+    args = parser.parse_args()
+
+    return add_admin(args.username[0], args.password)
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() is True else 1)

--- a/cmstestsuite/testrunner.py
+++ b/cmstestsuite/testrunner.py
@@ -34,7 +34,7 @@ from cms import LANGUAGES
 from cmstestsuite import get_cms_config, CONFIG
 from cmstestsuite import add_contest, add_existing_user, add_existing_task, \
     add_user, add_task, add_testcase, add_manager, \
-    get_tasks, get_users, start_service, start_server, \
+    get_tasks, get_users, initialize_aws, start_service, start_server, \
     start_ranking_web_server, shutdown_services, restart_service
 from cmstestsuite.Test import TestFailure
 from cmscommon.datetime import get_system_timezone
@@ -64,6 +64,8 @@ class TestRunner(object):
             os.environ["PYTHONPATH"] = "%(TEST_DIR)s" % CONFIG
 
         TestRunner.start_generic_services(workers)
+        initialize_aws(self.rand)
+
         if contest_id is None:
             self.contest_id = self.create_contest()
         else:

--- a/cmstestsuite/web/AWSRequests.py
+++ b/cmstestsuite/web/AWSRequests.py
@@ -4,7 +4,7 @@
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2012 Bernard Blackham <bernard@largestprime.net>
 # Copyright © 2010-2012 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
-# Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2016 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -28,7 +28,20 @@ import re
 
 from BeautifulSoup import BeautifulSoup
 
-from cmstestsuite.web import GenericRequest
+from cmstestsuite.web import GenericRequest, LoginRequest
+
+
+class AWSLoginRequest(LoginRequest):
+    def test_success(self):
+        if not LoginRequest.test_success(self):
+            return False
+        fail_re = re.compile('Failed to log in.')
+        if fail_re.search(self.res_data) is not None:
+            return False
+        username_re = re.compile(self.username)
+        if username_re.search(self.res_data) is None:
+            return False
+        return True
 
 
 class AWSSubmissionViewRequest(GenericRequest):

--- a/cmstestsuite/web/CWSRequests.py
+++ b/cmstestsuite/web/CWSRequests.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2010-2012 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
-# Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2016 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 #
@@ -29,7 +29,16 @@ import os
 import random
 
 from cmscommon.crypto import decrypt_number
-from cmstestsuite.web import GenericRequest
+from cmstestsuite.web import GenericRequest, LoginRequest
+
+
+class CWSLoginRequest(LoginRequest):
+    def test_success(self):
+        if not LoginRequest.test_success(self):
+            return False
+        if self.redirected_to != './':
+            return False
+        return True
 
 
 class HomepageRequest(GenericRequest):
@@ -56,35 +65,6 @@ class HomepageRequest(GenericRequest):
             if username_re.search(self.res_data) is not None:
                 return False
         return True
-
-
-class LoginRequest(GenericRequest):
-    """Try to login to CWS with given credentials.
-
-    """
-    def __init__(self, browser, username, password, base_url=None):
-        GenericRequest.__init__(self, browser, base_url)
-        self.username = username
-        self.password = password
-        self.url = '%slogin' % self.base_url
-        self.data = {'username': self.username,
-                     'password': self.password,
-                     'next': '/'}
-
-    def describe(self):
-        return "try to login"
-
-    def test_success(self):
-        if not GenericRequest.test_success(self):
-            return False
-        if self.redirected_to != './':
-            return False
-        return True
-
-    def specific_info(self):
-        return 'Username: %s\nPassword: %s\n' % \
-               (self.username, self.password) + \
-            GenericRequest.specific_info(self)
 
 
 class TaskRequest(GenericRequest):

--- a/cmstestsuite/web/__init__.py
+++ b/cmstestsuite/web/__init__.py
@@ -4,7 +4,7 @@
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2012 Bernard Blackham <bernard@largestprime.net>
 # Copyright © 2010-2012 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
-# Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2016 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -24,14 +24,14 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import codecs
+import datetime
 import io
+import os
 import sys
 import time
-import urllib
-import datetime
 import traceback
-import codecs
-import os
+import urllib
 
 from mechanize import HTMLForm, HTTPError
 
@@ -256,3 +256,31 @@ class GenericRequest(object):
             print("", file=fd)
             print("EXCEPTION CASTED", file=fd)
             fd.write(unicode(self.exception_data))
+
+
+class LoginRequest(GenericRequest):
+    """Try to login to CWS or AWS with the given credentials.
+
+    """
+    def __init__(self, browser, username, password, base_url=None):
+        GenericRequest.__init__(self, browser, base_url)
+        self.username = username
+        self.password = password
+        self.url = '%slogin' % self.base_url
+        self.data = {'username': self.username,
+                     'password': self.password,
+                     'next': '/'}
+
+    def describe(self):
+        return "try to login"
+
+    def test_success(self):
+        if not GenericRequest.test_success(self):
+            return False
+        # Additional checks needs to be done from the subclasses.
+        return True
+
+    def specific_info(self):
+        return 'Username: %s\nPassword: %s\n' % \
+               (self.username, self.password) + \
+            GenericRequest.specific_info(self)

--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -131,6 +131,10 @@
     "admin_listen_address": "",
     "admin_listen_port":    8889,
 
+    "_help": "Login cookie duration for admins in seconds.",
+    "_help": "The duration is refreshed on every manual request.",
+    "admin_cookie_duration": 36000,
+
 
 
     "_section": "ScoringService",

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -213,7 +213,7 @@ To install CMS python dependencies on Ubuntu, you can issue:
          python-sqlalchemy python-psutil python-netifaces python-crypto \
          python-tz python-six python-beautifulsoup python-mechanize \
          python-coverage python-mock python-requests python-werkzeug \
-         python-gevent patool
+         python-gevent python-bcrypt patool
 
     # Optional.
     # sudo apt-get install python-yaml python-sphinx python-cups python-pypdf2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ requests==2.7
 gevent==1.0.2
 werkzeug==0.10.4
 patool==1.7
+bcrypt==2.0
 
 # Only for some importers:
 pyyaml==3.11


### PR DESCRIPTION
This was longer than expected... but I believe that the code is better organized now.

The end structure is comprised of:
- a cookie-based authentication middleware that can be passed to WebService; this translate authentication cookies into authentication headers for the underlying WSGI apps, and viceversa (the app can say when it wants a cookie to be set, deleted, or refreshed);
- the tornado app is similar to CWS, just it doesn't do any cookie-based authentication; the templates change based on the capabilities of the current user;
- the rpc middleware has a new parameter, a function that does authorization based on the cookie.

The capability _jobs that Giovanni suggested is missing, but it is simple enough to add it now (just add the field, change the reevaluation template to enable the buttons in that case, and add the rpc methods to the whitelist).

As for the commits, they are as self-contained as possible. Feel free to review them one at a time, but I think you'd like to see the complete result as well.

One thing that is missing is the possibility of revoking a cookie-based authentication (that in CWS happens when you change the password), because I wanted to avoid DB access in the authentication middleware. The admins can be disabled, or deleted and recreated, so I think that's not a big problem.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/447)
<!-- Reviewable:end -->
