### PR TITLE
Add proxy_redirect for AWS

### DIFF
--- a/config/nginx.conf.sample
+++ b/config/nginx.conf.sample
@@ -114,6 +114,8 @@ http {
         location ^~ /aws/ {
             proxy_pass http://aws/;
             include proxy_params;
+            proxy_redirect http://$host/ /aws/;
+            proxy_redirect https://$host/ /aws/;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
 


### PR DESCRIPTION
For cms v1.3 AWS also needs proxy_redirect because AWS has login redirect as RWS.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/552)
<!-- Reviewable:end -->
