### PR TITLE
Fix bug from 200ec7e

### DIFF
--- a/prerequisites.py
+++ b/prerequisites.py
@@ -8,6 +8,7 @@
 # Copyright © 2013 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -277,7 +278,11 @@ Options:
 
     def install_conf(self):
         """Install configuration files"""
+        assert_root()
+
         print("===== Copying configuration to /usr/local/etc/")
+        root = pwd.getpwnam("root")
+        cmsuser = pwd.getpwnam("cmsuser")
         makedir(os.path.join(USR_ROOT, "etc"), root, 0755)
         for conf_file_name in ["cms.conf", "cms.ranking.conf"]:
             conf_file = os.path.join(USR_ROOT, "etc", conf_file_name)


### PR DESCRIPTION
When run command "sudo ./prerequisites.py install", following error occurs.
```
===== Creating user and group cmsuser
useradd: user 'cmsuser' already exists
===== Compiling localization files
  ja
  nl
  ko
  bs
  lt
  it
  bg
  vi
  zh_CN
  fr
  zh_TW
  et
  ru
===== Compiling isolate
make: `isolate' is up to date.
===== Copying isolate to /usr/local/bin/
===== Copying configuration to /usr/local/etc/
Traceback (most recent call last):
  File "./prerequisites.py", line 439, in <module>
    CLI()
  File "./prerequisites.py", line 212, in __init__
    getattr(self, args.command)()
  File "./prerequisites.py", line 335, in install
    self.install_conf()
  File "./prerequisites.py", line 281, in install_conf
    makedir(os.path.join(USR_ROOT, "etc"), root, 0755)
NameError: global name 'root' is not defined
```

It's bug from 200ec7e, this commit fix it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/570)
<!-- Reviewable:end -->
