### PR TITLE
Reduce memory usage in AWS

### DIFF
--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -40,7 +40,7 @@ from functools import wraps
 import tornado.web
 
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import subqueryload
 
 from cms import __version__
 from cms.db import Admin, Contest, Participation, Question, \
@@ -513,12 +513,12 @@ class BaseHandler(CommonRequestHandler):
 
         """
         query = query\
-            .options(joinedload(Submission.task))\
-            .options(joinedload(Submission.participation))\
-            .options(joinedload(Submission.files))\
-            .options(joinedload(Submission.token))\
-            .options(joinedload(Submission.results)
-                     .joinedload(SubmissionResult.evaluations))\
+            .options(subqueryload(Submission.task))\
+            .options(subqueryload(Submission.participation))\
+            .options(subqueryload(Submission.files))\
+            .options(subqueryload(Submission.token))\
+            .options(subqueryload(Submission.results)
+                     .subqueryload(SubmissionResult.evaluations))\
             .order_by(Submission.timestamp.desc())
 
         offset = page * page_size


### PR DESCRIPTION
If a task has many test cases, using `joinedload` with `SubmissionResult.evaluations` consumes a lot of unnecessary memory because `joinedload` creates a lot of duplicated columns.
This patch replaces some `joinedload`s with `subqueryload`s and reduces the memory usage of AWS significantly.

Although memory usage varies based on a contest configuration (the amount of problems / test cases / submissions etc...), in my environment this patch reduces the memory usage of AWS from 1.3GB to 130MB when opening submissions page of a contest.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/546)
<!-- Reviewable:end -->
