### PR TITLE
Make ResourceService work with psutil-3.0

### DIFF
--- a/cms/service/ResourceService.py
+++ b/cms/service/ResourceService.py
@@ -5,7 +5,7 @@
 # Copyright © 2010-2014 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
 # Copyright © 2010-2014 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
-# Copyright © 2013-2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2013-2015 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2014 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -247,7 +247,7 @@ class ResourceService(Service):
 
         """
         logger.debug("ResourceService._find_proc")
-        for proc in psutil.get_process_list():
+        for proc in psutil.process_iter():
             try:
                 proc_info = proc.as_dict(attrs=PSUTIL_PROC_ATTRS)
                 if ResourceService._is_service_proc(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ sqlalchemy>=0.9,<1.1
 netifaces==0.10.4
 pycrypto==2.6.1
 pytz==2015.4
-psutil==2.2.1
+psutil>=0.6,<3.1
 six==1.9
 requests==2.7
 gevent==1.0.2


### PR DESCRIPTION
In psutil-3.0 they removed for good some functions that have been
deprecated for a while. Only one affected us, for which there's a handy
substitute, that always existed. (In fact, get_process_list was defined
as list(process_iter()).) Moreover we restored the old minimal required
version of psutil, and updated the highest supported one (because 3.0.1
is working on my system).