### PR TITLE
ES performance fixes

### DIFF
--- a/cms/grading/Job.py
+++ b/cms/grading/Job.py
@@ -130,6 +130,33 @@ class Job(object):
         """Create a Job from the output of export_to_dict."""
         return cls(**data)
 
+    @staticmethod
+    def from_operation(operation, object_, dataset):
+        """Produce the job for the operation in the argument.
+
+        Return the Job object that has to be sent to Workers to have
+        them perform the operation this object describes.
+
+        operation (ESOperation): the operation to use.
+        object_ (Submission|UserTest): the object this operation
+            refers to (might be a submission or a user test).
+        dataset (Dataset): the dataset this operation refers to.
+
+        return (Job): the job encoding of the operation, as understood
+            by Workers and TaskTypes.
+
+        """
+        job = None
+        if operation.type_ == ESOperation.COMPILATION:
+            job = CompilationJob.from_submission(operation, object_, dataset)
+        elif operation.type_ == ESOperation.EVALUATION:
+            job = EvaluationJob.from_submission(operation, object_, dataset)
+        elif operation.type_ == ESOperation.USER_TEST_COMPILATION:
+            job = CompilationJob.from_user_test(operation, object_, dataset)
+        elif operation.type_ == ESOperation.USER_TEST_EVALUATION:
+            job = EvaluationJob.from_user_test(operation, object_, dataset)
+        return job
+
 
 class CompilationJob(Job):
     """Job representing a compilation.

--- a/cms/grading/Job.py
+++ b/cms/grading/Job.py
@@ -145,7 +145,21 @@ class Job(object):
         return (Job): the job encoding of the operation, as understood
             by Workers and TaskTypes.
 
+        raise (ValueError): if object_ or dataset are not those
+            referred by the operation.
+
         """
+        if operation.object_id != object_.id:
+            logger.error("Programming error: operation is for object `%s' "
+                         "while passed object is `%s'.",
+                         operation.object_id, object_.id)
+            raise ValueError("Object mismatch while building job.")
+        if operation.dataset_id != dataset.id:
+            logger.error("Programming error: operation is for dataset `%s' "
+                         "while passed dataset is `%s'.",
+                         operation.dataset_id, dataset.id)
+            raise ValueError("Dataset mismatch while building job.")
+
         job = None
         if operation.type_ == ESOperation.COMPILATION:
             job = CompilationJob.from_submission(operation, object_, dataset)

--- a/cms/grading/Job.py
+++ b/cms/grading/Job.py
@@ -88,6 +88,7 @@ class Job(object):
         self.info = info
 
     def export_to_dict(self):
