### PR TITLE
Avoid spawning too many desktop notifications

### DIFF
--- a/cms/server/contest/static/cws_utils.js
+++ b/cms/server/contest/static/cws_utils.js
@@ -102,8 +102,10 @@ CMS.CWSUtils.prototype.display_notification = function(type, timestamp,
 
     $("#notifications").prepend(alert);
 
-    // Trigger a desktop notification as well
-    this.desktop_notification(type, timestamp, subject, text, level);
+    // Trigger a desktop notification as well (but only if it's needed)
+    if (type !== "notification") {
+        this.desktop_notification(type, timestamp, subject, text, level);
+    }
 };
 
 


### PR DESCRIPTION
Apparently, AWS wasn't the only one spawning notifications for just
about everything. CWS does that too, when you:

 * send a submission
 * use a token on a submission

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/492)
<!-- Reviewable:end -->
