### PR TITLE
Fix minor issue that sometimes happened when using symlinks

### DIFF
--- a/cmscontrib/AddContest.py
+++ b/cmscontrib/AddContest.py
@@ -73,7 +73,7 @@ class ContestImporter(BaseImporter):
         self.no_statements = no_statements
         self.file_cacher = FileCacher()
 
-        self.loader = loader_class(os.path.realpath(path), self.file_cacher)
+        self.loader = loader_class(os.path.abspath(path), self.file_cacher)
 
     def do_import(self):
         """Get the contest from the Loader and store it."""

--- a/cmscontrib/AddTask.py
+++ b/cmscontrib/AddTask.py
@@ -64,7 +64,7 @@ class TaskImporter(BaseImporter):
         self.file_cacher = FileCacher()
         self.update = update
         self.no_statement = no_statement
-        self.loader = loader_class(os.path.realpath(path), self.file_cacher)
+        self.loader = loader_class(os.path.abspath(path), self.file_cacher)
 
     def do_import(self):
         """Get the task from the TaskLoader and store it."""

--- a/cmscontrib/AddUser.py
+++ b/cmscontrib/AddUser.py
@@ -61,7 +61,7 @@ class UserImporter(object):
 
     def __init__(self, path, loader_class):
         self.file_cacher = FileCacher()
-        self.loader = loader_class(os.path.realpath(path), self.file_cacher)
+        self.loader = loader_class(os.path.abspath(path), self.file_cacher)
 
     def do_import(self):
         """Get the user from the UserLoader and store it."""

--- a/cmscontrib/Reimporter.py
+++ b/cmscontrib/Reimporter.py
@@ -76,7 +76,7 @@ class Reimporter(object):
 
         self.file_cacher = FileCacher()
 
-        self.loader = loader_class(os.path.realpath(path), self.file_cacher)
+        self.loader = loader_class(os.path.abspath(path), self.file_cacher)
 
     def _update_columns(self, old_object, new_object):
         for prp in old_object._col_props:

--- a/cmstaskenv/cmsMake.py
+++ b/cmstaskenv/cmsMake.py
@@ -115,11 +115,11 @@ def call(base_dir, args, stdin=None, stdout=None, stderr=None, env=None):
 
 
 def detect_task_name(base_dir):
-    return os.path.split(os.path.realpath(base_dir))[1]
+    return os.path.split(os.path.abspath(base_dir))[1]
 
 
 def parse_task_yaml(base_dir):
-    parent_dir = os.path.split(os.path.realpath(base_dir))[0]
+    parent_dir = os.path.split(os.path.abspath(base_dir))[0]
 
     # We first look for the yaml file inside the task folder,
     # and eventually fallback to a yaml file in its parent folder.


### PR DESCRIPTION
For example, if you had this folder structure:

```
tasks/
  mytask/
    ...
    mytask2.yaml
contest/
  {mytask2 --> ../tasks/mytask}
```

You would get and error when trying to import mytask2 from contest folder.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/487)
<!-- Reviewable:end -->
