### PR TITLE
Add escape around first and last names in RWS.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -34,6 +34,10 @@ Copyright: 2008-2012 Dmitry Baranovskiy (http://raphaeljs.com)
 License: Expat
 Comment: See http://raphaeljs.com/license.html
 
+Files: cmsranking/static/lib/he.js
+Copyright: 2013-2015 Mathias Bynens <https://mathiasbynens.be/>
+License: Expat
+
 Files: cms/server/static/jq/jquery-1.7.1.min.js
 Copyright: 2011 John Resig, http://jquery.com/
 License: Expat or GPL-2

--- a/cmsranking/static/Ranking.html
+++ b/cmsranking/static/Ranking.html
@@ -17,6 +17,7 @@ if (!("EventSource" in window)) {
         <!--[if lt IE 9]>
             <script type="text/javascript" src="lib/explorercanvas.js"></script>
         <![endif]-->
+        <script type="text/javascript" src="lib/he.js"></script>
         <script type="text/javascript" src="Config.js"></script>
         <script type="text/javascript" src="DataStore.js"></script>
         <script type="text/javascript" src="HistoryStore.js"></script>

--- a/cmsranking/static/Scoreboard.js
+++ b/cmsranking/static/Scoreboard.js
@@ -15,24 +15,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-var escapeHTML = (function() {
-    var escapeMap = {
-        '&' : '&amp;',
-        '<' : '&lt;',
-        '>' : '&gt;',
-        '"' : '&quot;',
-        "'" : '&#x27;',
-        '/' : '&#x2F;',
-        '`' : '&#x60;',
-    };
-    var escapeHTML = function(str) {
-        return String(str).replace(/[&<>"'\/`]/g, function(ch) {
-            return escapeMap[ch];
-        });
-    };
-    return escapeHTML;
-})();
-
 var Scoreboard = new function () {
     var self = this;
 
@@ -235,8 +217,8 @@ var Scoreboard = new function () {
 <tr class=\"user" + (user["selected"] > 0 ? " selected color" + user["selected"] : "") + "\" data-user=\"" + user["key"] + "\"> \
     <td class=\"sel\"></td> \
     <td class=\"rank\">" + user["rank"] + "</td> \
-    <td colspan=\"10\" class=\"f_name\">" + escapeHTML(user["f_name"]) + "</td> \
-    <td colspan=\"10\" class=\"l_name\">" + escapeHTML(user["l_name"]) + "</td>";
+    <td colspan=\"10\" class=\"f_name\">" + he.escape(user["f_name"]) + "</td> \
+    <td colspan=\"10\" class=\"l_name\">" + he.escape(user["l_name"]) + "</td>";
 
         if (user['team']) {
             result += " \

--- a/cmsranking/static/Scoreboard.js
+++ b/cmsranking/static/Scoreboard.js
@@ -15,6 +15,24 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+var escapeHTML = (function() {
+    var escapeMap = {
+        '&' : '&amp;',
+        '<' : '&lt;',
+        '>' : '&gt;',
+        '"' : '&quot;',
+        "'" : '&#x27;',
+        '/' : '&#x2F;',
+        '`' : '&#x60;',
+    };
+    var escapeHTML = function(str) {
+        return String(str).replace(/[&<>"'\/`]/g, function(ch) {
+            return escapeMap[ch];
+        });
+    };
+    return escapeHTML;
+})();
+
 var Scoreboard = new function () {
     var self = this;
 
@@ -217,8 +235,8 @@ var Scoreboard = new function () {
 <tr class=\"user" + (user["selected"] > 0 ? " selected color" + user["selected"] : "") + "\" data-user=\"" + user["key"] + "\"> \
     <td class=\"sel\"></td> \
     <td class=\"rank\">" + user["rank"] + "</td> \
-    <td colspan=\"10\" class=\"f_name\">" + user["f_name"] + "</td> \
-    <td colspan=\"10\" class=\"l_name\">" + user["l_name"] + "</td>";
+    <td colspan=\"10\" class=\"f_name\">" + escapeHTML(user["f_name"]) + "</td> \
+    <td colspan=\"10\" class=\"l_name\">" + escapeHTML(user["l_name"]) + "</td>";
 
         if (user['team']) {
             result += " \


### PR DESCRIPTION
Since we (Japanese OI committee) use a registration form for online contest, we don't trust neither last names nor first names. This patch adds escapes around first and last names in RWS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/592)
<!-- Reviewable:end -->