+        """Return a dict representing the job."""
         res = {
             'operation': self.operation,
             'task_type': self.task_type,
@@ -100,6 +101,15 @@ class Job(object):
 
     @staticmethod
     def import_from_dict_with_type(data):
+        """Create a Job from a dict having a type information.
+
+        data (dict): a dict with all the items required for a job, and
+            in addition a 'type' key with associated value
+            'compilation' or 'evaluation'.
+
+        return (Job): either a CompilationJob or an EvaluationJob.
+
+        """
         type_ = data['type']
         del data['type']
         if type_ == 'compilation':
@@ -112,6 +122,7 @@ class Job(object):
 
     @classmethod
     def import_from_dict(cls, data):
+        """Create a Job from the output of export_to_dict."""
         return cls(**data)
 
 
@@ -202,6 +213,17 @@ class CompilationJob(Job):
 
     @staticmethod
     def from_submission(operation, submission, dataset):
+        """Create a CompilationJob from a submission.
+
+        operation (ESOperation): a COMPILATION operation.
+        submission (Submission): the submission object referred by the
+            operation.
+        dataset (Dataset): the dataset object referred by the
+            operation.
+
+        return (CompilationJob): the job.
+
+        """
         job = CompilationJob()
 
         # Job
@@ -219,6 +241,11 @@ class CompilationJob(Job):
         return job
 
     def to_submission(self, sr):
+        """Fill detail of the submission result with the job result.
+
+        sr (SubmissionResult): the DB object to fill.
+
+        """
         # This should actually be useless.
         sr.invalidate_compilation()
 
@@ -240,6 +267,17 @@ class CompilationJob(Job):
 
     @staticmethod
     def from_user_test(operation, user_test, dataset):
+        """Create a CompilationJob from a user test.
+
+        operation (ESOperation): a USER_TEST_COMPILATION operation.
+        user_test (UserTest): the user test object referred by the
+            operation.
+        dataset (Dataset): the dataset object referred by the
+            operation.
+
+        return (CompilationJob): the job.
+
+        """
         job = CompilationJob()
 
         # Job
@@ -272,6 +310,11 @@ class CompilationJob(Job):
         return job
 
     def to_user_test(self, ur):
+        """Fill detail of the user test result with the job result.
+
+        ur (UserTestResult): the DB object to fill.
+
+        """
         # This should actually be useless.
         ur.invalidate_compilation()
 
@@ -412,6 +455,17 @@ class EvaluationJob(Job):
 
     @staticmethod
     def from_submission(operation, submission, dataset):
+        """Create an EvaluationJob from a submission.
+
+        operation (ESOperation): an EVALUATION operation.
+        submission (Submission): the submission object referred by the
+            operation.
+        dataset (Dataset): the dataset object referred by the
+            operation.
+
+        return (EvaluationJob): the job.
+
+        """
         job = EvaluationJob()
 
         # Job
@@ -442,9 +496,11 @@ class EvaluationJob(Job):
         return job
 
     def to_submission(self, sr):
-        # Should not invalidate because evaluations will be added one
-        # by one now.
+        """Fill detail of the submission result with the job result.
 
+        sr (SubmissionResult): the DB object to fill.
+
+        """
         # No need to check self.success because this method gets called
         # only if it is True.
 
@@ -462,6 +518,17 @@ class EvaluationJob(Job):
 
     @staticmethod
     def from_user_test(operation, user_test, dataset):
+        """Create an EvaluationJob from a user test.
+
+        operation (ESOperation): an EVALUATION operation.
+        user_test (UserTest): the user test object referred by the
+            operation.
+        dataset (Dataset): the dataset object referred by the
+            operation.
+
+        return (EvaluationJob): the job.
+
+        """
         job = EvaluationJob()
 
         # Job
@@ -506,6 +573,11 @@ class EvaluationJob(Job):
         return job
 
     def to_user_test(self, ur):
+        """Fill detail of the user test result with the job result.
+
+        ur (UserTestResult): the DB object to fill.
+
+        """
         # This should actually be useless.
         ur.invalidate_evaluation()
 

--- a/cms/grading/Job.py
+++ b/cms/grading/Job.py
@@ -39,8 +39,13 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import json
+import logging
 
 from cms.db import File, Manager, Executable, UserTestExecutable, Evaluation
+from cms.service.esoperations import ESOperation
+
+
+logger = logging.getLogger(__name__)
 
 
 class Job(object):
@@ -224,6 +229,11 @@ class CompilationJob(Job):
         return (CompilationJob): the job.
 
         """
+        if operation.type_ != ESOperation.COMPILATION:
+            logger.error("Programming error: asking for a compilation job, "
+                         "but the operation is %s.", operation.type_)
+            raise ValueError("Operation is not a compilation")
+
         job = CompilationJob()
 
         # Job
@@ -278,6 +288,12 @@ class CompilationJob(Job):
         return (CompilationJob): the job.
 
         """
+        if operation.type_ != ESOperation.USER_TEST_COMPILATION:
+            logger.error("Programming error: asking for a user test "
+                         "compilation job, but the operation is %s.",
+                         operation.type_)
+            raise ValueError("Operation is not a user test compilation")
+
         job = CompilationJob()
 
         # Job
@@ -466,6 +482,11 @@ class EvaluationJob(Job):
         return (EvaluationJob): the job.
 
         """
+        if operation.type_ != ESOperation.EVALUATION:
+            logger.error("Programming error: asking for an evaluation job, "
+                         "but the operation is %s.", operation.type_)
+            raise ValueError("Operation is not an evaluation")
+
         job = EvaluationJob()
 
         # Job
@@ -520,7 +541,7 @@ class EvaluationJob(Job):
     def from_user_test(operation, user_test, dataset):
         """Create an EvaluationJob from a user test.
 
-        operation (ESOperation): an EVALUATION operation.
+        operation (ESOperation): an USER_TEST_EVALUATION operation.
         user_test (UserTest): the user test object referred by the
             operation.
         dataset (Dataset): the dataset object referred by the
@@ -529,6 +550,12 @@ class EvaluationJob(Job):
         return (EvaluationJob): the job.
 
         """
+        if operation.type_ != ESOperation.USER_TESTEVALUATION:
+            logger.error("Programming error: asking for a user test "
+                         "evaluation job, but the operation is %s.",
+                         operation.type_)
+            raise ValueError("Operation is not a user test evaluation")
+
         job = EvaluationJob()
 
         # Job

--- a/cms/io/priorityqueue.py
+++ b/cms/io/priorityqueue.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Contest Management System - http://cms-dev.github.io/
-# Copyright © 2014-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2014-2016 Stefano Maggiolo <s.maggiolo@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -127,6 +127,9 @@ class PriorityQueue(object):
 
         # Index of the next element that will be added to the queue.
         self._next_index = 0
+
+    def __len__(self):
+        return len(self._queue)
 
     def _verify(self):
         """Make sure that the internal state of the queue is consistent.

--- a/cms/server/admin/templates/overview.html
+++ b/cms/server/admin/templates/overview.html
@@ -115,7 +115,15 @@ function update_workers_status(response)
     var strings = [];
     for (var i in response['data'])
     {
-        var job = utils.repr_job(response['data'][i]['operation']);
+        var job = "";
+        if ($.isArray(response['data'][i]['operations'])) {
+            job = utils.repr_job(response['data'][i]['operations'][0]);
+            if (response['data'][i]['operations'].length > 1) {
+                job += ' and ' + (response['data'][i]['operations'].length - 1) + ' more';
+            }
+        } else {
+            job = utils.repr_job(response['data'][i]['operations']);
+        }
         var start_time = utils.repr_time_ago(response['data'][i]['start_time']);
         var connected = "Yes";
         if (response['data'][i]['connected'] == false)

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -51,7 +51,7 @@ from cms.db import SessionGen, Dataset, Submission, SubmissionResult, Task, \
     UserTest
 from cms.service import get_datasets_to_judge, \
     get_submissions, get_submission_results
-from cms.grading.Job import Job
+from cms.grading.Job import JobGroup
 
 from .esoperations import ESOperation, get_relevant_operations, \
     get_submissions_operations, get_user_tests_operations, \
@@ -163,8 +163,7 @@ class Result(object):
 
     """
 
-    def __init__(self, plus, job, job_success):
-        self.plus = plus
+    def __init__(self, job, job_success):
         self.job = job
         self.job_success = job_success
 
@@ -445,23 +444,11 @@ class EvaluationService(TriggeredService):
         """Callback from a worker, to signal that is finished some
         action (compilation or evaluation).
 
-        data (dict): a dictionary that describes a Job instance.
-        plus (tuple): the tuple (type_,
-                                 object_id,
-                                 dataset_id,
-                                 testcase_codename,
-                                 side_data=(priority, timestamp),
-                                 shard_of_worker)
+        data (dict): the JobGroup, exported to dict.
+        plus (tuple): the tuple (shard, (priority, timestamp)).
 
         """
-        # Unpack the plus tuple. It's built in the RPC call to Worker's
-        # execute_job method inside WorkerPool.acquire_worker.
-        type_, object_id, dataset_id, testcase_codename, _, \
-            shard = plus
-
-        # Restore operation from its fields.
-        operation = ESOperation(
-            type_, object_id, dataset_id, testcase_codename)
+        shard, side_data = plus
 
         # We notify the pool that the worker is available again for
         # further work (no matter how the current request turned out,
@@ -475,29 +462,27 @@ class EvaluationService(TriggeredService):
             logger.info("Ignored result from worker %s as requested.", shard)
             return
 
-        job = None
-        job_success = True
+        job_group = None
+        job_group_success = True
         if error is not None:
             logger.error("Received error from Worker: `%s'.", error)
-            job_success = False
+            job_group_success = False
 
         else:
             try:
-                job = Job.import_from_dict_with_type(data)
+                job_group = JobGroup.import_from_dict(data)
             except:
-                logger.error("Couldn't build Job for data %s.", data,
+                logger.error("Couldn't build JobGroup for data %s.", data,
                              exc_info=True)
-                job_success = False
+                job_group_success = False
 
-            else:
-                if not job.success:
-                    logger.error("Worker %s signaled action not successful.",
-                                 shard)
-                    job_success = False
-
-        logger.info("`%s' completed. Success: %s.", operation, job_success)
-
-        self.result_cache.add(operation, Result(plus, job, job_success))
+        if job_group_success:
+            for job in job_group.jobs:
+                operation = ESOperation.from_dict(job.operation)
+                logger.info("`%s' completed. Success: %s.",
+                            operation, job.success)
+                self.result_cache.add(
+                    operation, Result(side_data, job, job.success))
 
     @with_post_finish_lock
     def write_results(self, items):
@@ -520,9 +505,7 @@ class EvaluationService(TriggeredService):
         # evaluations for the same submission and dataset).
         by_object_and_type = defaultdict(list)
         for operation, result in items:
-            type_, object_id, dataset_id, testcase_codename, _, \
-                shard = result.plus
-            t = (type_, object_id, dataset_id)
+            t = (operation.type_, operation.object_id, operation.dataset_id)
             by_object_and_type[t].append((operation, result))
 
         with SessionGen() as session:
@@ -572,8 +555,7 @@ class EvaluationService(TriggeredService):
                     object_result = object_.get_result(dataset)
 
                 self.write_results_one_object_and_type(
-                    session, type_, dataset, object_, object_result,
-                    operation_results)
+                    session, object_result, operation_results)
 
             logger.info("Committing evaluations...")
             session.commit()
@@ -603,19 +585,15 @@ class EvaluationService(TriggeredService):
         logger.info("Done")
 
     def write_results_one_object_and_type(
-            self, session, type_, dataset, object_,
-            object_result, operation_results):
+            self, session, object_result, operation_results):
         """Write to the DB the results for one object and type.
 
         session (Session): the DB session to use.
-        type_ (unicode): the type of all the ESOperations.
-        dataset (Dataset): the dataset of all the ESOperations.
-        object_ (Submission|UserTest): the object of all the ESOperations.
         object_result (SubmissionResult|UserTestResult): the DB object
-            for the result of object_, for all the ESOperations.
+            for the result referred to all the ESOperations.
         operation_results ([(ESOperation, WorkerResult)]): all the
-            operation and corresponding worker results we have
-            received for the given parameters.
+            operations and corresponding worker results we have
+            received for the given object_result
 
         """
         for operation, result in operation_results:
@@ -623,39 +601,35 @@ class EvaluationService(TriggeredService):
             try:
                 with session.begin_nested():
                     self.write_results_one_row(
-                        session, type_, dataset, object_,
-                        object_result, result)
+                        session, object_result, operation, result)
             except IntegrityError:
                 logger.warning(
                     "Integrity error while inserting worker result.",
                     exc_info=True)
 
-    def write_results_one_row(self, session, type_, dataset, object_,
-                              object_result, result):
+    def write_results_one_row(self, session, object_result, operation, result):
         """Write to the DB a single result.
 
         session (Session): the DB session to use.
-        type_ (unicode): the type of the ESOperation.
-        dataset (Dataset): the dataset of the ESOperation.
-        object_ (Submission|UserTest): the object of the ESOperation.
         object_result (SubmissionResult|UserTestResult): the DB object
-            for the result of object_, for the ESOperation.
+            for the operation (and for the result).
+        operation (ESOperation): the operation for which we have the result.
         result (WorkerResult): the result from the worker.
 
         """
-        if type_ == ESOperation.COMPILATION:
+        if operation.type_ == ESOperation.COMPILATION:
             if result.job_success:
                 result.job.to_submission(object_result)
             else:
                 object_result.compilation_tries += 1
 
-        elif type_ == ESOperation.EVALUATION:
+        elif operation.type_ == ESOperation.EVALUATION:
             if result.job_success:
                 result.job.to_submission(object_result)
             else:
                 object_result.evaluation_tries += 1
 
-        elif type_ == ESOperation.USER_TEST_COMPILATION:
+        elif operation.type_ == ESOperation.USER_TEST_COMPILATION:
             if result.job_success:
                 result.job.to_user_test(object_result)
             else:
@@ -663,7 +637,7 @@ class EvaluationService(TriggeredService):
 
             self.user_test_compilation_ended(object_result)
 
-        elif type_ == ESOperation.USER_TEST_EVALUATION:
+        elif operation.type_ == ESOperation.USER_TEST_EVALUATION:
             if result.job_success:
                 result.job.to_user_test(object_result)
             else:
@@ -672,7 +646,7 @@ class EvaluationService(TriggeredService):
             self.user_test_evaluation_ended(object_result)
 
         else:
-            logger.error("Invalid operation type %r.", type_)
+            logger.error("Invalid operation type %r.", operation.type_)
 
     def compilation_ended(self, submission_result):
         """Actions to be performed when we have a submission that has

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -36,17 +36,19 @@ from __future__ import unicode_literals
 
 import logging
 
+from collections import defaultdict
 from datetime import timedelta
 from functools import wraps
 
 import gevent.coros
 
 from sqlalchemy import func, not_
+from sqlalchemy.exc import IntegrityError
 
 from cms import ServiceCoord, get_service_shards
 from cms.io import Executor, TriggeredService, rpc_method
-from cms.db import SessionGen, Dataset, Submission, \
-    SubmissionResult, Task, UserTest
+from cms.db import SessionGen, Dataset, Submission, SubmissionResult, Task, \
+    UserTest
 from cms.service import get_datasets_to_judge, \
     get_submissions, get_submission_results
 from cms.grading.Job import Job
@@ -55,6 +57,7 @@ from .esoperations import ESOperation, get_relevant_operations, \
     get_submissions_operations, get_user_tests_operations, \
     submission_get_operations, submission_to_evaluate, \
     user_test_get_operations
+from .flushingdict import FlushingDict
 from .workerpool import WorkerPool
 
 
@@ -154,6 +157,18 @@ def with_post_finish_lock(func):
     return wrapped
 
 
+class Result(object):
+    """An object grouping the results obtained from a worker for an
+    operation.
+
+    """
+
+    def __init__(self, plus, job, job_success):
+        self.plus = plus
+        self.job = job
+        self.job_success = job_success
+
+
 class EvaluationService(TriggeredService):
     """Evaluation service.
 
@@ -173,10 +188,22 @@ class EvaluationService(TriggeredService):
     # How often we check if a worker is connected.
     WORKER_CONNECTION_CHECK_TIME = timedelta(seconds=10)
 
+    # How many worker results we accumulate before processing them.
+    RESULT_CACHE_SIZE = 100
+    # The maximum time since the last result before processing.
+    MAX_FLUSHING_TIME_SECONDS = 2
+
     def __init__(self, shard, contest_id=None):
         super(EvaluationService, self).__init__(shard)
 
         self.contest_id = contest_id
+
+        # Cache holding the results from the worker until they are
+        # written to the DB.
+        self.result_cache = FlushingDict(
+            EvaluationService.RESULT_CACHE_SIZE,
+            EvaluationService.MAX_FLUSHING_TIME_SECONDS,
+            self.write_results)
 
         # This lock is used to avoid inserting in the queue (which
         # itself is already thread-safe) an operation which is already
@@ -448,6 +475,7 @@ class EvaluationService(TriggeredService):
             logger.info("Ignored result from worker %s as requested.", shard)
             return
 
+        job = None
         job_success = True
         if error is not None:
             logger.error("Received error from Worker: `%s'.", error)
@@ -469,120 +497,182 @@ class EvaluationService(TriggeredService):
 
         logger.info("`%s' completed. Success: %s.", operation, job_success)
 
-        # We get the submission from DB and update it.
+        self.result_cache.add(operation, Result(plus, job, job_success))
+
+    @with_post_finish_lock
+    def write_results(self, items):
+        """Receive worker results from the cache and writes them to the DB.
+
+        Grouping results together by object (i.e., submission result
+        or user test result) and type (compilation or evaluation)
+        allows this method to talk less to the DB, for example by
+        retrieving datasets and submission results only once instead
+        of once for every result.
+
+        items ([(operation, Result)]): the results received by ES but
+            not yet written to the db.
+
+        """
+        logger.info("Starting commit process...")
+
+        # Reorganize the results by submission/usertest result and
+        # operation type (i.e., group together the testcase
+        # evaluations for the same submission and dataset).
+        by_object_and_type = defaultdict(list)
+        for operation, result in items:
+            type_, object_id, dataset_id, testcase_codename, _, \
+                shard = result.plus
+            t = (type_, object_id, dataset_id)
+            by_object_and_type[t].append((operation, result))
+
         with SessionGen() as session:
-            dataset = Dataset.get_from_id(dataset_id, session)
-            if dataset is None:
-                logger.error("Could not find dataset %d in the database.",
-                             dataset_id)
-                return
+            # Dictionary holding the objects we use repeatedly,
+            # indexed by id, to avoid querying them multiple times.
+            datasets = dict()
+            subs = dict()
+            srs = dict()
 
-            # TODO Try to move this 4-cases if-clause into a method of
-            # ESOperation: I'd really like ES itself not to care about
-            # which type of operation it's handling.
-            if type_ == ESOperation.COMPILATION:
-                submission = Submission.get_from_id(object_id, session)
-                if submission is None:
-                    logger.error("Could not find submission %d "
-                                 "in the database.", object_id)
-                    return
+            for key, operation_results in by_object_and_type.iteritems():
+                type_, object_id, dataset_id = key
 
-                submission_result = submission.get_result(dataset)
-                if submission_result is None:
-                    logger.info("Couldn't find submission %d(%d) "
-                                "in the database. Creating it.",
-                                object_id, dataset_id)
-                    submission_result = \
-                        submission.get_result_or_create(dataset)
+                # Get dataset.
+                if dataset_id not in datasets:
+                    datasets[dataset_id] = \
+                        Dataset.get_from_id(dataset_id, session)
+                dataset = datasets[dataset_id]
+                if dataset is None:
+                    logger.error("Could not find dataset %d in the database.",
+                                 dataset_id)
+                    continue
 
-                if job_success:
-                    job.to_submission(submission_result)
+                # Get submission or user test, and their results.
+                if type_ in [ESOperation.COMPILATION, ESOperation.EVALUATION]:
+                    if object_id not in subs:
+                        subs[object_id] = \
+                            Submission.get_from_id(object_id, session)
+                    object_ = subs[object_id]
+                    if object_ is None:
+                        logger.error("Could not find submission %d "
+                                     "in the database.", object_id)
+                        continue
+                    result_id = (object_id, dataset_id)
+                    if result_id not in srs:
+                        srs[result_id] = object_.get_result(dataset)
+                        if srs[result_id] is None:
+                            logger.info("Couldn't find submission %d(%d) "
+                                        "in the database. Creating it.",
+                                        object_id, dataset_id)
+                            srs[result_id] = \
+                                object_.get_result_or_create(dataset)
+                    object_result = srs[result_id]
                 else:
-                    submission_result.compilation_tries += 1
+                    # We do not cache user tests as they can come up
+                    # only once.
+                    object_ = UserTest.get_from_id(object_id, session)
+                    object_result = object_.get_result(dataset)
 
-                session.commit()
+                self.write_results_one_object_and_type(
+                    session, type_, dataset, object_, object_result,
+                    operation_results)
 
-                self.compilation_ended(submission_result)
+            logger.info("Committing evaluations...")
+            session.commit()
 
-            elif type_ == ESOperation.EVALUATION:
-                submission = Submission.get_from_id(object_id, session)
-                if submission is None:
-                    logger.error("Could not find submission %d "
-                                 "in the database.", object_id)
-                    return
+            for type_, object_id, dataset_id in by_object_and_type:
+                if type_ == ESOperation.EVALUATION:
+                    submission_result = srs[(object_id, dataset_id)]
+                    dataset = datasets[dataset_id]
+                    if len(submission_result.evaluations) == \
+                            len(dataset.testcases):
+                        submission_result.set_evaluation_outcome()
 
-                submission_result = submission.get_result(dataset)
-                if submission_result is None:
-                    logger.error("Couldn't find submission %d(%d) "
-                                 "in the database.", object_id, dataset_id)
-                    return
+            logger.info("Committing evaluation outcomes...")
+            session.commit()
 
-                if job_success:
-                    job.to_submission(submission_result)
-                else:
-                    submission_result.evaluation_tries += 1
+            logger.info("Ending operations for %s objects...",
+                        len(by_object_and_type))
+            for type_, submission_id, dataset_id in by_object_and_type:
+                if type_ == ESOperation.COMPILATION:
+                    submission_result = srs[(submission_id, dataset_id)]
+                    self.compilation_ended(submission_result)
+                elif type_ == ESOperation.EVALUATION:
+                    submission_result = srs[(submission_id, dataset_id)]
+                    if submission_result.evaluated():
+                        self.evaluation_ended(submission_result)
 
-                # Submission evaluation will be ended only when
-                # evaluation for each testcase is available.
-                evaluation_complete = (len(submission_result.evaluations) ==
-                                       len(dataset.testcases))
-                if evaluation_complete:
-                    submission_result.set_evaluation_outcome()
+        logger.info("Done")
 
-                session.commit()
+    def write_results_one_object_and_type(
+            self, session, type_, dataset, object_,
+            object_result, operation_results):
+        """Write to the DB the results for one object and type.
 
-                if evaluation_complete:
-                    self.evaluation_ended(submission_result)
+        session (Session): the DB session to use.
+        type_ (unicode): the type of all the ESOperations.
+        dataset (Dataset): the dataset of all the ESOperations.
+        object_ (Submission|UserTest): the object of all the ESOperations.
+        object_result (SubmissionResult|UserTestResult): the DB object
+            for the result of object_, for all the ESOperations.
+        operation_results ([(ESOperation, WorkerResult)]): all the
+            operation and corresponding worker results we have
+            received for the given parameters.
 
-            elif type_ == ESOperation.USER_TEST_COMPILATION:
-                user_test = UserTest.get_from_id(object_id, session)
-                if user_test is None:
-                    logger.error("Could not find user test %d "
-                                 "in the database.", object_id)
-                    return
+        """
+        for operation, result in operation_results:
+            logger.info("Writing result to db for %s", operation)
+            try:
+                with session.begin_nested():
+                    self.write_results_one_row(
+                        session, type_, dataset, object_,
+                        object_result, result)
+            except IntegrityError:
+                logger.warning(
+                    "Integrity error while inserting worker result.",
+                    exc_info=True)
 
-                user_test_result = user_test.get_result(dataset)
-                if user_test_result is None:
-                    logger.error("Couldn't find user test %d(%d) "
-                                 "in the database. Creating it.",
-                                 object_id, dataset_id)
-                    user_test_result = \
-                        user_test.get_result_or_create(dataset)
+    def write_results_one_row(self, session, type_, dataset, object_,
+                              object_result, result):
+        """Write to the DB a single result.
 
-                if job_success:
-                    job.to_user_test(user_test_result)
-                else:
-                    user_test_result.compilation_tries += 1
+        session (Session): the DB session to use.
+        type_ (unicode): the type of the ESOperation.
+        dataset (Dataset): the dataset of the ESOperation.
+        object_ (Submission|UserTest): the object of the ESOperation.
+        object_result (SubmissionResult|UserTestResult): the DB object
+            for the result of object_, for the ESOperation.
+        result (WorkerResult): the result from the worker.
 
-                session.commit()
-
-                self.user_test_compilation_ended(user_test_result)
-
-            elif type_ == ESOperation.USER_TEST_EVALUATION:
-                user_test = UserTest.get_from_id(object_id, session)
-                if user_test is None:
-                    logger.error("Could not find user test %d "
-                                 "in the database.", object_id)
-                    return
-
-                user_test_result = user_test.get_result(dataset)
-                if user_test_result is None:
-                    logger.error("Couldn't find user test %d(%d) "
-                                 "in the database.", object_id, dataset_id)
-                    return
-
-                if job_success:
-                    job.to_user_test(user_test_result)
-                else:
-                    user_test_result.evaluation_tries += 1
-
-                session.commit()
-
-                self.user_test_evaluation_ended(user_test_result)
-
+        """
+        if type_ == ESOperation.COMPILATION:
+            if result.job_success:
+                result.job.to_submission(object_result)
             else:
-                logger.error("Invalid operation type %r.", type_)
-                return
+                object_result.compilation_tries += 1
+
+        elif type_ == ESOperation.EVALUATION:
+            if result.job_success:
+                result.job.to_submission(object_result)
+            else:
+                object_result.evaluation_tries += 1
+
+        elif type_ == ESOperation.USER_TEST_COMPILATION:
+            if result.job_success:
+                result.job.to_user_test(object_result)
+            else:
+                object_result.compilation_tries += 1
+
+            self.user_test_compilation_ended(object_result)
+
+        elif type_ == ESOperation.USER_TEST_EVALUATION:
+            if result.job_success:
+                result.job.to_user_test(object_result)
+            else:
+                object_result.evaluation_tries += 1
+
+            self.user_test_evaluation_ended(object_result)
+
+        else:
+            logger.error("Invalid operation type %r.", type_)
 
     def compilation_ended(self, submission_result):
         """Actions to be performed when we have a submission that has
@@ -887,6 +977,7 @@ class EvaluationService(TriggeredService):
                 self.submission_enqueue_operations(submission)
 
             session.commit()
+        logger.info("Invalidate successfully completed.")
 
     @rpc_method
     def disable_worker(self, shard):

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -44,6 +44,7 @@ import gevent.coros
 
 from sqlalchemy import func, not_
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import joinedload
 
 from cms import ServiceCoord, get_service_shards
 from cms.io import Executor, TriggeredService, rpc_method
@@ -65,20 +66,27 @@ logger = logging.getLogger(__name__)
 
 
 class EvaluationExecutor(Executor):
+
+    # Real maximum number of operations to be sent to a worker.
+    MAX_OPERATIONS_PER_BATCH = 25
+
     def __init__(self, evaluation_service):
         """Create the single executor for ES.
 
         The executor just delegates work to the worker pool.
 
         """
-        super(EvaluationExecutor, self).__init__()
+        super(EvaluationExecutor, self).__init__(True)
 
         self.evaluation_service = evaluation_service
         self.pool = WorkerPool(self.evaluation_service)
 
-        # QueueItem (ESOperation) we have extracted from the queue,
-        # but not yet finished to execute.
-        self._currently_executing = None
+        # List of QueueItem (ESOperation) we have extracted from the
+        # queue, but not yet finished to execute.
+        self._currently_executing = []
+
+        # Lock used to guard the currently executing operations
+        self._current_execution_lock = gevent.coros.RLock()
 
         # Whether execute need to drop the currently executing
         # operation.
@@ -99,37 +107,61 @@ class EvaluationExecutor(Executor):
 
         """
         return super(EvaluationExecutor, self).__contains__(item) or \
-            self._currently_executing == item or \
+            item in self._currently_executing or \
             item in self.pool
 
-    def execute(self, entry):
-        """Execute an operation in the queue.
+    def max_operations_per_batch(self):
+        """Return the maximum number of operations per batch.
 
-        The operation might not be executed immediately because of
-        lack of workers.
-
-        entry (QueueEntry): entry containing the operation to perform.
+        We derive the number from the length of the queue divided by
+        the number of workers, with a cap at MAX_OPERATIONS_PER_BATCH.
 
         """
-        self._currently_executing = entry.item
-        side_data = (entry.priority, entry.timestamp)
+        # TODO: len(self.pool) is the total number of workers,
+        # included those that are disabled.
+        ratio = len(self._operation_queue) // len(self.pool) + 1
+        ret = min(max(ratio, 1), EvaluationExecutor.MAX_OPERATIONS_PER_BATCH)
+        logger.info("Ratio is %d, executing %d operations together.",
+                    ratio, ret)
+        return ret
+
+    def execute(self, entries):
+        """Execute a batch of operations in the queue.
+
+        The operations might not be executed immediately because of
+        lack of workers.
+
+        entries ([QueueEntry]): entries containing the operations to
+            perform.
+
+        """
+        with self._current_execution_lock:
+            self._currently_executing = []
+            for entry in entries:
+                operation = entry.item
+                # Side data is attached to the operation sent to the
+                # worker pool. In case the operation is lost, the pool
+                # will return it to us, and we will use it to
+                # re-enqueue it.
+                operation.side_data = (entry.priority, entry.timestamp)
+                self._currently_executing.append(operation)
         res = None
-        while res is None and not self._drop_current:
+        while len(self._currently_executing) > 0:
             self.pool.wait_for_workers()
-            if self._drop_current:
-                break
-            res = self.pool.acquire_worker(entry.item,
-                                           side_data=side_data)
-        self._drop_current = False
-        self._currently_executing = None
+            with self._current_execution_lock:
+                if len(self._currently_executing) == 0:
+                    break
+                res = self.pool.acquire_worker(self._currently_executing)
+                if res is not None:
+                    self._drop_current = False
+                    self._currently_executing = []
+                    break
 
     def dequeue(self, operation):
         """Remove an item from the queue.
 
-        We need to override dequeue because in execute we wait for a
-        worker to become available to serve the operation, and if that
-        operation needed to be dequeued, we need to remove it also
-        from there.
+        We need to override dequeue because the operation to dequeue
+        might have already been extracted, but not yet executed.
 
         operation (ESOperation)
 
@@ -137,10 +169,12 @@ class EvaluationExecutor(Executor):
         try:
             super(EvaluationExecutor, self).dequeue(operation)
         except KeyError:
-            if self._currently_executing == operation:
-                self._drop_current = True
-            else:
-                raise
+            with self._current_execution_lock:
+                for i in range(len(self._currently_executing)):
+                    if self._currently_executing[i] == operation:
+                        del self._currently_executing[i]
+                        return
+            raise
 
 
 def with_post_finish_lock(func):
@@ -400,9 +434,10 @@ class EvaluationService(TriggeredService):
 
         """
         lost_operations = self.get_executor().pool.check_timeouts()
-        for priority, timestamp, operation in lost_operations:
+        for operation in lost_operations:
             logger.info("Operation %s put again in the queue because of "
                         "worker timeout.", operation)
+            priority, timestamp = operation.side_data
             self.enqueue(operation, priority, timestamp)
         return True
 
@@ -412,9 +447,10 @@ class EvaluationService(TriggeredService):
 
         """
         lost_operations = self.get_executor().pool.check_connections()
-        for priority, timestamp, operation in lost_operations:
+        for operation in lost_operations:
             logger.info("Operation %s put again in the queue because of "
                         "disconnected worker.", operation)
+            priority, timestamp = operation.side_data
             self.enqueue(operation, priority, timestamp)
         return True
 
@@ -440,16 +476,14 @@ class EvaluationService(TriggeredService):
             operation, priority, timestamp) > 0
 
     @with_post_finish_lock
-    def action_finished(self, data, plus, error=None):
+    def action_finished(self, data, shard, error=None):
         """Callback from a worker, to signal that is finished some
         action (compilation or evaluation).
 
         data (dict): the JobGroup, exported to dict.
-        plus (tuple): the tuple (shard, (priority, timestamp)).
+        shard (int): the shard finishing the action.
 
         """
-        shard, side_data = plus
-
         # We notify the pool that the worker is available again for
         # further work (no matter how the current request turned out,
         # even if the worker encountered an error). If the pool
@@ -458,7 +492,8 @@ class EvaluationService(TriggeredService):
         # this method and do nothing because in that case we know the
         # operation has returned to the queue and perhaps already been
         # reassigned to another worker.
-        if self.get_executor().pool.release_worker(shard):
+        to_ignore = self.get_executor().pool.release_worker(shard)
+        if to_ignore is True:
             logger.info("Ignored result from worker %s as requested.", shard)
             return
 
@@ -481,8 +516,10 @@ class EvaluationService(TriggeredService):
                 operation = ESOperation.from_dict(job.operation)
                 logger.info("`%s' completed. Success: %s.",
                             operation, job.success)
-                self.result_cache.add(
-                    operation, Result(side_data, job, job.success))
+                if isinstance(to_ignore, list) and operation in to_ignore:
+                    logger.info("`%s' result ignored as requested", operation)
+                else:
+                    self.result_cache.add(operation, Result(job, job.success))
 
     @with_post_finish_lock
     def write_results(self, items):
@@ -511,6 +548,8 @@ class EvaluationService(TriggeredService):
         with SessionGen() as session:
             # Dictionary holding the objects we use repeatedly,
             # indexed by id, to avoid querying them multiple times.
+            # TODO: this pattern is used in WorkerPool and should be
+            # abstracted away.
             datasets = dict()
             subs = dict()
             srs = dict()
@@ -520,8 +559,10 @@ class EvaluationService(TriggeredService):
 
                 # Get dataset.
                 if dataset_id not in datasets:
-                    datasets[dataset_id] = \
-                        Dataset.get_from_id(dataset_id, session)
+                    datasets[dataset_id] = session.query(Dataset)\
+                        .filter(Dataset.id == dataset_id)\
+                        .options(joinedload(Dataset.testcases))\
+                        .first()
                 dataset = datasets[dataset_id]
                 if dataset is None:
                     logger.error("Could not find dataset %d in the database.",
@@ -970,9 +1011,10 @@ class EvaluationService(TriggeredService):
         except ValueError:
             return False
 
-        for priority, timestamp, operation in lost_operations:
+        for operation in lost_operations:
             logger.info("Operation %s put again in the queue because "
                         "the worker was disabled.", operation)
+            priority, timestamp = operation.side_data
             self.enqueue(operation, priority, timestamp)
         return True
 

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -392,75 +392,6 @@ class EvaluationService(TriggeredService):
             self.enqueue(operation, priority, timestamp)
         return True
 
-    def submission_busy(self, submission_id, dataset_id,
-                        testcase_codename=None):
-        """Check if the submission has a related operation in the queue or
-        assigned to a worker.
-
-        This might be either the compilation of the submission, or the
-        evaluation of the testcase.
-
-        submission_id (int): the id of the submission.
-        dataset_id (int): the id of the dataset.
-        testcase_codename (unicode|None): if not set, we will only
-            check for the presence of the compilation of the
-            submission.
-
-        return (bool): True when the submission / testcase is present
-            in the queue.
-
-        """
-        operations = []
-        operations.append(ESOperation(
-            ESOperation.COMPILATION,
-            submission_id,
-            dataset_id))
-        if testcase_codename is not None:
-            operations.append(ESOperation(
-                ESOperation.EVALUATION,
-                submission_id,
-                dataset_id,
-                testcase_codename))
-        return any([operation in self.get_executor()
-                    for operation in operations])
-
-    def user_test_busy(self, user_test_id, dataset_id):
-        """Check if the user test has a related operation in the queue or
-        assigned to a worker.
-
-        """
-        operations = [
-            ESOperation(
-                ESOperation.USER_TEST_COMPILATION,
-                user_test_id,
-                dataset_id),
-            ESOperation(
-                ESOperation.USER_TEST_EVALUATION,
-                user_test_id,
-                dataset_id),
-        ]
-        return any([operation in self.get_executor()
-                    for operation in operations])
-
-    def operation_busy(self, operation):
-        """Check the entity (submission or user test) related to an operation
-        has other related operations in the queue or assigned to a
-        worker.
-
-        """
-
-        if operation.type_ in (ESOperation.COMPILATION,
-                               ESOperation.EVALUATION):
-            return self.submission_busy(operation.object_id,
-                                        operation.dataset_id,
-                                        operation.testcase_codename)
-        elif operation.type_ in (ESOperation.USER_TEST_COMPILATION,
-                                 ESOperation.USER_TEST_EVALUATION):
-            return self.user_test_busy(operation.object_id,
-                                       operation.dataset_id)
-        else:
-            raise Exception("Wrong operation type %s" % operation.type_)
-
     @with_post_finish_lock
     def enqueue(self, operation, priority, timestamp):
         """Push an operation in the queue.
@@ -475,7 +406,7 @@ class EvaluationService(TriggeredService):
         return (bool): True if pushed, False if not.
 
         """
-        if self.operation_busy(operation):
+        if operation in self.get_executor() or operation in self.result_cache:
             return False
 
         # enqueue() returns the number of successful pushes.

--- a/cms/service/Worker.py
+++ b/cms/service/Worker.py
@@ -38,7 +38,7 @@ from cms.db import SessionGen, Contest
 from cms.db.filecacher import FileCacher
 from cms.grading import JobException
 from cms.grading.tasktypes import get_task_type
-from cms.grading.Job import CompilationJob, EvaluationJob, Job
+from cms.grading.Job import CompilationJob, EvaluationJob, JobGroup
 
 
 logger = logging.getLogger(__name__)
@@ -94,48 +94,54 @@ class Worker(Service):
         logger.info("Precaching finished.")
 
     @rpc_method
-    def execute_job(self, job_dict):
-        """Receive a group of jobs in a dict format and executes them
-        one by one.
+    def execute_job_group(self, job_group_dict):
+        """Receive a group of jobs in a list format and executes them one by
+        one.
 
-        job_dict (dict): a dictionary suitable to be imported from Job.
+        job_group_dict ({}): a JobGroup exported to dict.
+
+        return ({}): the same JobGroup in dict format, but containing
+            the results.
 
         """
         start_time = time.time()
-        job = Job.import_from_dict_with_type(job_dict)
+        job_group = JobGroup.import_from_dict(job_group_dict)
 
         if self.work_lock.acquire(False):
-
             try:
-                logger.info("Starting job.",
-                            extra={"operation": job.info})
+                logger.info("Starting job group.")
+                for job in job_group.jobs:
+                    logger.info("Starting job.",
+                                extra={"operation": job.info})
 
-                job.shard = self.shard
+                    job.shard = self.shard
 
-                if self._fake_worker_time is None:
-                    task_type = get_task_type(job.task_type,
-                                              job.task_type_parameters)
-                    task_type.execute_job(job, self.file_cacher)
+                    if self._fake_worker_time is None:
+                        task_type = get_task_type(job.task_type,
+                                                  job.task_type_parameters)
+                        task_type.execute_job(job, self.file_cacher)
 
-                else:
-                    time.sleep(self._fake_worker_time)
-                    job.success = True
-                    job.text = ["ok"]
-                    job.plus = {
-                        "execution_time": self._fake_worker_time,
-                        "execution_wall_clock_time": self._fake_worker_time,
-                        "execution_memory": 1000,
-                    }
+                    else:
+                        time.sleep(self._fake_worker_time)
+                        job.success = True
+                        job.text = ["ok"]
+                        job.plus = {
+                            "execution_time": self._fake_worker_time,
+                            "execution_wall_clock_time":
+                            self._fake_worker_time,
+                            "execution_memory": 1000,
+                        }
 
-                    if isinstance(job, CompilationJob):
-                        job.compilation_success = True
-                    elif isinstance(job, EvaluationJob):
-                        job.outcome = "1.0"
+                        if isinstance(job, CompilationJob):
+                            job.compilation_success = True
+                        elif isinstance(job, EvaluationJob):
+                            job.outcome = "1.0"
 
-                logger.info("Finished job.",
-                            extra={"operation": job.info})
+                    logger.info("Finished job.",
+                                extra={"operation": job.info})
 
-                return job.export_to_dict()
+                logger.info("Finished job group.")
+                return job_group.export_to_dict()
 
             except:
                 err_msg = "Worker failed."

--- a/cms/service/esoperations.py
+++ b/cms/service/esoperations.py
@@ -509,6 +509,13 @@ class ESOperation(QueueItem):
         self.dataset_id = dataset_id
         self.testcase_codename = testcase_codename
 
+    @staticmethod
+    def from_dict(d):
+        return ESOperation(d["type"],
+                           d["object_id"],
+                           d["dataset_id"],
+                           d["testcase_codename"])
+
     def __eq__(self, other):
         # We may receive a non-ESOperation other when comparing with
         # operations in the worker pool (as these may also be unicode or
@@ -541,10 +548,12 @@ class ESOperation(QueueItem):
             self.testcase_codename)
 
     def to_dict(self):
-        return {"type": self.type_,
-                "object_id": self.object_id,
-                "dataset_id": self.dataset_id,
-                "testcase_codename": self.testcase_codename}
+        return {
+            "type": self.type_,
+            "object_id": self.object_id,
+            "dataset_id": self.dataset_id,
+            "testcase_codename": self.testcase_codename
+        }
 
     def build_job(self, session):
         """Produce the Job for this operation.
@@ -563,15 +572,14 @@ class ESOperation(QueueItem):
         dataset = Dataset.get_from_id(self.dataset_id, session)
         if self.type_ == ESOperation.COMPILATION:
             submission = Submission.get_from_id(self.object_id, session)
-            result = CompilationJob.from_submission(submission, dataset)
+            result = CompilationJob.from_submission(self, submission, dataset)
         elif self.type_ == ESOperation.EVALUATION:
             submission = Submission.get_from_id(self.object_id, session)
-            result = EvaluationJob.from_submission(
-                submission, dataset, self.testcase_codename)
+            result = EvaluationJob.from_submission(self, submission, dataset)
         elif self.type_ == ESOperation.USER_TEST_COMPILATION:
             user_test = UserTest.get_from_id(self.object_id, session)
-            result = CompilationJob.from_user_test(user_test, dataset)
+            result = CompilationJob.from_user_test(self, user_test, dataset)
         elif self.type_ == ESOperation.USER_TEST_EVALUATION:
             user_test = UserTest.get_from_id(self.object_id, session)
-            result = EvaluationJob.from_user_test(user_test, dataset)
+            result = EvaluationJob.from_user_test(self, user_test, dataset)
         return result

--- a/cms/service/esoperations.py
+++ b/cms/service/esoperations.py
@@ -38,7 +38,6 @@ from sqlalchemy import case, literal
 from cms.io import PriorityQueue, QueueItem
 from cms.db import Dataset, Evaluation, Submission, SubmissionResult, \
     Task, Testcase, UserTest, UserTestResult
-from cms.grading.Job import CompilationJob, EvaluationJob
 
 
 logger = logging.getLogger(__name__)
@@ -563,28 +562,3 @@ class ESOperation(QueueItem):
             "dataset_id": self.dataset_id,
             "testcase_codename": self.testcase_codename
         }
-
-    def build_job(self, object_, dataset):
-        """Produce the Job for this operation.
-
-        Return the Job object that has to be sent to Workers to have
-        them perform the operation this object describes.
-
-        object_ (Submission|UserTest): the object this operation
-            refers to (might be a submission or a user test).
-        dataset (Dataset): the dataset this operation refers to.
-
-        return (Job): the job encoding of the operation, as understood
-            by Workers and TaskTypes.
-
-        """
-        result = None
-        if self.type_ == ESOperation.COMPILATION:
-            result = CompilationJob.from_submission(self, object_, dataset)
-        elif self.type_ == ESOperation.EVALUATION:
-            result = EvaluationJob.from_submission(self, object_, dataset)
-        elif self.type_ == ESOperation.USER_TEST_COMPILATION:
-            result = CompilationJob.from_user_test(self, object_, dataset)
-        elif self.type_ == ESOperation.USER_TEST_EVALUATION:
-            result = EvaluationJob.from_user_test(self, object_, dataset)
-        return result

--- a/cms/service/flushingdict.py
+++ b/cms/service/flushingdict.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2016 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import gevent
+import logging
+
+try:
+    from gevent.locks import RLock
+except ImportError:
+    from gevent.coros import RLock
+
+
+logger = logging.getLogger(__name__)
+
+
+class FlushingDict(object):
+    """A dict that periodically flushes its content to a callback.
+
+    The dict flushes after a specified time since the latest entry
+    was added, or when it has reached its maximum size.
+
+    This dict is thread safe. Keys must be hashable. New values for an
+    existing keys will overwrite the previous values.
+
+    """
+
+    def __init__(self, size, flush_latency_seconds, callback):
+        # Elements contained in the dict that force a flush.
+        self.size = size
+
+        # How much time we wait for other key-values before flushing.
+        self.flush_latency_seconds = flush_latency_seconds
+
+        # Function to flush the data to.
+        self.callback = callback
+
+        # This contains all the key-values received and not yet
+        # flushed.
+        self.d = dict()
+
+        # The greenlet in which we schedule the flush. Whenever a new
+        # key-value is added, the greenlet is killed and rescheduled.
+        self.flush_greenlet = None
+
+        # This lock ensures that if a key-value arrives while flush is
+        # executing, it is not inserted in the dict until flush
+        # terminates.
+        self.d_lock = RLock()
+
+        # This lock ensures that we do not change the flush greenlet
+        # while it is executing.
+        self.f_lock = RLock()
+
+    def _deschedule(self):
+        """Remove the scheduling of the flush."""
+        with self.f_lock:
+            if self.flush_greenlet is not None:
+                self.flush_greenlet.kill()
+                self.flush_greenlet = None
+
+    def add(self, key, value):
+        logger.debug("Adding item %s", key)
+        with self.d_lock:
+            self.d[key] = value
+        self._deschedule()
+        if len(self.d) >= self.size:
+            self.flush_greenlet = gevent.spawn(self.flush)
+        else:
+            self.flush_greenlet = gevent.spawn_later(
+                self.flush_latency_seconds,
+                self.flush)
+
+    def flush(self):
+        logger.debug("Flushing items")
+        with self.f_lock:
+            with self.d_lock:
+                to_send = self.d.items()
+                self.d = dict()
+            self.callback(to_send)
+
+    def __contains__(self, key):
+        return key in self.d

--- a/cms/service/workerpool.py
+++ b/cms/service/workerpool.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2010-2014 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
-# Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2016 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2013-2015 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
@@ -39,6 +39,7 @@ from gevent.event import Event
 
 from cms.io import QueueItem
 from cms.db import SessionGen
+from cms.grading.Job import JobGroup
 from cmscommon.datetime import make_datetime, make_timestamp
 
 
@@ -176,14 +177,13 @@ class WorkerPool(object):
 
         with SessionGen() as session:
             job = operation.build_job(session)
-            job_dict = job.export_to_dict()
+            job_group = JobGroup([job])
+            job_group_dict = job_group.export_to_dict()
 
-        self._worker[shard].execute_job(
-            job_dict=job_dict,
+        self._worker[shard].execute_job_group(
+            job_group_dict=job_group_dict,
             callback=self._service.action_finished,
-            plus=(operation.type_, operation.object_id,
-                  operation.dataset_id, operation.testcase_codename,
-                  side_data, shard))
+            plus=(shard, side_data))
         return shard
 
     def release_worker(self, shard):

--- a/cms/service/workerpool.py
+++ b/cms/service/workerpool.py
@@ -35,10 +35,11 @@ import random
 
 from datetime import timedelta
 
+import gevent.coros
+
 from gevent.event import Event
 
-from cms.io import QueueItem
-from cms.db import SessionGen
+from cms.db import Dataset, SessionGen, Submission, UserTest
 from cms.grading.Job import JobGroup
 from cmscommon.datetime import make_datetime, make_timestamp
 
@@ -66,22 +67,40 @@ class WorkerPool(object):
         self._service = service
         self._worker = {}
         # These dictionary stores data about the workers (identified
-        # by their shard number). Side data is anything one want to
-        # attach to the worker. Schedule disabling to True means that
-        # we are going to disable the worker as soon as possible (when
-        # it finishes the current operation). The current operation is
-        # also discarded because we already re-assigned it. Ignore is
-        # true if the next result coming from the worker should be
-        # discarded.
+        # by their shard number). Schedule disabling to True means
+        # that we are going to disable the worker as soon as possible
+        # (when it finishes the current operations). The current
+        # operations are also discarded because we already re-assigned
+        # it. Ignore is true if the next results coming from the
+        # worker should be discarded. Operations is the list of
+        # operations currently executing. Operations to ignore is the
+        # list of operations to ignore in the next batch of results.
+        # Type: {int: [ESOperation]}
+        self._operations = {}
+        # Type: {int: [ESOperation]}
+        self._operations_to_ignore = {}
+        # Type: {int: Datetime|None}
+        self._start_time = {}
+        # Type: {int: bool}
+        self._schedule_disabling = {}
+        # Type: {int: bool}
+        self._ignore = {}
 
         # TODO: given the number of pieces data associated to each
         # worker, this class could be simplified by creating a new
         # WorkerPoolItem class.
-        self._operation = {}
-        self._start_time = {}
-        self._side_data = {}
-        self._schedule_disabling = {}
-        self._ignore = {}
+
+        # TODO: at the moment race conditions during the periodic
+        # checks cannot be excluded. A refactoring of this class
+        # should take that into account.
+
+        # A reverse lookup dictionary mapping operations to shards.
+        # Type: {ESOperation: int}
+        self._operations_reverse = dict()
+
+        # A lock to ensure that the reverse lookup stays in sync with
+        # the operations lists.
+        self._operation_lock = gevent.coros.RLock()
 
         # Event set when there are workers available to take jobs. It
         # is only guaranteed that if a worker is available, then this
@@ -89,10 +108,40 @@ class WorkerPool(object):
         # set does not mean that there is a worker available.
         self._workers_available_event = Event()
 
+    def __len__(self):
+        return len(self._worker)
+
     def __contains__(self, operation):
-        return any(operation == self._operation[shard] and
-                   not self._ignore[shard]
-                   for shard in self._worker)
+        return operation in self._operations_reverse
+
+    def _remove_operations(self, shard, new_operation):
+        """Safely remove operations from a worker, assigning a new status.
+
+        shard (int): the worker from which to remove operations.
+        new_operations (unicode|None): the new operation, which can be
+            INACTIVE or DISABLED.
+
+        """
+        with self._operation_lock:
+            operations = self._operations[shard]
+            self._operations[shard] = new_operation
+            if isinstance(operations, list):
+                for operation in operations:
+                    del self._operations_reverse[operation]
+
+    def _add_operations(self, shard, operations):
+        """Assigns new operations to a currently inactive worker.
+
+        shard (int): shard of the worker.
+        operations ([ESOperation]) operations to assign to the worker.
+
+        """
+        if self._operations[shard] != WorkerPool.WORKER_INACTIVE:
+            raise ValueError("Shard %s is already doing an operation.", shard)
+        with self._operation_lock:
+            self._operations[shard] = operations
+            for operation in operations:
+                self._operations_reverse[operation] = shard
 
     def wait_for_workers(self):
         """Wait until a worker might be available."""
@@ -111,9 +160,9 @@ class WorkerPool(object):
             on_connect=self.on_worker_connected)
 
         # And we fill all data.
-        self._operation[shard] = WorkerPool.WORKER_INACTIVE
+        self._operations[shard] = WorkerPool.WORKER_INACTIVE
+        self._operations_to_ignore[shard] = []
         self._start_time[shard] = None
-        self._side_data[shard] = None
         self._schedule_disabling[shard] = False
         self._ignore[shard] = False
         self._workers_available_event.set()
@@ -141,14 +190,12 @@ class WorkerPool(object):
         # so we wake up the consumers.
         self._workers_available_event.set()
 
-    def acquire_worker(self, operation, side_data=None):
+    def acquire_worker(self, operations):
         """Tries to assign an operation to an available worker. If no workers
         are available then this returns None, otherwise this returns
         the chosen worker.
 
-        operation (ESOperation): the operation to assign to a worker.
-        side_data (object): object to attach to the worker for later
-            use.
+        operations ([ESOperation]): the operations to assign to a worker.
 
         return (int|None): None if no workers are available, the worker
             assigned to the operation otherwise.
@@ -164,26 +211,42 @@ class WorkerPool(object):
             return None
 
         # Then we fill the info for future memory.
-        self._operation[shard] = operation
-        self._start_time[shard] = make_datetime()
-        self._side_data[shard] = side_data
-        logger.debug("Worker %s acquired.", shard)
+        self._add_operations(shard, operations)
 
-        # And finally we ask the worker to do the operation.
-        timestamp = side_data[1]
-        queue_time = self._start_time[shard] - timestamp
-        logger.info("Asking worker %s to `%s' (%s after submission).",
-                    shard, operation, queue_time)
+        logger.debug("Worker %s acquired.", shard)
+        self._start_time[shard] = make_datetime()
 
         with SessionGen() as session:
-            job = operation.build_job(session)
-            job_group = JobGroup([job])
-            job_group_dict = job_group.export_to_dict()
+            jobs = []
+            datasets = {}
+            submissions = {}
+            user_tests = {}
+            for operation in operations:
+                if operation.dataset_id not in datasets:
+                    datasets[operation.dataset_id] = Dataset.get_from_id(
+                        operation.dataset_id, session)
+                object_ = None
+                if operation.for_submission():
+                    if operation.object_id not in submissions:
+                        submissions[operation.object_id] = \
+                            Submission.get_from_id(
+                                operation.object_id, session)
+                    object_ = submissions[operation.object_id]
+                else:
+                    if operation.object_id not in user_tests:
+                        user_tests[operation.object_id] = \
+                            UserTest.get_from_id(operation.object_id, session)
+                    object_ = user_tests[operation.object_id]
+                logger.info("Asking worker %s to `%s'.", shard, operation)
+
+                jobs.append(operation.build_job(
+                    object_, datasets[operation.dataset_id]))
+            job_group_dict = JobGroup(jobs).export_to_dict()
 
         self._worker[shard].execute_job_group(
             job_group_dict=job_group_dict,
             callback=self._service.action_finished,
-            plus=(shard, side_data))
+            plus=shard)
         return shard
 
     def release_worker(self, shard):
