### PR TITLE
Fix regression

### DIFF
--- a/cmstaskenv/Test.py
+++ b/cmstaskenv/Test.py
@@ -179,7 +179,7 @@ def test_testcases(base_dir, solution, language, assume=None):
 
     # Subtasks scoring
     subtasks = json.loads(dataset.score_type_parameters)
-    if len(subtasks) == 0:
+    if not isinstance(subtasks, list) or len(subtasks) == 0:
         subtasks = [[100, len(info)]]
 
     if dataset.score_type == 'GroupMin':


### PR DESCRIPTION
Fixes this error when trying to use cmsMake on tasks without subtasks:

```
Traceback (most recent call last):
  File "/home/wil93/venvs/cms/bin/cmsMake", line 9, in <module>
    load_entry_point('cms==1.3.dev0', 'console_scripts', 'cmsMake')()
  File "/home/wil93/venvs/cms/lib/python2.7/site-packages/cms-1.3.dev0-py2.7.egg/cmstaskenv/cmsMake.py", line 753, in main
    assume=assume)
  File "/home/wil93/venvs/cms/lib/python2.7/site-packages/cms-1.3.dev0-py2.7.egg/cmstaskenv/cmsMake.py", line 680, in execute_multiple_targets
    already_executed, debug=debug, assume=assume)
  File "/home/wil93/venvs/cms/lib/python2.7/site-packages/cms-1.3.dev0-py2.7.egg/cmstaskenv/cmsMake.py", line 670, in execute_target
    action(assume=assume)
  File "/home/wil93/venvs/cms/lib/python2.7/site-packages/cms-1.3.dev0-py2.7.egg/cmstaskenv/cmsMake.py", line 265, in test_src
    assume=assume)
  File "/home/wil93/venvs/cms/lib/python2.7/site-packages/cms-1.3.dev0-py2.7.egg/cmstaskenv/Test.py", line 182, in test_testcases
    if len(subtasks) == 0:
TypeError: object of type 'float' has no len()
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/515)
<!-- Reviewable:end -->