### PR TITLE
Add default message when checker gives empty message

### DIFF
--- a/cms/grading/__init__.py
+++ b/cms/grading/__init__.py
@@ -8,6 +8,7 @@
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
 # Copyright © 2013-2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
+# Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -721,6 +722,19 @@ def extract_outcome_and_text(sandbox):
     except ValueError:
         logger.error("Wrong outcome `%s' from manager.", outcome)
         raise ValueError("Outcome is not a float.")
+
+    # Write default message when text is empty
+    # TODO: Add description about this mechanism to docs.
+    if not text.strip():
+        if outcome == 1.0:
+            text = EVALUATION_MESSAGES.get("success").message
+        elif outcome == 0.0:
+            text = EVALUATION_MESSAGES.get("wrong").message
+        else:
+            # TODO: Decide default message for partially correct
+            # Proper message couldn't be found in po file.
+            # It seems it need to be added after.
+            text = 'No message'
 
     return outcome, [text]
 


### PR DESCRIPTION
When checker gives empty stderr, translator prints po file information in non-English language.

<img width="962" alt="2016-02-28 9 26 04" src="https://cloud.githubusercontent.com/assets/9026019/13379169/f6904fac-de61-11e5-9707-e8178ec0bb28.png">

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/564)
<!-- Reviewable:end -->
