### PR TITLE
Fix #458

### DIFF
--- a/cms/grading/tasktypes/OutputOnly.py
+++ b/cms/grading/tasktypes/OutputOnly.py
@@ -108,7 +108,7 @@ class OutputOnly(TaskType):
 
         # Since we allow partial submission, if the file is not
         # present we report that the outcome is 0.
-        if "output_%s.txt" % job._key not in job.files:
+        if "output_%s.txt" % job.testcase_codename not in job.files:
             job.success = True
             job.outcome = "0.0"
             job.text = [N_("File not submitted")]
@@ -116,7 +116,7 @@ class OutputOnly(TaskType):
 
         # First and only one step: diffing (manual or with manager).
         output_digest = job.files["output_%s.txt" %
-                                  job._key].digest
+                                  job.testcase_codename].digest
 
         # Put the files into the sandbox
         sandbox.create_file_from_storage(


### PR DESCRIPTION
Fix the problem #458 using the `testcase_codename` to identify the output in OutOnly tasks.