@@ -196,32 +259,39 @@ class WorkerPool(object):
 
         shard (int): the worker to release.
 
-        returns (bool): if the result is to be ignored.
+        return (bool|[ESOperation]): if boolean, whether the result is
+            to be ignored; if a list, the list of operation for which
+            the results should be ignored.
 
         """
-        if self._operation[shard] == WorkerPool.WORKER_INACTIVE:
+        if self._operations[shard] == WorkerPool.WORKER_INACTIVE:
             err_msg = "Trying to release worker while it's inactive."
             logger.error(err_msg)
             raise ValueError(err_msg)
 
         # If the worker has already been disabled, ignore the result
         # and keep the worker disabled.
-        if self._operation[shard] == WorkerPool.WORKER_DISABLED:
+        if self._operations[shard] == WorkerPool.WORKER_DISABLED:
             return True
 
         ret = self._ignore[shard]
+        with self._operation_lock:
+            to_ignore = self._operations_to_ignore[shard]
+            self._operations_to_ignore[shard] = []
         self._start_time[shard] = None
-        self._side_data[shard] = None
         self._ignore[shard] = False
         if self._schedule_disabling[shard]:
-            self._operation[shard] = WorkerPool.WORKER_DISABLED
+            self._remove_operations(shard, WorkerPool.WORKER_DISABLED)
             self._schedule_disabling[shard] = False
             logger.info("Worker %s released and disabled.", shard)
         else:
-            self._operation[shard] = WorkerPool.WORKER_INACTIVE
+            self._remove_operations(shard, WorkerPool.WORKER_INACTIVE)
             self._workers_available_event.set()
             logger.debug("Worker %s released.", shard)
-        return ret
+        if ret is False and to_ignore != []:
+            return to_ignore
+        else:
+            return ret
 
     def find_worker(self, operation, require_connection=False,
                     random_worker=False):
@@ -244,7 +314,7 @@ class WorkerPool(object):
 
         """
         pool = []
