### PR TITLE
Introduce teams and enable ProxyService to send team data

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -53,7 +53,7 @@ __all__ = [
     # contest
     "Contest", "Announcement",
     # user
-    "User", "Participation", "Message", "Question",
+    "User", "Team", "Participation", "Message", "Question",
     # task
     "Task", "Statement", "Attachment", "SubmissionFormatElement", "Dataset",
     "Manager", "Testcase",
@@ -92,7 +92,7 @@ from .session import Session, ScopedSession, SessionGen, \
 from .types import RepeatedUnicode
 from .base import metadata, Base
 from .contest import Contest, Announcement
-from .user import User, Participation, Message, Question
+from .user import User, Team, Participation, Message, Question
 from .task import Task, Statement, Attachment, SubmissionFormatElement, \
     Dataset, Manager, Testcase
 from .submission import Submission, File, Token, SubmissionResult, \

--- a/cms/db/user.py
+++ b/cms/db/user.py
@@ -6,6 +6,7 @@
 # Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2012-2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -51,7 +52,7 @@ def generate_random_password():
 
 
 class User(Base):
-    """Class to store a 'user participating in a contest'.
+    """Class to store a user.
 
     """
 
@@ -111,8 +112,39 @@ class User(Base):
     # participations (list of Participation objects)
 
 
+class Team(Base):
+    """Class to store a team.
+
+    A team is a way of grouping the users participating in a contest.
+    This grouping has no effect on the contest itself; it is only used
+    for display purposes in RWS.
+
+    """
+
+    __tablename__ = 'teams'
+
+    # Auto increment primary key.
+    id = Column(
+        Integer,
+        primary_key=True)
+
+    # Team code (e.g. the ISO 3166-1 code of a country)
+    code = Column(
+        Unicode,
+        nullable=False,
+        unique=True)
+
+    # Human readable team name (e.g. the ISO 3166-1 short name of a country)
+    name = Column(
+        Unicode,
+        nullable=False)
+
+    # TODO: decide if the flag images will eventually be stored here.
+    # TODO: (hopefully, the same will apply for faces in User).
+
+
 class Participation(Base):
-    """Class to store user participations to contests.
+    """Class to store a single participation of a user in a contest.
 
     """
     __tablename__ = 'participations'
@@ -189,6 +221,18 @@ class Participation(Base):
                         cascade="all, delete-orphan",
                         passive_deletes=True))
     __table_args__ = (UniqueConstraint('contest_id', 'user_id'),)
+
+    # Team (id and object) that the user is representing with this participation.
+    team_id = Column(
+        Integer,
+        ForeignKey(Team.id,
+                   onupdate="CASCADE", ondelete="RESTRICT"),
+        nullable=True)
+    team = relationship(
+        Team,
+        backref=backref("participations",
+                        cascade="all, delete-orphan",
+                        passive_deletes=True))
 
     # Follows the description of the fields automatically added by
     # SQLAlchemy.

--- a/cms/server/admin/handlers/contestuser.py
+++ b/cms/server/admin/handlers/contestuser.py
@@ -8,6 +8,7 @@
 # Copyright © 2012-2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
+# Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -34,7 +35,7 @@ import logging
 
 import tornado.web
 
-from cms.db import Contest, Message, Participation, Submission, User
+from cms.db import Contest, Message, Participation, Submission, User, Team
 from cmscommon.datetime import make_datetime
 
 from .base import BaseHandler
@@ -147,6 +148,7 @@ class ParticipationHandler(BaseHandler):
 
         self.r_params["participation"] = participation
         self.r_params["selected_user"] = participation.user
+        self.r_params["teams"] = self.sql_session.query(Team).all()
         self.render("participation.html", **self.r_params)
 
     def post(self, contest_id, user_id):
@@ -174,6 +176,13 @@ class ParticipationHandler(BaseHandler):
 
             # Update the participation.
             participation.set_attrs(attrs)
