### PR TITLE
Update ajax redirect link to relative

### DIFF
--- a/cms/server/admin/handlers/admin.py
+++ b/cms/server/admin/handlers/admin.py
@@ -3,6 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -164,4 +165,4 @@ class AdminHandler(BaseHandler):
         self.try_commit()
 
         # Page to redirect to.
-        self.write("/admins")
+        self.write("../admins")

--- a/cms/server/admin/handlers/contestannouncement.py
+++ b/cms/server/admin/handlers/contestannouncement.py
@@ -8,6 +8,7 @@
 # Copyright © 2012-2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
+# Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -78,4 +79,4 @@ class AnnouncementHandler(BaseHandler):
         self.try_commit()
 
         # Page to redirect to.
-        self.write("/contest/%s/announcements" % contest_id)
+        self.write("announcements")

--- a/cms/server/admin/handlers/task.py
+++ b/cms/server/admin/handlers/task.py
@@ -8,6 +8,7 @@
 # Copyright © 2012-2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
+# Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -271,7 +272,7 @@ class StatementHandler(BaseHandler):
         self.try_commit()
 
         # Page to redirect to.
-        self.write("/task/%s" % task.id)
+        self.write("%s" % task.id)
 
 
 class AddAttachmentHandler(BaseHandler):
@@ -342,7 +343,7 @@ class AttachmentHandler(BaseHandler):
         self.try_commit()
 
         # Page to redirect to.
-        self.write("/task/%s" % task.id)
+        self.write("%s" % task.id)
 
 
 class AddDatasetHandler(BaseHandler):


### PR DESCRIPTION
When aws is mapping by nginx prefix with proxy (like [/config/nginx.conf.sample](https://github.com/cms-dev/cms/blob/master/config/nginx.conf.sample): line 114-115), ajax redirect link should be changed to relative.
It is redirected by javascript(window.location.replace).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/577)
<!-- Reviewable:end -->
