### PR TITLE
Fixed problem with empty partecipation password

### DIFF
--- a/cms/server/admin/handlers/contestuser.py
+++ b/cms/server/admin/handlers/contestuser.py
@@ -162,9 +162,7 @@ class ParticipationHandler(BaseHandler):
         try:
             attrs = participation.get_attrs()
 
-            self.get_string(attrs, "password")
-            if attrs["password"] == "":
-                attrs["password"] = None
+            self.get_string(attrs, "password", empty=None)
             self.get_ip_address_or_subnet(attrs, "ip")
             self.get_datetime(attrs, "starting_time")
             self.get_timedelta_sec(attrs, "delay_time")

--- a/cms/server/admin/handlers/contestuser.py
+++ b/cms/server/admin/handlers/contestuser.py
@@ -164,7 +164,7 @@ class ParticipationHandler(BaseHandler):
 
             self.get_string(attrs, "password")
             if attrs["password"] == "":
-				attrs["password"] = None
+                attrs["password"] = None
             self.get_ip_address_or_subnet(attrs, "ip")
             self.get_datetime(attrs, "starting_time")
             self.get_timedelta_sec(attrs, "delay_time")

--- a/cms/server/admin/handlers/contestuser.py
+++ b/cms/server/admin/handlers/contestuser.py
@@ -163,6 +163,8 @@ class ParticipationHandler(BaseHandler):
             attrs = participation.get_attrs()
 
             self.get_string(attrs, "password")
+            if attrs["password"] == "":
+				attrs["password"] = None
             self.get_ip_address_or_subnet(attrs, "ip")
             self.get_datetime(attrs, "starting_time")
             self.get_timedelta_sec(attrs, "delay_time")

--- a/cms/server/admin/templates/participation.html
+++ b/cms/server/admin/templates/participation.html
@@ -168,7 +168,7 @@ function update_additional_answer(element, invoker)
       <tr>
         <td>Password (if not specified, the user's main password is used)</td>
         <!-- FIXME: Plain text? -->
-        <td><input type="text" name="password" value="{{ participation.password }}"/></td>
+        <td><input type="text" name="password" value="{{ participation.password if participation.password is not None else "" }}"/></td>
       </tr>
       <tr>
         <td>Hidden?</td>


### PR DESCRIPTION
When a user is created and added to a contest it's contest password is None, but in the admin page the None value is converted to the 'None' string causing an unwanted side effect. If the user update the record the None value is converted to the 'None' password. With this patch the special '' (empty) password is converted internally to None.

Fix #471 