+
+            # Update the team
+            self.get_string(attrs, "team")
+            team = self.sql_session.query(Team)\
+                       .filter(Team.code == attrs["team"])\
+                       .first()
+            participation.team = team
 
         except Exception as error:
             self.application.service.add_notification(

--- a/cms/server/admin/templates/add_user.html
+++ b/cms/server/admin/templates/add_user.html
@@ -31,24 +31,8 @@
         <td><input type="text" name="email" /></td>
       </tr>
       <tr>
-        <td>IP address or subnet</td>
-        <td><input type="text" name="ip" /></td>
-      </tr>
-      <tr>
         <td>Timezone (like "Europe/Rome", "America/New_York", ...)</td>
         <td><input type="text" name="timezone" value=""></td>
-      </tr>
-      <tr>
-        <td>First login time during contest</td>
-        <td><input type="text" name="starting_time" value=""></td>
-      </tr>
-      <tr>
-        <td>Delay time (in seconds)</td>
-        <td><input type="text" name="delay_time" value="0"></td>
-      </tr>
-      <tr>
-        <td>Extra time (in seconds)</td>
-        <td><input type="text" name="extra_time" value="0"></td>
       </tr>
       <tr>
         <td>Preferred languages (JSON-encoded list of language codes, from the most to the least preferred)</td>

--- a/cms/server/admin/templates/participation.html
+++ b/cms/server/admin/templates/participation.html
@@ -59,6 +59,15 @@ function update_additional_answer(element, invoker)
   <form enctype="multipart/form-data" action="{{ url_root }}/contest/{{ contest.id }}/user/{{ selected_user.id }}" method="POST">
     <table>
       <tr>
+        <td>Team</td>
+        <td><input list="teams" name="team" value="{{ participation.team.code if participation.team is not None else "" }}"/></td>
+        <datalist id="teams">
+          {% for t in teams %}
+          <option value="{{ t.code }}">
+          {% end %}
+        </datalist>
+      </tr>
+      <tr>
         <td>Password (if not specified, the user's main password is used)</td>
         <!-- FIXME: Plain text? -->
         <td><input type="text" name="password" value="{{ participation.password if participation.password is not None else "" }}"/></td>

--- a/cmscontrib/AddContest.py
+++ b/cmscontrib/AddContest.py
@@ -6,7 +6,7 @@
 # Copyright © 2010-2012 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2013 Luca Wehrstedt <luca.wehrstedt@gmail.com>
-# Copyright © 2014 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2014-2015 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -45,7 +45,7 @@ import os
 import os.path
 
 from cms import utf8_decoder
-from cms.db import SessionGen, User, Participation, Task, Contest
+from cms.db import SessionGen, User, Team, Participation, Task, Contest
 from cms.db.filecacher import FileCacher
 
 from cmscontrib.loaders import choose_loader, build_epilog
@@ -79,7 +79,7 @@ class ContestImporter(BaseImporter):
         """Get the contest from the Loader and store it."""
 
         # Get the contest
-        contest, tasks, users = self.loader.get_contest()
+        contest, tasks, participations = self.loader.get_contest()
 
         # Apply the modification flags
         if self.zero_time:
@@ -151,23 +151,36 @@ class ContestImporter(BaseImporter):
                     task.num = tasknum
                     task.contest = contest
 
-            # Check needed users
-            for username in users:
+            # Check needed participations
+            for p in participations:
                 user = session.query(User) \
-                              .filter(User.username == username).first()
+                              .filter(User.username == p["username"]).first()
+
+                team = session.query(Team) \
+                              .filter(Team.code == p.get("team")).first()
+
                 if user is None:
                     # FIXME: it would be nice to automatically try to
                     # import.
                     logger.critical("User \"%s\" not found in database.",
-                                    username)
+                                    p["username"])
                     return
-                # We should tie this user to a new contest
-                # FIXME: there is no way for the loader to specify
-                # hidden users
-                session.add(Participation(
-                    user=user,
-                    contest=contest
-                ))
+
+                if team is None and p.get("team") is not None:
+                    # FIXME: it would be nice to automatically try to
+                    # import.
+                    logger.critical("Team \"%s\" not found in database.",
+                                    p.get("team"))
+                    return
+
+                # Prepare new participation
+                args = {
+                    "user": user,
+                    "team": team,
+                    "contest": contest,
+                }
+
+                session.add(Participation(**args))
 
             # Here we could check if there are actually some tasks or
             # users to add: if there are not, then don't create the

--- a/cmscontrib/AddContest.py
+++ b/cmscontrib/AddContest.py
@@ -180,6 +180,13 @@ class ContestImporter(BaseImporter):
                     "contest": contest,
                 }
 
+                if "hidden" in p:
+                    args["hidden"] = p["hidden"]
+                if "ip" in p:
+                    args["ip"] = p["ip"]
+                if "password" in p:
+                    args["password"] = p["password"]
+
                 session.add(Participation(**args))
 
             # Here we could check if there are actually some tasks or

--- a/cmscontrib/loaders/base_loader.py
+++ b/cmscontrib/loaders/base_loader.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2013 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
-# Copyright © 2014 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2014-2015 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -160,6 +160,50 @@ class UserLoader(BaseLoader):
         raise NotImplementedError("Please extend UserLoader")
 
 