-        for shard, worker_operation in self._operation.iteritems():
+        for shard, worker_operation in self._operations.iteritems():
             if worker_operation == operation:
                 if not require_connection or self._worker[shard].connected:
                     pool.append(shard)
@@ -256,7 +326,7 @@ class WorkerPool(object):
             return random.choice(pool)
 
     def ignore_operation(self, operation):
-        """Mark the operation to be ignored, and try to inform the worker.
+        """Mark the operation to be ignored.
 
         operation (ESOperation): the operation to ignore.
 
@@ -264,12 +334,13 @@ class WorkerPool(object):
 
         """
         try:
-            shard = self.find_worker(operation)
+            with self._operation_lock:
+                shard = self._operations_reverse[operation]
+                self._operations_to_ignore[shard].append(operation)
         except LookupError:
             logger.debug("Asked to ignore operation `%s' "
                          "that cannot be found.", operation)
             raise
-        self._ignore[shard] = True
 
     def get_status(self):
         """Returns a dict with info about the current status of all
@@ -284,18 +355,14 @@ class WorkerPool(object):
         for shard in self._worker.keys():
             s_time = self._start_time[shard]
             s_time = make_timestamp(s_time) if s_time is not None else None
-            s_data = self._side_data[shard]
-            s_data = (s_data[0], make_timestamp(s_data[1])) \
-                if s_data is not None else None
 
             result["%d" % shard] = {
                 'connected': self._worker[shard].connected,
-                'operation': (self._operation[shard]
-                              if not isinstance(self._operation[shard],
-                                                QueueItem)
-                              else self._operation[shard].to_dict()),
-                'start_time': s_time,
-                'side_data': s_data}
+                'operations': [operation.to_dict()
+                               for operation in self._operations[shard]]
+                if isinstance(self._operations[shard], list)
+                else self._operations[shard],
+                'start_time': s_time}
         return result
 
     def check_timeouts(self):
