### PR TITLE
Use server time instead of local time in RWS (fixes #367)

### DIFF
--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -9,6 +9,7 @@
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
 # Copyright © 2015 Luca Versari <veluca93@gmail.com>
 # Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2015 Luca Chiodini <luca@chiodini.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -46,7 +47,7 @@ from cms import config
 from cms.io import Executor, QueueItem, TriggeredService, rpc_method
 from cms.db import SessionGen, Contest, Task, Submission
 from cms.grading.scoretypes import get_score_type
-from cmscommon.datetime import make_timestamp
+from cmscommon.datetime import get_timezone, make_timestamp
 
 
 logger = logging.getLogger(__name__)
@@ -329,7 +330,10 @@ class ProxyService(TriggeredService):
                 "name": contest.description,
                 "begin": int(make_timestamp(contest.start)),
                 "end": int(make_timestamp(contest.stop)),
-                "score_precision": contest.score_precision}
+                "score_precision": contest.score_precision,
+                "tz_offset": int(get_timezone(None, contest)
+                                 .utcoffset(contest.start).total_seconds())
+            }
 
             users = dict()
             teams = dict()

--- a/cmscommon/datetime.py
+++ b/cmscommon/datetime.py
@@ -4,6 +4,7 @@
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2012 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2013 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2015 Luca Chiodini <luca@chiodini.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -72,16 +73,19 @@ def make_timestamp(_datetime=None):
 
 
 def get_timezone(user, contest):
-    """Return the timezone for the given user and contest
+    """Return the timezone for the given user and contest.
 
-    user (User): the user owning the timezone.
-    contest (Contest): the contest in which the user is competing.
+    user (User|None): the user for which the timezone should be determined, or
+        None if the user timezone should not be considered.
+    contest (Contest): the contest for which the timezone should be determined.
 
-    return (tzinfo): the timezone information for the user.
+    return (tzinfo): the timezone information for the user (or for the contest
+        if user is None).
 
     """
-    if user.timezone is not None and user.timezone in all_timezones:
-        return timezone(user.timezone)
+    if user is not None:
+        if user.timezone is not None and user.timezone in all_timezones:
+            return timezone(user.timezone)
     if contest.timezone is not None and contest.timezone in all_timezones:
         return timezone(contest.timezone)
     return local

--- a/cmsranking/Contest.py
+++ b/cmsranking/Contest.py
@@ -3,6 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2011-2013 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2015 Luca Chiodini <luca@chiodini.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -47,6 +48,7 @@ class Contest(Entity):
         self.begin = None
         self.end = None
         self.score_precision = None
+        self.tz_offset = None
 
     @staticmethod
     def validate(data):
@@ -70,6 +72,8 @@ class Contest(Entity):
                 "Field 'score_precision' isn't an integer"
             assert data['score_precision'] >= 0, \
                 "Field 'score_precision' is negative"
+            assert isinstance(data['tz_offset'], six.integer_types), \
+                "Field 'tz_offset' isn't an integer"
         except KeyError as exc:
             raise InvalidData("Field %s is missing" % exc.message)
         except AssertionError as exc:
@@ -81,6 +85,7 @@ class Contest(Entity):
         self.begin = data['begin']
         self.end = data['end']
         self.score_precision = data['score_precision']
+        self.tz_offset = data['tz_offset']
 
     def get(self):
         result = self.__dict__.copy()

--- a/cmsranking/static/DataStore.js
+++ b/cmsranking/static/DataStore.js
@@ -1,5 +1,6 @@
 /* Programming contest management system
  * Copyright © 2012 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+ * Copyright © 2015 Luca Chiodini <luca@chiodini.org>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -66,6 +67,14 @@ var DataStore = new function () {
             dataType: "json",
             success: function (data, status, xhr) {
                 self.contest_init_time = parseFloat(xhr.getResponseHeader("Timestamp"));
+
+                // This is expected to be the first AJAX call and so it is a good
+                // chance to properly initialize "diff_with_server_time",
+                // which contains the difference in seconds between local time
+                // and server time (not considering timezone offsets).
+                TimeView.diff_with_server_time =
+                    Math.round($.now() / 1000 - self.contest_init_time);
+
                 for (var key in data) {
                     self.create_contest(key, data[key]);
                 }
@@ -828,6 +837,7 @@ var DataStore = new function () {
             if (timestamp > self.contest_init_time) {
                 self.contest_listener(event);
             }
+            TimeView.diff_with_server_time = Math.round($.now() / 1000 - timestamp);
             self.last_event_id = event.lastEventId;
         }, false);
         self.es.addEventListener("task", function (event) {
@@ -835,6 +845,7 @@ var DataStore = new function () {
             if (timestamp > self.task_init_time) {
                 self.task_listener(event);
             }
+            TimeView.diff_with_server_time = Math.round($.now() / 1000 - timestamp);
             self.last_event_id = event.lastEventId;
         }, false);
         self.es.addEventListener("team", function (event) {
@@ -842,6 +853,7 @@ var DataStore = new function () {
             if (timestamp > self.team_init_time) {
                 self.team_listener(event);
             }
+            TimeView.diff_with_server_time = Math.round($.now() / 1000 - timestamp);
             self.last_event_id = event.lastEventId;
         }, false);
         self.es.addEventListener("user", function (event) {
@@ -849,6 +861,7 @@ var DataStore = new function () {
             if (timestamp > self.user_init_time) {
                 self.user_listener(event);
             }
+            TimeView.diff_with_server_time = Math.round($.now() / 1000 - timestamp);
             self.last_event_id = event.lastEventId;
         }, false);
         self.es.addEventListener("score", function (event) {
@@ -856,6 +869,7 @@ var DataStore = new function () {
             if (timestamp > self.score_init_time) {
                 self.score_listener(event);
             }
+            TimeView.diff_with_server_time = Math.round($.now() / 1000 - timestamp);
             self.last_event_id = event.lastEventId;
         }, false);
     };


### PR DESCRIPTION
Server time differs from local time in two cases (can be both):
- Different timezone
- Same timezone but clocks not aligned (for instance due to a
  misconfiguration of NTP)