### PR TITLE
Fix cms.mo files not found when using virtual environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,12 @@ import os
 from setuptools import setup, find_packages
 
 
+# Install cms.mo files
+DATA_FILES = []
+for root, subdirs, files in os.walk("mo"):
+    if subdirs == []:
+        DATA_FILES.append((root, [os.path.join(root, files[0])]))
+
 PACKAGE_DATA = {
     "cms.server": [
         os.path.join("static", "*.*"),
@@ -83,6 +89,7 @@ setup(
                 "for IOI-like programming competitions",
     packages=find_packages(),
     package_data=PACKAGE_DATA,
+    data_files=DATA_FILES,
     scripts=["scripts/cmsLogService",
              "scripts/cmsScoringService",
              "scripts/cmsEvaluationService",


### PR DESCRIPTION
Fixes this error:

```
Traceback (most recent call last):
  File "/home/wil93/venvs/cms/bin/cmsContestWebServer", line 4, in <module>
    __import__('pkg_resources').run_script('cms==1.3.dev0', 'cmsContestWebServer')
  File "/home/wil93/venvs/cms/lib/python2.7/site-packages/pkg_resources/__init__.py", line 723, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/home/wil93/venvs/cms/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1636, in run_script
    exec(code, namespace, namespace)
  File "/home/wil93/venvs/cms/lib/python2.7/site-packages/cms-1.3.dev0-py2.7.egg/EGG-INFO/scripts/cmsContestWebServer", line 52, in <module>
    sys.exit(0 if main() is True else 1)
  File "/home/wil93/venvs/cms/lib/python2.7/site-packages/cms-1.3.dev0-py2.7.egg/EGG-INFO/scripts/cmsContestWebServer", line 47, in main
    ask_contest=ask_for_contest).run()
  File "/home/wil93/venvs/cms/lib/python2.7/site-packages/cms-1.3.dev0-py2.7.egg/cms/util.py", line 228, in default_argument_parser
    return cls(args.shard, ask_contest())
  File "/home/wil93/venvs/cms/lib/python2.7/site-packages/cms-1.3.dev0-py2.7.egg/cms/server/contest/server.py", line 103, in __init__
    for lang_code, trans in get_translations().iteritems()}
  File "/home/wil93/venvs/cms/lib/python2.7/site-packages/cms-1.3.dev0-py2.7.egg/cms/server/locale.py", line 98, in get_translations
    for lang_code in os.listdir(locale_dir):
OSError: [Errno 2] No such file or directory: '/home/wil93/venvs/cms/lib/python2.7/site-packages/cms-1.3.dev0-py2.7.egg/cms/server/../../mo'
```