@@ -303,8 +370,8 @@ class WorkerPool(object):
         this is the case, the worker is scheduled for disabling, and
         we send him a message trying to shut it down.
 
-        return (list): list of tuples (priority, timestamp, operation)
-            of operations assigned to worker that timeout.
+        return ([ESOperation]): list of operations assigned to worker
+            that timeout.
 
         """
         now = make_datetime()
@@ -319,18 +386,19 @@ class WorkerPool(object):
                     logger.error("Disabling and shutting down "
                                  "worker %d because of no response "
                                  "in %s.", shard, active_for)
-                    is_busy = (self._operation[shard] !=
+                    is_busy = (self._operations[shard] !=
                                WorkerPool.WORKER_INACTIVE and
-                               self._operation[shard] !=
+                               self._operations[shard] !=
                                WorkerPool.WORKER_DISABLED)
                     assert is_busy
 
                     # We return the operation so ES can do what it needs.
-                    if not self._ignore[shard]:
-                        operation = self._operation[shard]
-                        priority, timestamp = self._side_data[shard]
-                        lost_operations.append(
-                            (priority, timestamp, operation))
+                    if not self._ignore[shard] and \
+                            isinstance(self._operations[shard], list):
+                        for operation in self._operations[shard]:
+                            if operation not in \
+                                    self._operations_to_ignore[shard]:
+                                lost_operations.append(operation)
 
                     # Also, we are not trusting it, so we are not
                     # assigning him new operations even if it comes back to
@@ -348,33 +416,36 @@ class WorkerPool(object):
 
         shard (int): which worker to disable.
 
-        return ([(int, datetime, ESOperation)]): list of tuples
-            (priority, timestamp, operation) of operations assigned to
-            the worker; it is going to be either empty or a singleton.
+        return ([ESOperation]): list of non-ignored operations
+            assigned to the worker.
 
         raise (ValueError): if worker is already disabled.
 
         """
