### PR TITLE
Update italy_yaml and cmsMake

### DIFF
--- a/cmscontrib/loaders/italy_yaml.py
+++ b/cmscontrib/loaders/italy_yaml.py
@@ -344,7 +344,7 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader):
 
         return User(**args)
 
-    def get_task(self):
+    def get_task(self, get_statement=True):
         """See docstring in class Loader.
 
         """
@@ -384,24 +384,28 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader):
             logger.warning("Short name equals long name (title). "
                            "Please check.")
 
-        primary_language = load(conf, None, "primary_language")
-        if primary_language is None:
-            primary_language = 'it'
-        paths = [os.path.join(self.path, "statement", "statement.pdf"),
-                 os.path.join(self.path, "testo", "testo.pdf")]
-        for path in paths:
-            if os.path.exists(path):
-                digest = self.file_cacher.put_file_from_path(
-                    path,
-                    "Statement for task %s (lang: %s)" % (name,
-                                                          primary_language))
-                break
-        else:
-            logger.critical("Couldn't find any task statement, aborting...")
-            sys.exit(1)
-        args["statements"] = [Statement(primary_language, digest)]
+        if get_statement:
+            primary_language = load(conf, None, "primary_language")
+            if primary_language is None:
+                primary_language = 'it'
+            paths = [os.path.join(self.path, "statement", "statement.pdf"),
+                     os.path.join(self.path, "testo", "testo.pdf")]
+            for path in paths:
+                if os.path.exists(path):
+                    digest = self.file_cacher.put_file_from_path(
+                        path,
+                        "Statement for task %s (lang: %s)" % (name,
+                                                              primary_language))
+                    break
+            else:
+                logger.critical("Couldn't find any task statement, aborting...")
+                sys.exit(1)
+            args["statements"] = [Statement(primary_language, digest)]
 
-        args["primary_statements"] = '["%s"]' % (primary_language)
+            args["primary_statements"] = '["%s"]' % (primary_language)
+        else:
+            args["statements"] = []
+            args["primary_statements"] = '[]'
 
         args["attachments"] = []  # FIXME Use auxiliary
 

--- a/cmstaskenv/Test.py
+++ b/cmstaskenv/Test.py
@@ -30,7 +30,7 @@ import os
 import sys
 import logging
 
-import cmscontrib.YamlLoader
+import cmscontrib.loaders
 from cms.db import Executable
 from cms.db.filecacher import FileCacher
 from cms.grading import format_status_text
@@ -100,7 +100,7 @@ def test_testcases(base_dir, solution, language, assume=None):
     if file_cacher is None:
         file_cacher = FileCacher(null=True)
 
-    cmscontrib.YamlLoader.logger = NullLogger()
+    cmscontrib.loaders.italy_yaml.logger = NullLogger()
     # Load the task
     # TODO - This implies copying a lot of data to the FileCacher,
     # which is annoying if you have to do it continuously; it would be
@@ -108,12 +108,9 @@ def test_testcases(base_dir, solution, language, assume=None):
     # filesystem-based instead of database-based) and somehow detect
     # when the task has already been loaded
     if task is None:
-        loader = cmscontrib.YamlLoader.YamlLoader(
-            os.path.realpath(os.path.join(base_dir, "..")),
-            file_cacher)
-        # Normally we should import the contest before, but YamlLoader
-        # accepts get_task() even without previous get_contest() calls
-        task = loader.get_task(os.path.split(os.path.realpath(base_dir))[1])
+        loader = cmscontrib.loaders.italy_yaml.YamlLoader(base_dir,
+                                                          file_cacher)
+        task = loader.get_task(get_statement=False)
 
     # Prepare the EvaluationJob
     dataset = task.active_dataset

--- a/cmstaskenv/cmsMake.py
+++ b/cmstaskenv/cmsMake.py
@@ -207,8 +207,7 @@ def build_sols_list(base_dir, task_type, in_out_files, yaml_conf):
                                      STUB_BASENAME + '.%s' % (lang)))
         srcs.append(src)
 
-        test_deps = \
-            [exe_EVAL, os.path.join(TEXT_DIRNAME, TEXT_PDF)] + in_out_files
+        test_deps = in_out_files
         if task_type == ['Batch', 'Comp'] or \
                 task_type == ['Batch', 'GradComp']:
             test_deps.append('cor/correttore')
@@ -325,22 +324,11 @@ def build_text_list(base_dir, task_type):
               '-interaction', 'batchmode', text_tex],
              env={'TEXINPUTS': '.:%s:%s/file:' % (TEXT_DIRNAME, TEXT_DIRNAME)})
 
-    def make_dummy_pdf(assume=None):
-        try:
-            open(text_pdf, 'r')
-        except IOError:
-            logger.warning(
-                "%s does not exist, creating an empty file..." % text_pdf
-            )
-            open(text_pdf, 'w')
-
     actions = []
     if os.path.exists(text_tex):
         actions.append(([text_tex], [text_pdf, text_aux, text_log],
                         make_pdf, 'compile to PDF'))
-    else:
-        actions.append(([TEXT_DIRNAME], [text_pdf], make_dummy_pdf,
-                        "create empty PDF file"))
+
     return actions
 
 


### PR DESCRIPTION
Now italy_yaml works with the changes made in c09c052.
Moreover, cmsMake uses the "no_statement" feature required to loaders
and ignores the statement if it's missing, instead of creating an empty
one.