### PR TITLE
Quick fix to support changing what version of python to use

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -57,6 +57,7 @@ class Config(object):
         self.temp_dir = "/tmp"
         self.backdoor = False
         self.file_log_debug = False
+        self.python_version = "2"
 
         # Database.
         self.database = "postgresql+psycopg2://cmsuser@localhost/cms"

--- a/cms/grading/__init__.py
+++ b/cms/grading/__init__.py
@@ -243,13 +243,19 @@ def get_compilation_commands(language, source_filenames, executable_filename,
         # The executable name is fixed, and there is no way to specify
         # the name of the pyc, so we need to bundle together two
         # commands (compilation and rename).
-        # In order to use Python 3 change them to:
-        # /usr/bin/python3 -m py_compile %s
-        # mv __pycache__/%s.*.pyc %s
-        py_command = ["/usr/bin/python2", "-m", "py_compile",
-                      source_filenames[0]]
-        mv_command = ["/bin/mv", "%s.pyc" % os.path.splitext(os.path.basename(
-                      source_filenames[0]))[0], executable_filename]
+        py_command = ["/usr/bin/python" + config.python_version, "-m",
+                      "py_compile", source_filenames[0]]
+
+        basename = os.path.splitext(os.path.basename(
+                                    source_filenames[0]))[0]
+
+        if config.python_version == "3":
+            pyc_name = "__pycache__/%s.cpython-34.pyc" % basename
+        else:
+            pyc_name = "%s.pyc" % basename
+
+        mv_command = ["/bin/mv", pyc_name, executable_filename]
+
         commands.append(py_command)
         commands.append(mv_command)
     elif language == LANG_PHP:
@@ -283,9 +289,8 @@ def get_evaluation_commands(language, executable_filename):
         command = [os.path.join(".", executable_filename)]
         commands.append(command)
     elif language == LANG_PYTHON:
-        # In order to use Python 3 change it to:
-        # /usr/bin/python3 %s
-        command = ["/usr/bin/python2", executable_filename]
+        command = ["/usr/bin/python" + config.python_version,
+                   executable_filename]
         commands.append(command)
     elif language == LANG_PHP:
         command = ["/usr/bin/php5", executable_filename]

--- a/docs/Configuring a contest.rst
+++ b/docs/Configuring a contest.rst
@@ -164,7 +164,7 @@ Language details
 
 * Java programs are first compiled using ``gcj`` (optimized with ``-O3``), and then run as normal executables. Proper Java support using a JVM will most probably come in the next CMS version.
 
-* Python submissions are interpreted using Python 2 (you need to have ``/usr/bin/python2``).
+* Python submissions are interpreted using Python 2 (you need to have ``/usr/bin/python2``). If you want to use Python 3, you can set the ``python_version`` to ``"3"`` in your :file:`cms.conf` file.
 
 * PHP submissions are interpreted by ``/usr/bin/php5``.
 


### PR DESCRIPTION
I know that we should look into making compilers "separate" from CMS (with a plugin system). In the meantime, though, I think it's good to have a simple way to switch the python version used when evaluating python submissions.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/506)
<!-- Reviewable:end -->