-        if self._operation[shard] == WorkerPool.WORKER_DISABLED:
+        if self._operations[shard] == WorkerPool.WORKER_DISABLED:
             err_msg = \
                 "Trying to disable already disabled worker %s." % shard
             logger.warning(err_msg)
             raise ValueError(err_msg)
 
         lost_operations = []
-        if self._operation[shard] == WorkerPool.WORKER_INACTIVE:
-            self._operation[shard] = WorkerPool.WORKER_DISABLED
+        if self._operations[shard] == WorkerPool.WORKER_INACTIVE:
+            self._operations[shard] = WorkerPool.WORKER_DISABLED
 
         else:
-            # We return the operation so ES can do what it needs.
+            # We return all non-ignored operations so ES can do what
+            # it needs.
             if not self._ignore[shard]:
-                operation = self._operation[shard]
-                priority, timestamp = self._side_data[shard]
-                lost_operations.append((priority, timestamp, operation))
+                to_ignore = self._operations_to_ignore[shard]
+                if isinstance(self._operations[shard], list):
+                    for operation in self._operations[shard]:
+                        if operation not in to_ignore:
+                            lost_operations.append(operation)
 
             # And we mark the worker as disabled (until another action
             # is taken).
             self._schedule_disabling[shard] = True
+            self._operations_to_ignore[shard] = []
             self._ignore[shard] = True
             self.release_worker(shard)
 
