### PR TITLE
Add an option to disable testing interface

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -91,6 +91,7 @@ class Config(object):
         self.max_input_length = 5000000
         self.stl_path = "/usr/share/doc/stl-manual/html/"
         self.allow_questions = True
+        self.allow_testing = True
         # Prefix of 'iso-codes'[1] installation. It can be found out
         # using `pkg-config --variable=prefix iso-codes`, but it's
         # almost universally the same (i.e. '/usr') so it's hardly

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -270,6 +270,7 @@ class BaseHandler(CommonRequestHandler):
         ret["phase"] = self.contest.phase(self.timestamp)
 
         ret["printing_enabled"] = (config.printer is not None)
+        ret["testing_enabled"] = config.allow_testing
 
         if self.current_user is not None:
             participation = self.current_user

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -67,6 +67,10 @@ class UserTestInterfaceHandler(BaseHandler):
     def get(self):
         participation = self.current_user
 
+        if not self.r_params["testing_enabled"]:
+            self.redirect("/")
+            return
+
         user_tests = dict()
         user_tests_left = dict()
         default_task = None
@@ -123,6 +127,10 @@ class UserTestHandler(BaseHandler):
     @actual_phase_required(0)
     def post(self, task_name):
         participation = self.current_user
+
+        if not self.r_params["testing_enabled"]:
+            self.redirect("/")
+            return
 
         try:
             task = self.contest.get_task(task_name)
@@ -442,6 +450,9 @@ class UserTestStatusHandler(BaseHandler):
     def get(self, task_name, user_test_num):
         participation = self.current_user
 
+        if not self.r_params["testing_enabled"]:
+            raise tornado.web.HTTPError(404)
+
         try:
             task = self.contest.get_task(task_name)
         except KeyError:
@@ -497,6 +508,9 @@ class UserTestDetailsHandler(BaseHandler):
     def get(self, task_name, user_test_num):
         participation = self.current_user
 
+        if not self.r_params["testing_enabled"]:
+            raise tornado.web.HTTPError(404)
+
         try:
             task = self.contest.get_task(task_name)
         except KeyError:
@@ -524,6 +538,9 @@ class UserTestIOHandler(FileHandler):
     @actual_phase_required(0)
     def get(self, task_name, user_test_num, io):
         participation = self.current_user
+
+        if not self.r_params["testing_enabled"]:
+            raise tornado.web.HTTPError(404)
 
         try:
             task = self.contest.get_task(task_name)
@@ -562,6 +579,9 @@ class UserTestFileHandler(FileHandler):
     @actual_phase_required(0)
     def get(self, task_name, user_test_num, filename):
         participation = self.current_user
+
+        if not self.r_params["testing_enabled"]:
+            raise tornado.web.HTTPError(404)
 
         try:
             task = self.contest.get_task(task_name)

--- a/cms/server/contest/templates/base.html
+++ b/cms/server/contest/templates/base.html
@@ -179,9 +179,11 @@ $(document).ready(function () {
                                 <a href="{{ url_root }}/documentation">{{ _("Documentation") }}</a>
                             </li>
     {% if actual_phase == 0 %}{% comment FIXME maybe >= 0? %}
+        {% if testing_enabled %}
                             <li{% if request.path == '/testing' %} class="active"{% end %}>
                                 <a href="{{ url_root }}/testing">{{ _("Testing") }}</a>
                             </li>
+        {% end %}
         {% if printing_enabled %}
                             <li{% if request.path == '/printing' %} class="active"{% end %}>
                                 <a href="{{ url_root }}/printing">{{ _("Printing") }}</a>

--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -121,6 +121,9 @@
     "_help": "Whether questions and messages are enabled.",
     "allow_questions": true,
 
+    "_help": "Whether testing interface is enabled.",
+    "allow_testing": true,
+
 
 
     "_section": "AdminWebServer",


### PR DESCRIPTION
This is useful if admins want to prohibit server side testing (like IOI-style).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/533)
<!-- Reviewable:end -->
