### PR TITLE
Fix RWS's error 400 when starting ProxyService with more than 0 subs

### DIFF
--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -262,10 +262,11 @@ class ProxyService(TriggeredService):
         self.rankings = list()
         for ranking in config.rankings:
             self.add_executor(ProxyExecutor(ranking.encode('utf-8')))
-        self.start_sweeper(347.0)
 
-        # Send some initial data to rankings.
+        # Enqueue the dispatch of some initial data to rankings.
         self.initialize()
+
+        self.start_sweeper(347.0)
 
     def _missing_operations(self):
         """Return a generator of data to be sent to the rankings..

--- a/cmsranking/RankingWebServer.py
+++ b/cmsranking/RankingWebServer.py
@@ -466,6 +466,8 @@ def main():
     Submission.store.load_from_disk()
     Subchange.store.load_from_disk()
 
+    Scoring.store.init_store()
+
     toplevel_handler = RoutingHandler(DataWatcher(), ImageHandler(
         os.path.join(config.lib_dir, '%(name)s'),
         os.path.join(config.web_dir, 'img', 'logo.png')))

--- a/cmsranking/Scoring.py
+++ b/cmsranking/Scoring.py
@@ -246,9 +246,12 @@ class ScoringStore(object):
         subchange_store.add_delete_callback(self.delete_subchange)
 
         self._scores = dict()
-
         self._callbacks = list()
 
+    # We can't do this in the __init__ method because RankingWebServer has not
+    # yet loaded the data from disk. So, after RWS has finished loading, it must
+    # explicitly call init_store.
+    def init_store(self):
         for key, value in submission_store._store.iteritems():
             self.create_submission(key, value)
         for key, value in sorted(subchange_store._store.iteritems()):


### PR DESCRIPTION
Sometimes RWS will get stuck and produce warnings about "invalid data".
Apparently, this can be caused by the fact that ProxyService starts by
sending the submissions/subchanges related data first, and then it will
proceed to the contests/teams/users related data. Now, if there are
already more than 0 submissions, this means that ProxyService will send
data about these submissions even though it has never initialized the
rankings.

This commit enqueues the initialization operation and *then* starts the
sweeper. I'm not sure if this is the right thing to do, but it works.