@@ -389,13 +460,14 @@ class WorkerPool(object):
         raise (ValueError): if worker is not disabled.
 
         """
-        if self._operation[shard] != WorkerPool.WORKER_DISABLED:
+        if self._operations[shard] != WorkerPool.WORKER_DISABLED:
             err_msg = \
                 "Trying to enable worker %s which is not disabled." % shard
             logger.error(err_msg)
             raise ValueError(err_msg)
 
-        self._operation[shard] = WorkerPool.WORKER_INACTIVE
+        self._operations[shard] = WorkerPool.WORKER_INACTIVE
+        self._operations_to_ignore[shard] = []
         self._workers_available_event.set()
         logger.info("Worker %s enabled.", shard)
 
@@ -403,19 +475,18 @@ class WorkerPool(object):
         """Check if a worker we assigned an operation to disconnects. In this
         case, requeue the operation.
 
-        return (list): list of tuples (priority, timestamp, operation)
-            of operations assigned to worker that disconnected.
+        return ([ESOperation]): list of operations assigned to worker
+            that disconnected.
 
         """
         lost_operations = []
         for shard in self._worker:
             if not self._worker[shard].connected and \
-                    self._operation[shard] not in [WorkerPool.WORKER_DISABLED,
-                                                   WorkerPool.WORKER_INACTIVE]:
+                    self._operations[shard] not in [
+                        WorkerPool.WORKER_DISABLED,
+                        WorkerPool.WORKER_INACTIVE]:
                 if not self._ignore[shard]:
-                    operation = self._operation[shard]
-                    priority, timestamp = self._side_data[shard]
-                    lost_operations.append((priority, timestamp, operation))
+                    lost_operations += self._operations[shard]
                 self.release_worker(shard)
 
         return lost_operations

--- a/cms/service/workerpool.py
+++ b/cms/service/workerpool.py
@@ -40,7 +40,7 @@ import gevent.coros
 from gevent.event import Event
 
 from cms.db import Dataset, SessionGen, Submission, UserTest
-from cms.grading.Job import JobGroup
+from cms.grading.Job import Job, JobGroup
 from cmscommon.datetime import make_datetime, make_timestamp
 
 
@@ -239,8 +239,8 @@ class WorkerPool(object):
                     object_ = user_tests[operation.object_id]
                 logger.info("Asking worker %s to `%s'.", shard, operation)
 
-                jobs.append(operation.build_job(
-                    object_, datasets[operation.dataset_id]))
+                jobs.append(Job.from_operation(
+                    operation, object_, datasets[operation.dataset_id]))
             job_group_dict = JobGroup(jobs).export_to_dict()
 
         self._worker[shard].execute_job_group(

--- a/cmstaskenv/Test.py
+++ b/cmstaskenv/Test.py
@@ -36,6 +36,7 @@ from cms.db.filecacher import FileCacher
 from cms.grading import format_status_text
 from cms.grading.Job import EvaluationJob
 from cms.grading.tasktypes import get_task_type
+from cms.service.esoperations import ESOperation
 from cmscommon.terminal import move_cursor, add_color_to_string, \
     colors, directions
 
@@ -119,6 +120,11 @@ def test_testcases(base_dir, solution, language, assume=None):
         "Solution %s for task %s" % (solution, task.name))
     executables = {task.name: Executable(filename=task.name, digest=digest)}
     jobs = [(t, EvaluationJob(
+        operation=ESOperation(
+            ESOperation.EVALUATION,
+            None,
+            dataset.id,
+            dataset.testcases[t].codename).to_dict(),
         language=language,
         task_type=dataset.task_type,
         task_type_parameters=json.loads(dataset.task_type_parameters),

--- a/cmstestsuite/unit_tests/service/WorkerTest.py
+++ b/cmstestsuite/unit_tests/service/WorkerTest.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Contest Management System - http://cms-dev.github.io/
-# Copyright © 2013 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2013-2016 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2015 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -30,10 +30,14 @@ import gevent
 import unittest
 from mock import Mock, call
 
+from cmstestsuite.unit_tests.testidgenerator import \
+    unique_long_id, unique_unicode_id
+
 import cms.service.Worker
 from cms.grading import JobException
-from cms.grading.Job import Job, EvaluationJob
+from cms.grading.Job import JobGroup, EvaluationJob
 from cms.service.Worker import Worker
+from cms.service.esoperations import ESOperation
 
 
 class TestWorker(unittest.TestCase):
@@ -47,75 +51,88 @@ class TestWorker(unittest.TestCase):
         """Executes three successful jobs.
 
         """
-        jobs, calls = TestWorker.new_jobs(3)
-        task_type = FakeTaskType([True, True, True])
+        n_jobs = 3
+        jobs, calls = TestWorker.new_jobs(n_jobs)
+        task_type = FakeTaskType([True] * n_jobs)
         cms.service.Worker.get_task_type = Mock(return_value=task_type)
 
         for job in jobs:
-            Job.import_from_dict_with_type(
-                self.service.execute_job(job.export_to_dict()))
+            job_group = JobGroup([job])
+            ret_job_group = JobGroup.import_from_dict(
+                self.service.execute_job_group(job_group.export_to_dict()))
+            self.assertTrue(ret_job_group.jobs[0].success)
 
         cms.service.Worker.get_task_type.assert_has_calls(calls)
-        self.assertEquals(task_type.call_count, 3)
+        self.assertEquals(task_type.call_count, n_jobs)
 
     def test_execute_job_failure(self):
         """Executes two unsuccessful jobs.
 
         """
-        jobs, unused_calls = TestWorker.new_jobs(2)
-        task_type = FakeTaskType([False, False])
+        n_jobs = 2
+        jobs, unused_calls = TestWorker.new_jobs(n_jobs)
+        task_type = FakeTaskType([False] * n_jobs)
         cms.service.Worker.get_task_type = Mock(return_value=task_type)
 
         results = []
         for job in jobs:
-            results.append(Job.import_from_dict_with_type(
-                self.service.execute_job(job.export_to_dict())))
+            job_group = JobGroup([job])
+            results.append(JobGroup.import_from_dict(
+                self.service.execute_job_group(job_group.export_to_dict())))
 
-        self.assertFalse(any(job.success for job in results))
-        self.assertEquals(cms.service.Worker.get_task_type.call_count, 2)
-        self.assertEquals(task_type.call_count, 2)
+        for job_group in results:
+            for job in job_group.jobs:
+                self.assertFalse(job.success)
+        self.assertEquals(cms.service.Worker.get_task_type.call_count, n_jobs)
+        self.assertEquals(task_type.call_count, n_jobs)
 
     def test_execute_job_tasktype_raise(self):
         """Executes two jobs raising exceptions.
 
         """
-        jobs, unused_calls = TestWorker.new_jobs(2)
+        n_jobs = 2
+        jobs, unused_calls = TestWorker.new_jobs(n_jobs)
         task_type = FakeTaskType([Exception(), Exception()])
         cms.service.Worker.get_task_type = Mock(return_value=task_type)
 
         for job in jobs:
             with self.assertRaises(JobException):
-                Job.import_from_dict_with_type(
-                    self.service.execute_job(job.export_to_dict()))
+                job_group = JobGroup([job])
+                JobGroup.import_from_dict(
+                    self.service.execute_job_group(job_group.export_to_dict()))
 
-        self.assertEquals(cms.service.Worker.get_task_type.call_count, 2)
-        self.assertEquals(task_type.call_count, 2)
+        self.assertEquals(cms.service.Worker.get_task_type.call_count, n_jobs)
+        self.assertEquals(task_type.call_count, n_jobs)
 
     def test_execute_job_subsequent_success(self):
-        """Executes three successful jobs, then other three.
+        """Executes three successful jobs, then four others.
 
         """
-        jobs_a, calls_a = TestWorker.new_jobs(3, prefix="a")
-        task_type_a = FakeTaskType([True, True, True])
+        n_jobs_a = 3
+        jobs_a, calls_a = TestWorker.new_jobs(n_jobs_a, prefix="a")
+        task_type_a = FakeTaskType([True] * n_jobs_a)
         cms.service.Worker.get_task_type = Mock(return_value=task_type_a)
 
         for job in jobs_a:
-            Job.import_from_dict_with_type(
-                self.service.execute_job(job.export_to_dict()))
+            job_group = JobGroup([job])
+            JobGroup.import_from_dict(
+                self.service.execute_job_group(job_group.export_to_dict()))
 
         cms.service.Worker.get_task_type.assert_has_calls(calls_a)
-        self.assertEquals(task_type_a.call_count, 3)
+        self.assertEquals(task_type_a.call_count, n_jobs_a)
 
-        jobs_b, calls_b = TestWorker.new_jobs(3, prefix="b")
-        task_type_b = FakeTaskType([True, True, True])
+        n_jobs_b = 4
+        jobs_b, calls_b = TestWorker.new_jobs(n_jobs_b, prefix="b")
+        task_type_b = FakeTaskType([True] * n_jobs_b)
         cms.service.Worker.get_task_type = Mock(return_value=task_type_b)
 
         for job in jobs_b:
-            Job.import_from_dict_with_type(
-                self.service.execute_job(job.export_to_dict()))
+            job_group = JobGroup([job])
+            JobGroup.import_from_dict(
+                self.service.execute_job_group(job_group.export_to_dict()))
 
         cms.service.Worker.get_task_type.assert_has_calls(calls_b)
