### PR TITLE
Fix bug from fd73d34 & add current user's extra_time to end_time

### DIFF
--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -22,17 +22,17 @@
         {{ _("The contest hasn't started yet.") }}
         </p>
         <p>
-        {{ _("The contest will start at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start, timezone, locale=locale), "stop_time": format_datetime_smart(contest.stop, timezone, locale=locale)} }}
+        {{ _("The contest will start at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start + current_user.delay_time, timezone, locale=locale), "stop_time": format_datetime_smart(contest.stop + current_user.delay_time + current_user.extra_time, timezone, locale=locale)} }}
 {% elif phase == 0 %}
         {{ _("The contest is currently running.") }}
         </p>
         <p>
-        {{ _("The contest started at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start + current_user.delay_time, timezone, locale=locale), "stop_time": format_datetime_smart(contest.stop + current_user.delay_time, timezone, locale=locale)} }}
+        {{ _("The contest started at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start + current_user.delay_time, timezone, locale=locale), "stop_time": format_datetime_smart(contest.stop + current_user.delay_time + current_user.extra_time, timezone, locale=locale)} }}
 {% elif phase == +1 %}
         {{ _("The contest has already ended.") }}
         </p>
         <p>
-        {{ _("The contest started at %(start_time)s and ended at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start, timezone, locale=locale), "stop_time": format_datetime_smart(contest.stop, timezone, locale=locale)} }}
+        {{ _("The contest started at %(start_time)s and ended at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start + current_user.delay_time, timezone, locale=locale), "stop_time": format_datetime_smart(contest.stop + current_user.delay_time + current_user.extra_time, timezone, locale=locale)} }}
 {% end %}
         </p>
 


### PR DESCRIPTION
I think it's much better adding extra_time to contest end time. (To make sure contestants know their actual end time)

And, even if contest hasn't started yet or contest has already ended, start_time & end_time should be shown as if contest is running.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/571)
<!-- Reviewable:end -->