+class TeamLoader(BaseLoader):
+    """Base class for deriving team loaders.
+
+    Each team loader must extend this class and support the following
+    access pattern:
+
+      * The class method detect() can be called at any time.
+
+      * Once a loader is instatiated, get_team() can be called on it,
+        for how many times the caller want.
+
+    """
+
+    def __init__(self, path, file_cacher):
+        super(TeamLoader, self).__init__(path, file_cacher)
+
+    def get_team(self):
+        """Produce a Team object.
+
+        return (Team): the Team object.
+
+        """
+        raise NotImplementedError("Please extend TeamLoader")
+
+    def team_has_changed(self):
+        """Detect if the team has been changed since its last import.
+
+        This is expected to happen by saving, at every import, some
+        piece of data about the last importation time. Then, when
+        team_has_changed() is called, such time is compared with the
+        last modification time of the files describing the team. Anyway,
+        the TeamLoader may choose the heuristic better suited for its
+        case.
+
+        If this team is being imported for the first time or if the
+        TeamLoader decides not to support changes detection, just return
+        True.
+
+        return (bool): True if the team was changed, False otherwise.
+
+        """
+        raise NotImplementedError("Please extend TeamLoader")
+
+
 class ContestLoader(BaseLoader):
     """Base class for deriving contest loaders.
 
@@ -182,8 +226,10 @@ class ContestLoader(BaseLoader):
         Do what is needed (i.e. search directories and explore files
         in the location given to the constructor) to produce a Contest
         object. Also get a minimal amount of information on tasks and
-        users, at least enough to produce the list of all task names
-        and the list of all usernames.
+        participations, at least enough to produce a list of all task
+        names and a list of dict objects that will represent all the
+        participations in the contest (each participation should have
+        at least the "username" field).
 
         return (tuple): the Contest object and the two lists described
                         above.

--- a/cmscontrib/loaders/polygon.py
+++ b/cmscontrib/loaders/polygon.py
@@ -423,7 +423,7 @@ class PolygonContestLoader(ContestLoader):
         for problem in root.find('problems'):
             tasks.append(os.path.basename(problem.attrib['url']))
 
-        users = []
+        participations = []
 
         # This is not standard Polygon feature, but useful for CMS users
         # we assume contestants.txt contains one line for each user:
@@ -441,10 +441,14 @@ class PolygonContestLoader(ContestLoader):
                 for user in users_file.readlines():
                     user = user.strip()
                     user = user.split(';')
-                    username = user[0].strip()
-                    users.append(username)
+                    participations.append({
+                        "username": user[0].strip(),
+                        "password": user[1].strip(),
+                        "hidden": user[4].strip()
+                        # "ip" is not passed
+                    })
 
-        return Contest(**args), tasks, users
+        return Contest(**args), tasks, participations
 
     def contest_has_changed(self):
         """See docstring in class Loader.

--- a/cmscontrib/updaters/update_17.py
+++ b/cmscontrib/updaters/update_17.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A class to update a dump created by CMS.
+
+Used by ContestImporter and DumpUpdater.
+
+This updater is no-op as the new field (team id) has a proper
+default value.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+
+class Updater(object):
+
+    def __init__(self, data):
+        assert data["_version"] == 16
+        self.objs = data
+
+    def run(self):
+        return self.objs

--- a/cmstestsuite/unit_tests/service/ProxyServiceTest.py
+++ b/cmstestsuite/unit_tests/service/ProxyServiceTest.py
@@ -66,10 +66,11 @@ class TestProxyService(unittest.TestCase):
                      for call in put_mock.call_args_list]
 
         assert urls_data[0][0].endswith("contests/")
-        assert any(urls_data[i][0].endswith("users/") for i in [1, 2])
-        assert any(urls_data[i][0].endswith("tasks/") for i in [1, 2])
-        assert urls_data[3][0].endswith("submissions/")
-        assert urls_data[4][0].endswith("subchanges/")
+        assert any(urls_data[i][0].endswith("users/") for i in [1, 2, 3])
+        assert any(urls_data[i][0].endswith("teams/") for i in [1, 2, 3])
+        assert any(urls_data[i][0].endswith("tasks/") for i in [1, 2, 3])
+        assert urls_data[4][0].endswith("submissions/")
+        assert urls_data[5][0].endswith("subchanges/")
 
     @staticmethod
     def set_up_db(tasks, participations, submissions):

--- a/cmstestsuite/unit_tests/testobjectgenerator.py
+++ b/cmstestsuite/unit_tests/testobjectgenerator.py
@@ -89,6 +89,13 @@ def get_user():
     return user
 
 
+def get_team():
+    team = Mock()
+    team.code = get_string()
+    team.name = get_string()
+    return team
+
+
 def get_participation(hidden=False, user=None):
     if user is None:
         user = get_user()
@@ -96,6 +103,7 @@ def get_participation(hidden=False, user=None):
     participation.id = get_int()
     participation.hidden = hidden
     participation.user = user
+    participation.team = get_team()
     return participation
 
 

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
             "cmsAdaptContest=cmstestsuite.AdaptContest:main",
             "cmsTestFileCacher=cmstestsuite.TestFileCacher:main",
             "cmsAddUser=cmscontrib.AddUser:main",
+            "cmsAddTeam=cmscontrib.AddTeam:main",
             "cmsRemoveUser=cmscontrib.RemoveUser:main",
             "cmsAddTask=cmscontrib.AddTask:main",
             "cmsRemoveTask=cmscontrib.RemoveTask:main",


### PR DESCRIPTION
Fixes #65.
Depends on ~~#472~~ and ~~#480~~.

No more need to touch `/teams/` and `/users/`, they are now completely automated :smile:. Now it's enough to provide `/faces/` and `/flags/`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/481)
<!-- Reviewable:end -->