-        self.assertEquals(task_type_b.call_count, 3)
+        self.assertEquals(task_type_b.call_count, n_jobs_b)
 
     def test_execute_job_subsequent_locked(self):
         """Executes a long job, then another one that should fail
@@ -130,15 +147,17 @@ class TestWorker(unittest.TestCase):
         jobs_b, calls_b = TestWorker.new_jobs(1, prefix="b")
 
         def first_call():
-            Job.import_from_dict_with_type(
-                self.service.execute_job(jobs_a[0].export_to_dict()))
+            job_group = JobGroup([jobs_a[0]])
+            JobGroup.import_from_dict(
+                self.service.execute_job_group(job_group.export_to_dict()))
 
         first_greenlet = gevent.spawn(first_call)
         gevent.sleep(0)  # To ensure we call jobgroup_a first.
 
         with self.assertRaises(JobException):
-            Job.import_from_dict_with_type(
-                self.service.execute_job(jobs_b[0].export_to_dict()))
+            job_group = JobGroup([jobs_b[0]])
+            JobGroup.import_from_dict(
+                self.service.execute_job_group(job_group.export_to_dict()))
 
         first_greenlet.get()
         self.assertNotIn(calls_b[0],
@@ -149,26 +168,91 @@ class TestWorker(unittest.TestCase):
         """After a failure, the worker should be able to accept another job.
 
         """
-        jobs_a, calls_a = TestWorker.new_jobs(1)
+        n_jobs_a = 1
+        jobs_a, calls_a = TestWorker.new_jobs(n_jobs_a)
         task_type_a = FakeTaskType([Exception()])
         cms.service.Worker.get_task_type = Mock(return_value=task_type_a)
 
         with self.assertRaises(JobException):
-            Job.import_from_dict_with_type(
-                self.service.execute_job(jobs_a[0].export_to_dict()))
+            job_group = JobGroup([jobs_a[0]])
+            JobGroup.import_from_dict(
+                self.service.execute_job_group(job_group.export_to_dict()))
         cms.service.Worker.get_task_type.assert_has_calls(calls_a)
-        self.assertEquals(task_type_a.call_count, 1)
+        self.assertEquals(task_type_a.call_count, n_jobs_a)
 
-        jobs_b, calls_b = TestWorker.new_jobs(3)
-        task_type_b = FakeTaskType([True, True, True])
+        n_jobs_b = 3
+        jobs_b, calls_b = TestWorker.new_jobs(n_jobs_b)
+        task_type_b = FakeTaskType([True] * n_jobs_b)
         cms.service.Worker.get_task_type = Mock(return_value=task_type_b)
 
         for job in jobs_b:
-            Job.import_from_dict_with_type(
-                self.service.execute_job(job.export_to_dict()))
+            job_group = JobGroup([job])
+            JobGroup.import_from_dict(
+                self.service.execute_job_group(job_group.export_to_dict()))
 
         cms.service.Worker.get_task_type.assert_has_calls(calls_b)
-        self.assertEquals(task_type_b.call_count, 3)
+        self.assertEquals(task_type_b.call_count, n_jobs_b)
+
+    def test_execute_job_group_success(self):
+        """Executes two successful job groups.
+
+        """
+        n_jobs = [3, 3]
+        job_groups, calls = TestWorker.new_job_groups(n_jobs)
+        task_type = FakeTaskType([True] * sum(n_jobs))
+        cms.service.Worker.get_task_type = Mock(return_value=task_type)
+
+        for job_group in job_groups:
+            JobGroup.import_from_dict(
+                self.service.execute_job_group(job_group.export_to_dict()))
+
+        cms.service.Worker.get_task_type.assert_has_calls(calls)
+        self.assertEquals(task_type.call_count, sum(n_jobs))
+
+    def test_execute_job_group_mixed_success(self):
+        """Executes three job groups with mixed grades of success.
+
+        """
+        n_jobs = [4, 4, 4]
+        expected_success = (
+            [True] * n_jobs[0] +
+            [False] + [True] * (n_jobs[1] - 1) +
+            [False] * n_jobs[2])
+        self.assertEquals(sum(n_jobs), len(expected_success))
+
+        job_groups, calls = TestWorker.new_job_groups(n_jobs)
+        task_type = FakeTaskType(expected_success)
+        cms.service.Worker.get_task_type = Mock(return_value=task_type)
+
+        results = []
+        for job_group in job_groups:
+            results.append(JobGroup.import_from_dict(
+                self.service.execute_job_group(job_group.export_to_dict())))
+
+        expected_idx = 0
+        for result in results:
+            for job in result.jobs:
+                self.assertIs(expected_success[expected_idx], job.success)
+                expected_idx += 1
+
+        cms.service.Worker.get_task_type.assert_has_calls(calls)
+        self.assertEquals(task_type.call_count, sum(n_jobs))
+
+    def test_execute_job_group_mixed_exceptions(self):
+        """Executes a job group with some exceptions.
+
+        """
+        n_jobs = 4
+        expected_success = [True, Exception(), False, True]
+        self.assertEquals(n_jobs, len(expected_success))
+
+        job_groups, unused_calls = TestWorker.new_job_groups([n_jobs])
+        task_type = FakeTaskType(expected_success)
+        cms.service.Worker.get_task_type = Mock(return_value=task_type)
+
+        with self.assertRaises(JobException):
+            JobGroup.import_from_dict(
+                self.service.execute_job_group(job_groups[0].export_to_dict()))
 
     @staticmethod
     def new_jobs(number_of_jobs, prefix=None):
@@ -176,12 +260,32 @@ class TestWorker(unittest.TestCase):
         jobs = []
         calls = []
         for i in xrange(number_of_jobs):
-            job_params = ("fake_task_type",
-                          "fake_parameters_%s%d" % (prefix, i))
+            job_params = [
+                ESOperation(ESOperation.EVALUATION,
+                            unique_long_id(), unique_long_id(),
+                            unique_unicode_id()).to_dict(),
+                "fake_task_type",
+                "fake_parameters_%s%d" % (prefix, i)
+            ]
             job = EvaluationJob(*job_params, info="%s%d" % (prefix, i))
             jobs.append(job)
-            calls.append(call(*job_params))
+            # Arguments to get_task_type are the same as for the job,
+            # but omitting the operation.
+            calls.append(call(*job_params[1:]))
         return jobs, calls
+
+    @staticmethod
+    def new_job_groups(spec, prefix=None):
+        """Return len(spec) job groups each with spec[i] jobs."""
+        prefix = prefix if prefix is not None else ""
+        job_groups = []
+        calls = []
+        for i, number_of_jobs in enumerate(spec):
+            jobs, this_calls = TestWorker.new_jobs(
+                number_of_jobs, str(i) + prefix)
+            job_groups.append(JobGroup(jobs))
+            calls += this_calls
+        return job_groups, calls
 
 
 class FakeTaskType(object):

--- a/cmstestsuite/unit_tests/service/flushingdicttest.py
+++ b/cmstestsuite/unit_tests/service/flushingdicttest.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2016 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the flushing dict module."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import gevent
+import unittest
+
+from cms.service.flushingdict import FlushingDict
+
+
+class TestFlushingDict(unittest.TestCase):
+
+    SIZE = 3
+    FLUSH_LATENCY_SECONDS = 0.2
+
+    def setUp(self):
+        super(TestFlushingDict, self).setUp()
+        self.received_data = []
+        self.d = FlushingDict(
+            TestFlushingDict.SIZE, TestFlushingDict.FLUSH_LATENCY_SECONDS,
+            self.callback)
+
+    def test_success_latency(self):
+        self.d.add(0, 0)
+        gevent.sleep(2 * TestFlushingDict.FLUSH_LATENCY_SECONDS)
+        self.assertEqual(1, len(self.received_data))
+        self.assertItemsEqual([(0, 0)], self.received_data[0])
+
+    def test_success_size(self):
+        expected_data = []
+        for i in range(TestFlushingDict.SIZE):
+            self.d.add(i, i)
+            expected_data.append((i, i))
+        gevent.sleep(0)
+        self.assertEqual(1, len(self.received_data))
+        self.assertItemsEqual(expected_data, self.received_data[0])
+
+    def test_success_size_latency(self):
+        expected_data = []
+        for i in range(TestFlushingDict.SIZE):
+            self.d.add(i, i)
+            expected_data.append((i, i))
+        gevent.sleep(0)
+        self.assertEqual(1, len(self.received_data))
+        self.assertItemsEqual(expected_data, self.received_data[0])
+        self.d.add(TestFlushingDict.SIZE, TestFlushingDict.SIZE)
+        gevent.sleep(TestFlushingDict.FLUSH_LATENCY_SECONDS)
+        self.assertEqual(2, len(self.received_data))
+        self.assertItemsEqual(
+            [(TestFlushingDict.SIZE, TestFlushingDict.SIZE)],
+            self.received_data[1])
+
+    def test_long_callback(self):
+        self.d = FlushingDict(
+            TestFlushingDict.SIZE, TestFlushingDict.FLUSH_LATENCY_SECONDS,
+            self.long_callback)
+        expected_data = []
+        for i in range(TestFlushingDict.SIZE):
+            self.d.add(i, i)
+            expected_data.append((i, i))
+
+        # We add another element while the callback is idling, to see
+        # if the new element is flushed later. We need to wait 2
+        # latencies for the callback, one more for the time-based
+        # second flush, and we add some tolerance.
+        gevent.sleep(0)
+        self.d.add(TestFlushingDict.SIZE, TestFlushingDict.SIZE)
+        gevent.sleep(TestFlushingDict.FLUSH_LATENCY_SECONDS * 3 + 0.1)
+
+        self.assertEqual(TestFlushingDict.SIZE + 1,
+                         sum(len(data) for data in self.received_data))
+
+    def test_many_elements(self):
+        expected_data = []
+        for i in range(20):
+            self.d.add(i, i)
+            expected_data.append((i, i))
+        gevent.sleep(TestFlushingDict.FLUSH_LATENCY_SECONDS)
+        self.assertItemsEqual(expected_data, sum(self.received_data, []))
+
+    def callback(self, data):
+        self.received_data.append(data)
+
+    def long_callback(self, data):
+        gevent.sleep(TestFlushingDict.FLUSH_LATENCY_SECONDS * 2)
+        self.callback(data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmstestsuite/unit_tests/testidgenerator.py
+++ b/cmstestsuite/unit_tests/testidgenerator.py
@@ -29,7 +29,7 @@ import random
 def unique_long_id():
     """Return a unique id of type long."""
     if not hasattr(unique_long_id, "id"):
-        unique_long_id.id = random.random()
+        unique_long_id.id = random.randint(0, 1000000000)
     unique_long_id.id += 1
     return unique_long_id.id
 


### PR DESCRIPTION
So in short there are two main changes, plus the machinery to allow them:

1. results from workers are cached for a while before being saved all at once;
1. if the queue is long, many operations are sent to the same worker in one batch.

Some numbers (my benchmark is RunTimeTest with 100 submissions and 6 workers, for a total of 100 compilations and 5k evaluations, faking the work at 0.1s/operation).
- Before this change, it takes 190-205s.
- With just 1, we go down to 140-160s.
- With both, we arrive to 105-120s

[I removed from these numbers about 25s of setup, which is not influenced by the changes.]

In general, ES also uses much less CPU. I suspect that for very big contests with large number of workers, it would still make sense to implement ES sharding. But with this code we another reasonable alternative, which is to increase the limits (worker results obtained before writing them, and maximum number of operations to send to the workers). This basically trades off a O(1) latency waste (because of the additional delays from grouping many ops) with a O(n) throughput gain (because ES is able to manage workers more effectively). In these situation a stress test would be advisable anyway...

A word of caution: I noted in the last version of workerpool that race conditions are possible when specific operations are performed (invalidations, disable workers, ...). I think this was also the case before. I tested in a few situation and it did the right thing, but I'd like to fix it asap.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/525)
<!-- Reviewable:end -->
