### PR TITLE
Set maximum question subject length in html

### DIFF
--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -38,7 +38,7 @@
             <div class="control-group">
                 <label class="control-label" for="input_subject">{{ _("Subject") }}</label>
                 <div class="controls">
-                    <input type="text" class="input-xlarge" name="question_subject" id="input_subject" maxlength="250"/>
+                    <input type="text" class="input-xlarge" name="question_subject" id="input_subject" maxlength="50"/>
                 </div>
             </div>
             <div class="control-group">


### PR DESCRIPTION
Maximum subject length is 50, not 250.
[communicaton.py](https://github.com/cms-dev/cms/blob/master/cms/server/contest/handlers/communication.py) line 72.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/568)
<!-- Reviewable:end -->
