### PR TITLE
Make CWS multi-contest

### DIFF
--- a/cms/server/__init__.py
+++ b/cms/server/__init__.py
@@ -27,7 +27,7 @@ from .util import \
     encode_for_url, file_handler_gen, filter_ascii, \
     format_amount_of_time, format_dataset_attrs, format_date, \
     format_datetime, format_datetime_smart, format_size, format_time, \
-    format_token_rules, get_score_class, get_url_root
+    format_token_rules, get_score_class, get_url_root, multi_contest
 
 
 __all__ = [
@@ -37,5 +37,5 @@ __all__ = [
     "encode_for_url", "file_handler_gen", "filter_ascii",
     "format_amount_of_time", "format_dataset_attrs", "format_date",
     "format_datetime", "format_datetime_smart", "format_size", "format_time",
-    "format_token_rules", "get_score_class", "get_url_root",
+    "format_token_rules", "get_score_class", "get_url_root", "multi_contest",
 ]

--- a/cms/server/contest/handlers/__init__.py
+++ b/cms/server/contest/handlers/__init__.py
@@ -9,7 +9,7 @@
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
-# Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2015-2016 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -33,7 +33,6 @@ from cms import config
 from .base import \
     StaticFileGzHandler
 from .main import \
-    MainHandler, \
     LoginHandler, \
     LogoutHandler, \
     StartHandler, \
@@ -67,7 +66,6 @@ HANDLERS = [
 
     # Main
 
-    (r"/", MainHandler),
     (r"/login", LoginHandler),
     (r"/logout", LogoutHandler),
     (r"/start", StartHandler),

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -9,7 +9,7 @@
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
-# Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2015-2016 William Di Luigi <williamdiluigi@gmail.com>
 # Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
 # Copyright © 2016 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
 #
@@ -35,67 +35,21 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import logging
-import pickle
-import socket
-import struct
+import os
 import traceback
-
-from datetime import timedelta
-
 import tornado.web
 
-from sqlalchemy.orm import contains_eager
-from werkzeug.datastructures import LanguageAccept
-from werkzeug.http import parse_accept_header
-
-from cms import config
-from cms.db import Contest, Participation, User
-from cms.server import CommonRequestHandler, compute_actual_phase, \
-    file_handler_gen, get_url_root
-from cms.locale import filter_language_codes
-from cmscommon.datetime import get_timezone, make_datetime, make_timestamp
-from cmscommon.isocodes import translate_language_code, \
-    translate_language_country_code
+from cms.db import Contest
+from cms.server import CommonRequestHandler, get_url_root
 
 
 logger = logging.getLogger(__name__)
 
 
-NOTIFICATION_ERROR = "error"
-NOTIFICATION_WARNING = "warning"
-NOTIFICATION_SUCCESS = "success"
-
-
-def check_ip(ip, whitelist):
-    """Return if client IP belongs to one of the accepted subnets.
-
-    ip (string): IP address to verify.
-    whitelist (string): IP addresses or subnets to check against (separated
-        by a comma).
-
-    return (bool): whether client is equal to one of the IPs in the whitelist
-        or client belongs to one of the subnets in the whitelist.
-
-    """
-    for wanted in whitelist.split(","):
-        wanted, sep, subnet = wanted.partition('/')
-
-        subnet = 32 if sep == "" else int(subnet)
-        snmask = 2 ** 32 - 2 ** (32 - subnet)
-        wanted = struct.unpack(">I", socket.inet_aton(wanted))[0]
-        client = struct.unpack(">I", socket.inet_aton(ip))[0]
-
-        if (wanted & snmask) == (client & snmask):
-            return True
-
-    return False
-
-
 class BaseHandler(CommonRequestHandler):
     """Base RequestHandler for this application.
 
-    All the RequestHandler classes in this application should be a
-    child of this class.
+    This will also handle the contest list on the homepage.
 
     """
 
@@ -106,207 +60,24 @@ class BaseHandler(CommonRequestHandler):
         self.langs = None
         self._ = None
 
+    def get(self):
+        self.r_params = self.render_params()
+
+        self.render("contest_list.html", **self.r_params)
+
     def prepare(self):
         """This method is executed at the beginning of each request.
 
         """
         super(BaseHandler, self).prepare()
-        self.contest = Contest.get_from_id(self.application.service.contest,
-                                           self.sql_session)
 
         self._ = self.locale.translate
 
-        self.r_params = self.render_params()
-
-    def get_current_user(self):
-        """Return the currently logged in participation.
-
-        The name is get_current_user because tornado requires that
-        name.
-
-        The participation is obtained from one of the possible sources:
-        - if IP autologin is enabled, the remote IP address is matched
-          with the participation IP address; if a match is found, that
-          participation is returned; in case of errors, None is returned;
-        - if username/password authentication is enabled, and the cookie
-          is valid, the corresponding participation is returned, and the
-          cookie is refreshed.
-
-        After finding the participation, IP login and hidden users
-        restrictions are checked.
-
-        In case of any error, or of a login by other sources, the
-        cookie is deleted.
-
-        return (Participation|None): the participation object for the
-            user logged in for the running contest.
-
-        """
-        participation = None
-
-        if self.contest.ip_autologin:
-            try:
-                participation = self._get_current_user_from_ip()
-                # If the login is IP-based, we delete previous cookies.
-                if participation is not None:
-                    self.clear_cookie("login")
-            except RuntimeError:
-                return None
-
-        if participation is None \
-                and self.contest.allow_password_authentication:
-            participation = self._get_current_user_from_cookie()
-
-        if participation is None:
-            self.clear_cookie("login")
-            return None
-
-        # Check if user is using the right IP (or is on the right subnet),
-        # and that is not hidden if hidden users are blocked.
-        ip_login_restricted = \
-            self.contest.ip_restriction and participation.ip is not None \
-            and not check_ip(self.request.remote_ip, participation.ip)
-        hidden_user_restricted = \
-            participation.hidden and self.contest.block_hidden_participations
-        if ip_login_restricted or hidden_user_restricted:
-            self.clear_cookie("login")
-            participation = None
-
-        return participation
-
-    def _get_current_user_from_ip(self):
-        """Return the current participation based on the IP address.
-
-        return (Participation|None): the only participation matching
-            the remote IP address, or None if no participations could
-            be matched.
-
-        raise (RuntimeError): if there is more than one participation
-            matching the remote IP address.
-
-        """
-        remote_ip = self.request.remote_ip
-        participations = self.sql_session.query(Participation)\
-            .filter(Participation.contest == self.contest)\
-            .filter(Participation.ip == remote_ip)
-
-        # If hidden users are blocked we ignore them completely.
-        if self.contest.block_hidden_participations:
-            participations = participations\
-                .filter(Participation.hidden.is_(False))
-
-        participations = participations.all()
-
-        if len(participations) == 1:
-            return participations[0]
-
-        # Having more than participation with the same IP,
-        # is a mistake and should not happen. In such case,
-        # we disallow login for that IP completely, in order to
-        # make sure the problem is noticed.
-        if len(participations) > 1:
-            logger.error("%d participants have IP %s while"
-                         "auto-login feature is enabled." % (
-                             len(participations), remote_ip))
-            raise RuntimeError("More than one participants with the same IP.")
-
-    def _get_current_user_from_cookie(self):
-        """Return the current participation based on the cookie.
-
-        If a participation can be extracted, the cookie is refreshed.
-
-        return (Participation|None): the participation extracted from
-            the cookie, or None if not possible.
-
-        """
-        if self.get_secure_cookie("login") is None:
-            return None
-
-        # Parse cookie.
-        try:
-            cookie = pickle.loads(self.get_secure_cookie("login"))
-            username = cookie[0]
-            password = cookie[1]
-            last_update = make_datetime(cookie[2])
-        except:
-            return None
-
-        # Check if the cookie is expired.
-        if self.timestamp - last_update > \
-                timedelta(seconds=config.cookie_duration):
-            return None
-
-        # Load participation from DB and make sure it exists.
-        participation = self.sql_session.query(Participation)\
-            .join(Participation.user)\
-            .options(contains_eager(Participation.user))\
-            .filter(Participation.contest == self.contest)\
-            .filter(User.username == username)\
-            .first()
-        if participation is None:
-            return None
-
-        # Check that the password is correct (if a contest-specific
-        # password is defined, use that instead of the user password).
-        if participation.password is None:
-            correct_password = participation.user.password
-        else:
-            correct_password = participation.password
-        if password != correct_password:
-            return None
-
-        if self.refresh_cookie:
-            self.set_secure_cookie("login",
-                                   pickle.dumps((username,
-                                                 password,
-                                                 make_timestamp())),
-                                   expires_days=None)
-
-        return participation
-
-    def get_user_locale(self):
-        self.langs = self.application.service.langs
-        lang_codes = self.langs.keys()
-
-        if len(self.contest.allowed_localizations) > 0:
-            lang_codes = filter_language_codes(
-                lang_codes, self.contest.allowed_localizations)
-
-        # Select the one the user likes most.
-        basic_lang = lang_codes[0].replace("_", "-") \
-            if len(self.contest.allowed_localizations) else 'en'
-        http_langs = [lang_code.replace("_", "-") for lang_code in lang_codes]
-        self.browser_lang = parse_accept_header(
-            self.request.headers.get("Accept-Language", ""),
-            LanguageAccept).best_match(http_langs, basic_lang)
-
-        self.cookie_lang = self.get_cookie("language", None)
-
-        if self.cookie_lang in http_langs:
-            lang_code = self.cookie_lang
-        else:
-            lang_code = self.browser_lang
-
-        self.set_header("Content-Language", lang_code)
-        return self.langs[lang_code.replace("-", "_")]
-
-    @staticmethod
-    def _get_token_status(obj):
-        """Return the status of the tokens for the given object.
-
-        obj (Contest or Task): an object that has the token_* attributes.
-        return (int): one of 0 (disabled), 1 (enabled/finite) and 2
-                      (enabled/infinite).
-
-        """
-        if obj.token_mode == "disabled":
-            return 0
-        elif obj.token_mode == "finite":
-            return 1
-        elif obj.token_mode == "infinite":
-            return 2
-        else:
-            raise RuntimeError("Unknown token_mode value.")
+        # We need this to be computed for each request because we want to be
+        # able to import new contests without having to restart CWS.
+        self.contest_list = {}
+        for contest in self.sql_session.query(Contest).all():
+            self.contest_list[contest.name] = contest
 
     def render_params(self):
         """Return the default render params used by almost all handlers.
@@ -316,68 +87,13 @@ class BaseHandler(CommonRequestHandler):
         """
         ret = {}
         ret["timestamp"] = self.timestamp
-        ret["contest"] = self.contest
         ret["url_root"] = get_url_root(self.request.path)
 
-        ret["phase"] = self.contest.phase(self.timestamp)
-
-        ret["printing_enabled"] = (config.printer is not None)
-        ret["questions_enabled"] = self.contest.allow_questions
-        ret["testing_enabled"] = self.contest.allow_user_tests
-
-        if self.current_user is not None:
-            participation = self.current_user
-
-            res = compute_actual_phase(
-                self.timestamp, self.contest.start, self.contest.stop,
-                self.contest.per_user_time, participation.starting_time,
-                participation.delay_time, participation.extra_time)
-
-            ret["actual_phase"], ret["current_phase_begin"], \
-                ret["current_phase_end"], ret["valid_phase_begin"], \
-                ret["valid_phase_end"] = res
-
-            if ret["actual_phase"] == 0:
-                ret["phase"] = 0
-
-            # set the timezone used to format timestamps
-            ret["timezone"] = get_timezone(participation.user, self.contest)
-
-        # some information about token configuration
-        ret["tokens_contest"] = self._get_token_status(self.contest)
-
-        t_tokens = sum(self._get_token_status(t) for t in self.contest.tasks)
-        if t_tokens == 0:
-            ret["tokens_tasks"] = 0  # all disabled
-        elif t_tokens == 2 * len(self.contest.tasks):
-            ret["tokens_tasks"] = 2  # all infinite
-        else:
-            ret["tokens_tasks"] = 1  # all finite or mixed
+        ret["contest_list"] = self.contest_list
 
         # TODO Now all language names are shown in the active language.
         # It would be better to show them in the corresponding one.
         ret["lang_names"] = {}
-
-        # Get language codes for allowed localizations
-        lang_codes = self.langs.keys()
-        if len(self.contest.allowed_localizations) > 0:
-            lang_codes = filter_language_codes(
-                lang_codes, self.contest.allowed_localizations)
-        for lang_code, trans in self.langs.iteritems():
-            language_name = None
-            # Filter lang_codes with allowed localizations
-            if lang_code not in lang_codes:
-                continue
-            try:
-                language_name = translate_language_country_code(
-                    lang_code, trans)
-            except ValueError:
-                language_name = translate_language_code(
-                    lang_code, trans)
-            ret["lang_names"][lang_code.replace("_", "-")] = language_name
-
-        ret["cookie_lang"] = self.cookie_lang
-        ret["browser_lang"] = self.browser_lang
 
         return ret
 
@@ -424,7 +140,16 @@ class BaseHandler(CommonRequestHandler):
 
 
 class StaticFileGzHandler(tornado.web.StaticFileHandler):
-    """Handle files which may be gzip-compressed on the filesystem."""
+    """Handle files which may be gzip-compressed on the filesystem.
+
+    """
+    def get_absolute_path(self, root, path):
+        if self.application.service.contest is None:
+            # The path argument is actually contest_name, so we don't use it
+            return os.path.abspath(os.path.join(root, self.path_args[1]))
+        else:
+            return os.path.abspath(os.path.join(root, path))
+
     def validate_absolute_path(self, root, absolute_path):
         self.is_gzipped = False
         try:
@@ -445,6 +170,3 @@ class StaticFileGzHandler(tornado.web.StaticFileHandler):
             return "text/plain"
         else:
             return tornado.web.StaticFileHandler.get_content_type(self)
-
-
-FileHandler = file_handler_gen(BaseHandler)

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -91,10 +91,6 @@ class BaseHandler(CommonRequestHandler):
 
         ret["contest_list"] = self.contest_list
 
-        # TODO Now all language names are shown in the active language.
-        # It would be better to show them in the corresponding one.
-        ret["lang_names"] = {}
-
         return ret
 
     def finish(self, *args, **kwds):

--- a/cms/server/contest/handlers/communication.py
+++ b/cms/server/contest/handlers/communication.py
@@ -9,7 +9,7 @@
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
-# Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2015-2016 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -33,39 +33,46 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import logging
+import os
 
 import tornado.web
 
 from cms.db import Question
+from cms.server import multi_contest
 
-from .base import BaseHandler, NOTIFICATION_ERROR, NOTIFICATION_SUCCESS
+from .contest import ContestHandler, NOTIFICATION_ERROR, NOTIFICATION_SUCCESS
 
 
 logger = logging.getLogger(__name__)
 
 
-class CommunicationHandler(BaseHandler):
+class CommunicationHandler(ContestHandler):
     """Displays the private conversations between the logged in user
     and the contest managers..
 
     """
     @tornado.web.authenticated
-    def get(self):
-        self.set_secure_cookie("unread_count", "0")
+    @multi_contest
+    def get(self, contest_name):
+        self.set_secure_cookie(self.contest.name + "_unread_count", "0")
         self.render("communication.html", **self.r_params)
 
 
-class QuestionHandler(BaseHandler):
+class QuestionHandler(ContestHandler):
     """Called when the user submits a question.
 
     """
     @tornado.web.authenticated
-    def post(self):
+    @multi_contest
+    def post(self, contest_name):
         participation = self.current_user
 
         # User can post only if we want.
         if not self.contest.allow_questions:
             raise tornado.web.HTTPError(404)
+
+        fallback_page = os.path.join(self.r_params["real_contest_root"],
+                                     "communication")
 
         subject_length = len(self.get_argument("question_subject", ""))
         text_length = len(self.get_argument("question_text", ""))
@@ -79,7 +86,7 @@ class QuestionHandler(BaseHandler):
                 self._("Question too big!"),
                 self._("You have reached the question length limit."),
                 NOTIFICATION_ERROR)
-            self.redirect("/communication")
+            self.redirect(fallback_page)
             return
 
         question = Question(self.timestamp,
@@ -101,4 +108,4 @@ class QuestionHandler(BaseHandler):
                    "notified when it is answered."),
             NOTIFICATION_SUCCESS)
 
-        self.redirect("/communication")
+        self.redirect(fallback_page)

--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -169,6 +169,31 @@ class ContestHandler(BaseHandler):
         else:
             ret["tokens_tasks"] = 1  # all finite or mixed
 
+        # TODO Now all language names are shown in the active language.
+        # It would be better to show them in the corresponding one.
+        ret["lang_names"] = {}
+
+        # Get language codes for allowed localizations
+        lang_codes = self.langs.keys()
+        if len(self.contest.allowed_localizations) > 0:
+            lang_codes = filter_language_codes(
+                lang_codes, self.contest.allowed_localizations)
+        for lang_code, trans in self.langs.iteritems():
+            language_name = None
+            # Filter lang_codes with allowed localizations
+            if lang_code not in lang_codes:
+                continue
+            try:
+                language_name = translate_language_country_code(
+                    lang_code, trans)
+            except ValueError:
+                language_name = translate_language_code(
+                    lang_code, trans)
+            ret["lang_names"][lang_code.replace("_", "-")] = language_name
+
+        ret["cookie_lang"] = self.cookie_lang
+        ret["browser_lang"] = self.browser_lang
+
         return ret
 
     def get_login_url(self):

--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2010-2014 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
+# Copyright © 2010-2016 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
+# Copyright © 2012-2015 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
+# Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
+# Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
+# Copyright © 2015-2016 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
+# Copyright © 2016 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Contest handler classes for CWS.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import pickle
+import socket
+import struct
+
+from datetime import timedelta
+
+from sqlalchemy.orm import contains_eager
+from werkzeug.datastructures import LanguageAccept
+from werkzeug.http import parse_accept_header
+
+from cms import config
+from cms.db import Contest, Participation, User
+from cms.server import compute_actual_phase, file_handler_gen
+from cms.locale import filter_language_codes
+from cmscommon.datetime import get_timezone, make_datetime, make_timestamp
+
+from .base import BaseHandler
+
+logger = logging.getLogger(__name__)
+
+
+NOTIFICATION_ERROR = "error"
+NOTIFICATION_WARNING = "warning"
+NOTIFICATION_SUCCESS = "success"
+
+
+def check_ip(ip, whitelist):
+    """Return if client IP belongs to one of the accepted subnets.
+
+    ip (string): IP address to verify.
+    whitelist (string): IP addresses or subnets to check against (separated
+        by a comma).
+
+    return (bool): whether client is equal to one of the IPs in the whitelist
+        or client belongs to one of the subnets in the whitelist.
+
+    """
+    for wanted in whitelist.split(","):
+        wanted, sep, subnet = wanted.partition('/')
+
+        subnet = 32 if sep == "" else int(subnet)
+        snmask = 2 ** 32 - 2 ** (32 - subnet)
+        wanted = struct.unpack(">I", socket.inet_aton(wanted))[0]
+        client = struct.unpack(">I", socket.inet_aton(ip))[0]
+
+        if (wanted & snmask) == (client & snmask):
+            return True
+
+    return False
+
+
+class ContestHandler(BaseHandler):
+    """A handler that has a contest attached.
+
+    Most of the RequestHandler classes in this application will be a
+    child of this class.
+    """
+    def prepare(self):
+        super(ContestHandler, self).prepare()
+
+        self.choose_contest()
+
+    def choose_contest(self, contest_name=None):
+        if self.application.service.contest is None:
+            if contest_name is None:
+                # Choose the contest found in the path argument
+                # see: https://github.com/tornadoweb/tornado/issues/1673
+                contest_name = self.path_args[0]
+
+            # Select the correct contest or return an error
+            try:
+                self.contest = self.contest_list[contest_name]
+            except KeyError:
+                # The right thing here would be:
+                #    raise tornado.web.HTTPError(404)
+                # however, that would make the "error.html" page fail because
+                # there is no self.contest available
+
+                # So, let's return to the contest list
+                self.redirect("/")
+                return
+        else:
+            # Select the contest specified on the command line
+            self.contest = Contest.get_from_id(self.application.service.contest,
+                                               self.sql_session)
+
+        # Run render_params() now, not at the beginning of the request,
+        # because we need contest_name
+        self.r_params = self.render_params()
+
+    def render_params(self):
+        ret = super(ContestHandler, self).render_params()
+
+        ret["contest"] = self.contest
+        ret["contest_root"] = ret["url_root"]
+        ret["real_contest_root"] = "/"
+        if self.application.service.contest is None:
+            ret["contest_root"] += "/" + self.contest.name
+            ret["real_contest_root"] += self.contest.name
+        ret["phase"] = self.contest.phase(self.timestamp)
+
+        ret["printing_enabled"] = (config.printer is not None)
+        ret["questions_enabled"] = self.contest.allow_questions
+        ret["testing_enabled"] = self.contest.allow_user_tests
+
+        if self.current_user is not None:
+            participation = self.current_user
+
+            res = compute_actual_phase(
+                self.timestamp, self.contest.start, self.contest.stop,
+                self.contest.per_user_time, participation.starting_time,
+                participation.delay_time, participation.extra_time)
+
+            ret["actual_phase"], ret["current_phase_begin"], \
+                ret["current_phase_end"], ret["valid_phase_begin"], \
+                ret["valid_phase_end"] = res
+
+            if ret["actual_phase"] == 0:
+                ret["phase"] = 0
+
+            # set the timezone used to format timestamps
+            ret["timezone"] = get_timezone(participation.user, self.contest)
+
+        # some information about token configuration
+        ret["tokens_contest"] = self._get_token_status(self.contest)
+
+        t_tokens = sum(self._get_token_status(t) for t in self.contest.tasks)
+        if t_tokens == 0:
+            ret["tokens_tasks"] = 0  # all disabled
+        elif t_tokens == 2 * len(self.contest.tasks):
+            ret["tokens_tasks"] = 2  # all infinite
+        else:
+            ret["tokens_tasks"] = 1  # all finite or mixed
+
+        return ret
+
+    def get_login_url(self):
+        """The login url depends on the contest name, so we can't just
+        use the "login_url" application parameter.
+
+        """
+        return "/" + self.contest.name
+
+    def get_current_user(self):
+        """Return the currently logged in participation.
+
+        The name is get_current_user because tornado requires that
+        name.
+
+        The participation is obtained from one of the possible sources:
+        - if IP autologin is enabled, the remote IP address is matched
+          with the participation IP address; if a match is found, that
+          participation is returned; in case of errors, None is returned;
+        - if username/password authentication is enabled, and the cookie
+          is valid, the corresponding participation is returned, and the
+          cookie is refreshed.
+
+        After finding the participation, IP login and hidden users
+        restrictions are checked.
+
+        In case of any error, or of a login by other sources, the
+        cookie is deleted.
+
+        return (Participation|None): the participation object for the
+            user logged in for the running contest.
+
+        """
+        cookie_name = self.contest.name + "_login"
+
+        participation = None
+
+        if self.contest.ip_autologin:
+            try:
+                participation = self._get_current_user_from_ip()
+                # If the login is IP-based, we delete previous cookies.
+                if participation is not None:
+                    self.clear_cookie(cookie_name)
+            except RuntimeError:
+                return None
+
+        if participation is None \
+                and self.contest.allow_password_authentication:
+            participation = self._get_current_user_from_cookie()
+
+        if participation is None:
+            self.clear_cookie(cookie_name)
+            return None
+
+        # Check if user is using the right IP (or is on the right subnet),
+        # and that is not hidden if hidden users are blocked.
+        ip_login_restricted = \
+            self.contest.ip_restriction and participation.ip is not None \
+            and not check_ip(self.request.remote_ip, participation.ip)
+        hidden_user_restricted = \
+            participation.hidden and self.contest.block_hidden_participations
+        if ip_login_restricted or hidden_user_restricted:
+            self.clear_cookie(cookie_name)
+            participation = None
+
+        return participation
+
+    def _get_current_user_from_ip(self):
+        """Return the current participation based on the IP address.
+
+        return (Participation|None): the only participation matching
+            the remote IP address, or None if no participations could
+            be matched.
+
+        raise (RuntimeError): if there is more than one participation
+            matching the remote IP address.
+
+        """
+        remote_ip = self.request.remote_ip
+        participations = self.sql_session.query(Participation)\
+            .filter(Participation.contest == self.contest)\
+            .filter(Participation.ip == remote_ip)
+
+        # If hidden users are blocked we ignore them completely.
+        if self.contest.block_hidden_participations:
+            participations = participations\
+                .filter(Participation.hidden.is_(False))
+
+        participations = participations.all()
+
+        if len(participations) == 1:
+            return participations[0]
+
+        # Having more than participation with the same IP,
+        # is a mistake and should not happen. In such case,
+        # we disallow login for that IP completely, in order to
+        # make sure the problem is noticed.
+        if len(participations) > 1:
+            logger.error("%d participants have IP %s while"
+                         "auto-login feature is enabled." % (
+                             len(participations), remote_ip))
+            raise RuntimeError("More than one participants with the same IP.")
+
+    def _get_current_user_from_cookie(self):
+        """Return the current participation based on the cookie.
+
+        If a participation can be extracted, the cookie is refreshed.
+
+        return (Participation|None): the participation extracted from
+            the cookie, or None if not possible.
+
+        """
+        cookie_name = self.contest.name + "_login"
+
+        if self.get_secure_cookie(cookie_name) is None:
+            return None
+
+        # Parse cookie.
+        try:
+            cookie = pickle.loads(self.get_secure_cookie(cookie_name))
+            username = cookie[0]
+            password = cookie[1]
+            last_update = make_datetime(cookie[2])
+        except:
+            return None
+
+        # Check if the cookie is expired.
+        if self.timestamp - last_update > \
+                timedelta(seconds=config.cookie_duration):
+            return None
+
+        # Load participation from DB and make sure it exists.
+        participation = self.sql_session.query(Participation)\
+            .join(Participation.user)\
+            .options(contains_eager(Participation.user))\
+            .filter(Participation.contest == self.contest)\
+            .filter(User.username == username)\
+            .first()
+
+        if participation is None:
+            return None
+
+        # Check that the password is correct (if a contest-specific
+        # password is defined, use that instead of the user password).
+        if participation.password is None:
+            correct_password = participation.user.password
+        else:
+            correct_password = participation.password
+
+        if password != correct_password:
+            return None
+
+        if self.refresh_cookie:
+            self.set_secure_cookie(cookie_name,
+                                   pickle.dumps((username,
+                                                 password,
+                                                 make_timestamp())),
+                                   expires_days=None)
+
+        return participation
+
+    def get_user_locale(self):
+        self.langs = self.application.service.langs
+        lang_codes = self.langs.keys()
+
+        if self.contest and len(self.contest.allowed_localizations) > 0:
+            lang_codes = filter_language_codes(
+                lang_codes, self.contest.allowed_localizations)
+
+        # Select the one the user likes most.
+        basic_lang = 'en'
+
+        if self.contest and len(self.contest.allowed_localizations):
+            basic_lang = lang_codes[0].replace("_", "-")
+
+        http_langs = [lang_code.replace("_", "-") for lang_code in lang_codes]
+        self.browser_lang = parse_accept_header(
+            self.request.headers.get("Accept-Language", ""),
+            LanguageAccept).best_match(http_langs, basic_lang)
+
+        self.cookie_lang = self.get_cookie("language", None)
+
+        if self.cookie_lang in http_langs:
+            lang_code = self.cookie_lang
+        else:
+            lang_code = self.browser_lang
+
+        self.set_header("Content-Language", lang_code)
+        return self.langs[lang_code.replace("-", "_")]
+
+    @staticmethod
+    def _get_token_status(obj):
+        """Return the status of the tokens for the given object.
+
+        obj (Contest or Task): an object that has the token_* attributes.
+        return (int): one of 0 (disabled), 1 (enabled/finite) and 2
+                      (enabled/infinite).
+
+        """
+        if obj.token_mode == "disabled":
+            return 0
+        elif obj.token_mode == "finite":
+            return 1
+        elif obj.token_mode == "infinite":
+            return 2
+        else:
+            raise RuntimeError("Unknown token_mode value.")
+
+
+FileHandler = file_handler_gen(ContestHandler)

--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -176,7 +176,7 @@ class ContestHandler(BaseHandler):
         use the "login_url" application parameter.
 
         """
-        return "/" + self.contest.name
+        return self.r_params["real_contest_root"]
 
     def get_current_user(self):
         """Return the currently logged in participation.

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -9,7 +9,7 @@
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
-# Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2015-2016 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -34,38 +34,43 @@ from __future__ import unicode_literals
 
 import json
 import logging
+import os
 import pickle
 
 import tornado.web
 
 from cms import config
 from cms.db import Participation, PrintJob, User
-from cms.server import actual_phase_required, filter_ascii
+from cms.server import actual_phase_required, filter_ascii, multi_contest
 from cmscommon.datetime import make_datetime, make_timestamp
 
-from .base import BaseHandler, check_ip, \
+from .contest import ContestHandler, check_ip, \
     NOTIFICATION_ERROR, NOTIFICATION_SUCCESS
 
 
 logger = logging.getLogger(__name__)
 
 
-class MainHandler(BaseHandler):
+class MainHandler(ContestHandler):
     """Home page handler.
 
     """
-    def get(self):
+    @multi_contest
+    def get(self, contest_name):
         self.render("overview.html", **self.r_params)
 
 
-class LoginHandler(BaseHandler):
+class LoginHandler(ContestHandler):
     """Login handler.
 
     """
-    def post(self):
+    @multi_contest
+    def post(self, contest_name):
+        fallback_page = self.r_params["real_contest_root"]
+
         username = self.get_argument("username", "")
         password = self.get_argument("password", "")
-        next_page = self.get_argument("next", "/")
+        next_page = self.get_argument("next", fallback_page)
         user = self.sql_session.query(User)\
             .filter(User.username == username)\
             .first()
@@ -76,12 +81,12 @@ class LoginHandler(BaseHandler):
 
         if user is None:
             # TODO: notify the user that they don't exist
-            self.redirect("/?login_error=true")
+            self.redirect(fallback_page + "?login_error=true")
             return
 
         if participation is None:
             # TODO: notify the user that they're uninvited
-            self.redirect("/?login_error=true")
+            self.redirect(fallback_page + "?login_error=true")
             return
 
         # If a contest-specific password is defined, use that. If it's
@@ -97,26 +102,26 @@ class LoginHandler(BaseHandler):
         if password != correct_password:
             logger.info("Login error: user=%s pass=%s remote_ip=%s." %
                         (filtered_user, filtered_pass, self.request.remote_ip))
-            self.redirect("/?login_error=true")
+            self.redirect(fallback_page + "?login_error=true")
             return
 
         if self.contest.ip_restriction and participation.ip is not None \
                 and not check_ip(self.request.remote_ip, participation.ip):
             logger.info("Unexpected IP: user=%s pass=%s remote_ip=%s.",
                         filtered_user, filtered_pass, self.request.remote_ip)
-            self.redirect("/?login_error=true")
+            self.redirect(fallback_page + "?login_error=true")
             return
 
         if participation.hidden and self.contest.block_hidden_participations:
             logger.info("Hidden user login attempt: "
                         "user=%s pass=%s remote_ip=%s.",
                         filtered_user, filtered_pass, self.request.remote_ip)
-            self.redirect("/?login_error=true")
+            self.redirect(fallback_page + "?login_error=true")
             return
 
         logger.info("User logged in: user=%s remote_ip=%s.",
                     filtered_user, self.request.remote_ip)
-        self.set_secure_cookie("login",
+        self.set_secure_cookie(self.contest.name + "_login",
                                pickle.dumps((user.username,
                                              correct_password,
                                              make_timestamp())),
@@ -124,7 +129,7 @@ class LoginHandler(BaseHandler):
         self.redirect(next_page)
 
 
-class StartHandler(BaseHandler):
+class StartHandler(ContestHandler):
     """Start handler.
 
     Used by a user who wants to start his per_user_time.
@@ -132,26 +137,28 @@ class StartHandler(BaseHandler):
     """
     @tornado.web.authenticated
     @actual_phase_required(-1)
-    def post(self):
+    @multi_contest
+    def post(self, contest_name):
         participation = self.current_user
 
         logger.info("Starting now for user %s", participation.user.username)
         participation.starting_time = self.timestamp
         self.sql_session.commit()
 
-        self.redirect("/")
+        self.redirect(self.r_params["contest_root"])
 
 
-class LogoutHandler(BaseHandler):
+class LogoutHandler(ContestHandler):
     """Logout handler.
 
     """
-    def get(self):
-        self.clear_cookie("login")
-        self.redirect("/")
+    @multi_contest
+    def get(self, contest_name):
+        self.clear_cookie(self.contest.name + "_login")
+        self.redirect(self.r_params["contest_root"])
 
 
-class NotificationsHandler(BaseHandler):
+class NotificationsHandler(ContestHandler):
     """Displays notifications.
 
     """
@@ -159,7 +166,8 @@ class NotificationsHandler(BaseHandler):
     refresh_cookie = False
 
     @tornado.web.authenticated
-    def get(self):
+    @multi_contest
+    def get(self, contest_name):
         if not self.current_user:
             raise tornado.web.HTTPError(403)
 
@@ -208,10 +216,11 @@ class NotificationsHandler(BaseHandler):
 
         # Update the unread_count cookie before taking notifications
         # into account because we don't want to count them.
-        prev_unread_count = self.get_secure_cookie("unread_count")
+        cookie_name = self.contest.name + "_unread_count"
+        prev_unread_count = self.get_secure_cookie(cookie_name)
         next_unread_count = len(res) + (
             int(prev_unread_count) if prev_unread_count is not None else 0)
-        self.set_secure_cookie("unread_count", "%d" % next_unread_count)
+        self.set_secure_cookie(cookie_name, "%d" % next_unread_count)
 
         # Simple notifications
         notifications = self.application.service.notifications
@@ -228,18 +237,18 @@ class NotificationsHandler(BaseHandler):
         self.write(json.dumps(res))
 
 
-class PrintingHandler(BaseHandler):
+class PrintingHandler(ContestHandler):
     """Serve the interface to print and handle submitted print jobs.
 
     """
     @tornado.web.authenticated
     @actual_phase_required(0)
-    def get(self):
+    @multi_contest
+    def get(self, contest_name):
         participation = self.current_user
 
         if not self.r_params["printing_enabled"]:
-            self.redirect("/")
-            return
+            raise tornado.web.HTTPError(403)
 
         printjobs = self.sql_session.query(PrintJob)\
             .filter(PrintJob.participation == participation)\
@@ -256,12 +265,15 @@ class PrintingHandler(BaseHandler):
 
     @tornado.web.authenticated
     @actual_phase_required(0)
-    def post(self):
+    @multi_contest
+    def post(self, contest_name):
         participation = self.current_user
 
         if not self.r_params["printing_enabled"]:
-            self.redirect("/")
-            return
+            raise tornado.web.HTTPError(403)
+
+        fallback_page = os.path.join(self.r_params["real_contest_root"],
+                                     "printing")
 
         printjobs = self.sql_session.query(PrintJob)\
             .filter(PrintJob.participation == participation)\
@@ -275,7 +287,7 @@ class PrintingHandler(BaseHandler):
                 self._("You have reached the maximum limit of "
                        "at most %d print jobs.") % config.max_jobs_per_user,
                 NOTIFICATION_ERROR)
-            self.redirect("/printing")
+            self.redirect(fallback_page)
             return
 
         # Ensure that the user did not submit multiple files with the
@@ -289,7 +301,7 @@ class PrintingHandler(BaseHandler):
                 self._("Invalid format!"),
                 self._("Please select the correct files."),
                 NOTIFICATION_ERROR)
-            self.redirect("/printing")
+            self.redirect(fallback_page)
             return
 
         filename = self.request.files["file"][0]["filename"]
@@ -304,7 +316,7 @@ class PrintingHandler(BaseHandler):
                 self._("Each file must be at most %d bytes long.") %
                 config.max_print_length,
                 NOTIFICATION_ERROR)
-            self.redirect("/printing")
+            self.redirect(fallback_page)
             return
 
         # We now have to send the file to the destination...
@@ -324,7 +336,7 @@ class PrintingHandler(BaseHandler):
                 self._("Print job storage failed!"),
                 self._("Please try again."),
                 NOTIFICATION_ERROR)
-            self.redirect("/printing")
+            self.redirect(fallback_page)
             return
 
         # The file is stored, ready to submit!
@@ -346,14 +358,15 @@ class PrintingHandler(BaseHandler):
             self._("Print job received"),
             self._("Your print job has been received."),
             NOTIFICATION_SUCCESS)
-        self.redirect("/printing")
+        self.redirect(fallback_page)
 
 
-class DocumentationHandler(BaseHandler):
+class DocumentationHandler(ContestHandler):
     """Displays the instruction (compilation lines, documentation,
     ...) of the contest.
 
     """
     @tornado.web.authenticated
-    def get(self):
+    @multi_contest
+    def get(self, contest_name):
         self.render("documentation.html", **self.r_params)

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -145,7 +145,7 @@ class StartHandler(ContestHandler):
         participation.starting_time = self.timestamp
         self.sql_session.commit()
 
-        self.redirect(self.r_params["contest_root"])
+        self.redirect(self.r_params["real_contest_root"])
 
 
 class LogoutHandler(ContestHandler):
@@ -155,7 +155,7 @@ class LogoutHandler(ContestHandler):
     @multi_contest
     def get(self, contest_name):
         self.clear_cookie(self.contest.name + "_login")
-        self.redirect(self.r_params["contest_root"])
+        self.redirect(self.r_params["real_contest_root"])
 
 
 class NotificationsHandler(ContestHandler):

--- a/cms/server/contest/handlers/task.py
+++ b/cms/server/contest/handlers/task.py
@@ -9,7 +9,7 @@
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
-# Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2015-2016 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -34,22 +34,23 @@ from __future__ import unicode_literals
 
 import tornado.web
 
-from cms.server import actual_phase_required
+from cms.server import actual_phase_required, multi_contest
 from cmscommon.isocodes import is_language_code, translate_language_code, \
     is_country_code, translate_country_code, \
     is_language_country_code, translate_language_country_code
 from cmscommon.mimetypes import get_type_for_file_name
 
-from .base import BaseHandler, FileHandler
+from .contest import ContestHandler, FileHandler
 
 
-class TaskDescriptionHandler(BaseHandler):
+class TaskDescriptionHandler(ContestHandler):
     """Shows the data of a task in the contest.
 
     """
     @tornado.web.authenticated
     @actual_phase_required(0)
-    def get(self, task_name):
+    @multi_contest
+    def get(self, contest_name, task_name):
         try:
             task = self.contest.get_task(task_name)
         except KeyError:
@@ -78,7 +79,8 @@ class TaskStatementViewHandler(FileHandler):
     """
     @tornado.web.authenticated
     @actual_phase_required(0)
-    def get(self, task_name, lang_code):
+    @multi_contest
+    def get(self, contest_name, task_name, lang_code):
         try:
             task = self.contest.get_task(task_name)
         except KeyError:
@@ -104,7 +106,8 @@ class TaskAttachmentViewHandler(FileHandler):
     """
     @tornado.web.authenticated
     @actual_phase_required(0)
-    def get(self, task_name, filename):
+    @multi_contest
+    def get(self, contest_name, task_name, filename):
         try:
             task = self.contest.get_task(task_name)
         except KeyError:

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -9,7 +9,7 @@
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
-# Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2015-2016 William Di Luigi <williamdiluigi@gmail.com>
 # Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -47,30 +47,30 @@ from sqlalchemy import func
 from cms import config, filename_to_language
 from cms.db import Task, UserTest, UserTestFile, UserTestManager
 from cms.grading.tasktypes import get_task_type
-from cms.server import actual_phase_required, format_size
+from cms.server import actual_phase_required, format_size, multi_contest
 from cmscommon.archive import Archive
 from cmscommon.datetime import make_timestamp
 from cmscommon.mimetypes import get_type_for_file_name
 
-from .base import BaseHandler, FileHandler, \
-    NOTIFICATION_ERROR, NOTIFICATION_SUCCESS
+from .contest import ContestHandler, FileHandler, NOTIFICATION_ERROR, \
+    NOTIFICATION_SUCCESS
 
 
 logger = logging.getLogger(__name__)
 
 
-class UserTestInterfaceHandler(BaseHandler):
+class UserTestInterfaceHandler(ContestHandler):
     """Serve the interface to test programs.
 
     """
     @tornado.web.authenticated
     @actual_phase_required(0)
-    def get(self):
+    @multi_contest
+    def get(self, contest_name):
         participation = self.current_user
 
         if not self.r_params["testing_enabled"]:
-            self.redirect("/")
-            return
+            raise tornado.web.HTTPError(403)
 
         user_tests = dict()
         user_tests_left = dict()
@@ -117,7 +117,7 @@ class UserTestInterfaceHandler(BaseHandler):
                     **self.r_params)
 
 
-class UserTestHandler(BaseHandler):
+class UserTestHandler(ContestHandler):
 
     refresh_cookie = False
 
@@ -126,17 +126,20 @@ class UserTestHandler(BaseHandler):
 
     @tornado.web.authenticated
     @actual_phase_required(0)
-    def post(self, task_name):
+    @multi_contest
+    def post(self, contest_name, task_name):
         participation = self.current_user
 
         if not self.r_params["testing_enabled"]:
-            self.redirect("/")
-            return
+            raise tornado.web.HTTPError(403)
 
         try:
             task = self.contest.get_task(task_name)
         except KeyError:
             raise tornado.web.HTTPError(404)
+
+        fallback_page = os.path.join(self.r_params["real_contest_root"],
+                                     "testing?%s" % quote(task.name, safe=''))
 
         # Check that the task is testable
         task_type = get_task_type(dataset=task.active_dataset)
@@ -180,7 +183,7 @@ class UserTestHandler(BaseHandler):
                 self._("Too many tests!"),
                 error.message,
                 NOTIFICATION_ERROR)
-            self.redirect("/testing?%s" % quote(task.name, safe=''))
+            self.redirect(fallback_page)
             return
 
         # Enforce minimum time between user_tests
@@ -224,7 +227,7 @@ class UserTestHandler(BaseHandler):
                 self._("Tests too frequent!"),
                 error.message,
                 NOTIFICATION_ERROR)
-            self.redirect("/testing?%s" % quote(task.name, safe=''))
+            self.redirect(fallback_page)
             return
 
         # Ensure that the user did not submit multiple files with the
@@ -236,7 +239,7 @@ class UserTestHandler(BaseHandler):
                 self._("Invalid test format!"),
                 self._("Please select the correct files."),
                 NOTIFICATION_ERROR)
-            self.redirect("/testing?%s" % quote(task.name, safe=''))
+            self.redirect(fallback_page)
             return
 
         # If the user submitted an archive, extract it and use content
@@ -256,7 +259,7 @@ class UserTestHandler(BaseHandler):
                     self._("Invalid archive format!"),
                     self._("The submitted archive could not be opened."),
                     NOTIFICATION_ERROR)
-                self.redirect("/testing?%s" % quote(task.name, safe=''))
+                self.redirect(fallback_page)
                 return
 
             # Extract the archive.
@@ -286,7 +289,7 @@ class UserTestHandler(BaseHandler):
                 self._("Invalid test format!"),
                 self._("Please select the correct files."),
                 NOTIFICATION_ERROR)
-            self.redirect("/testing?%s" % quote(task.name, safe=''))
+            self.redirect(fallback_page)
             return
 
         # Add submitted files. After this, files is a dictionary indexed
@@ -339,7 +342,7 @@ class UserTestHandler(BaseHandler):
                 self._("Invalid test!"),
                 error,
                 NOTIFICATION_ERROR)
-            self.redirect("/testing?%s" % quote(task.name, safe=''))
+            self.redirect(fallback_page)
             return
 
         # Check if submitted files are small enough.
@@ -352,7 +355,7 @@ class UserTestHandler(BaseHandler):
                 self._("Each source file must be at most %d bytes long.") %
                 config.max_submission_length,
                 NOTIFICATION_ERROR)
-            self.redirect("/testing?%s" % quote(task.name, safe=''))
+            self.redirect(fallback_page)
             return
         if len(files["input"][1]) > config.max_input_length:
             self.application.service.add_notification(
@@ -362,7 +365,7 @@ class UserTestHandler(BaseHandler):
                 self._("The input file must be at most %d bytes long.") %
                 config.max_input_length,
                 NOTIFICATION_ERROR)
-            self.redirect("/testing?%s" % quote(task.name, safe=''))
+            self.redirect(fallback_page)
             return
 
         # All checks done, submission accepted.
@@ -409,7 +412,7 @@ class UserTestHandler(BaseHandler):
                 self._("Test storage failed!"),
                 self._("Please try again."),
                 NOTIFICATION_ERROR)
-            self.redirect("/testing?%s" % quote(task.name, safe=''))
+            self.redirect(fallback_page)
             return
 
         # All the files are stored, ready to submit!
@@ -443,16 +446,17 @@ class UserTestHandler(BaseHandler):
             self._("Your test has been received "
                    "and is currently being executed."),
             NOTIFICATION_SUCCESS)
-        self.redirect("/testing?%s" % quote(task.name, safe=''))
+        self.redirect(fallback_page)
 
 
-class UserTestStatusHandler(BaseHandler):
+class UserTestStatusHandler(ContestHandler):
 
     refresh_cookie = False
 
     @tornado.web.authenticated
     @actual_phase_required(0)
-    def get(self, task_name, user_test_num):
+    @multi_contest
+    def get(self, contest_name, task_name, user_test_num):
         participation = self.current_user
 
         if not self.r_params["testing_enabled"]:
@@ -504,13 +508,14 @@ class UserTestStatusHandler(BaseHandler):
         self.write(data)
 
 
-class UserTestDetailsHandler(BaseHandler):
+class UserTestDetailsHandler(ContestHandler):
 
     refresh_cookie = False
 
     @tornado.web.authenticated
     @actual_phase_required(0)
-    def get(self, task_name, user_test_num):
+    @multi_contest
+    def get(self, contest_name, task_name, user_test_num):
         participation = self.current_user
 
         if not self.r_params["testing_enabled"]:
@@ -541,7 +546,8 @@ class UserTestIOHandler(FileHandler):
     """
     @tornado.web.authenticated
     @actual_phase_required(0)
-    def get(self, task_name, user_test_num, io):
+    @multi_contest
+    def get(self, contest_name, task_name, user_test_num, io):
         participation = self.current_user
 
         if not self.r_params["testing_enabled"]:
@@ -582,7 +588,8 @@ class UserTestFileHandler(FileHandler):
     """
     @tornado.web.authenticated
     @actual_phase_required(0)
-    def get(self, task_name, user_test_num, filename):
+    @multi_contest
+    def get(self, contest_name, task_name, user_test_num, filename):
         participation = self.current_user
 
         if not self.r_params["testing_enabled"]:

--- a/cms/server/contest/server.py
+++ b/cms/server/contest/server.py
@@ -9,7 +9,7 @@
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
-# Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2015-2016 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -52,6 +52,8 @@ from cms.db.filecacher import FileCacher
 from cms.locale import get_translations, wrap_translations_for_tornado
 
 from .handlers import HANDLERS
+from .handlers.base import BaseHandler
+from .handlers.main import MainHandler
 
 
 logger = logging.getLogger(__name__)
@@ -61,9 +63,8 @@ class ContestWebServer(WebService):
     """Service that runs the web server serving the contestants.
 
     """
-    def __init__(self, shard, contest):
+    def __init__(self, shard, contest=None):
         parameters = {
-            "login_url": "/",
             "template_path": pkg_resources.resource_filename(
                 "cms.server.contest", "templates"),
             "static_files": [("cms.server", "static"),
@@ -83,14 +84,24 @@ class ContestWebServer(WebService):
                               "contest_listen_address and contest_listen_port "
                               "in cms.conf." % __name__)
 
+        self.contest = contest
+        del contest
+
+        if self.contest is None:
+            HANDLERS.append((r"", MainHandler))
+            handlers = [(r'/', BaseHandler)]
+            for h in HANDLERS:
+                handlers.append((r'/([^/]+)' + h[0],) + h[1:])
+        else:
+            HANDLERS.append((r"/", MainHandler))
+            handlers = HANDLERS
+
         super(ContestWebServer, self).__init__(
             listen_port,
-            HANDLERS,
+            handlers,
             parameters,
             shard=shard,
             listen_address=listen_address)
-
-        self.contest = contest
 
         # This is a dictionary (indexed by username) of pending
         # notification. Things like "Yay, your submission went

--- a/cms/server/contest/static/cws_style.css
+++ b/cms/server/contest/static/cws_style.css
@@ -962,3 +962,35 @@ td.token_rules p:last-child {
 #lang {
     width: 100px;
 }
+
+/* Contest selection page */
+
+.contest-list {
+    width: 60%;
+    margin: auto;
+    margin-top: 50px;
+}
+
+.contest-list ul {
+    padding: 0;
+}
+
+.contest-list li:first-child > a {
+    -webkit-border-radius: 6px 6px 0 0;
+    -moz-border-radius: 6px 6px 0 0;
+    border-radius: 6px 6px 0 0;
+}
+
+.contest-list li:last-child > a {
+    -webkit-border-radius: 0 0 6px 6px;
+    -moz-border-radius: 0 0 6px 6px;
+    border-radius: 0 0 6px 6px;
+}
+
+.contest-list li > a {
+    display: block;
+    margin: 0 0 -1px;
+    padding: 8px 14px;
+    background-color: white;
+    border: 1px solid #e5e5e5;
+}

--- a/cms/server/contest/static/cws_utils.js
+++ b/cms/server/contest/static/cws_utils.js
@@ -25,9 +25,9 @@
 
 var CMS = CMS || {};
 
-CMS.CWSUtils = function(url_root, timestamp, timezoned_timestamp,
+CMS.CWSUtils = function(contest_root, timestamp, timezoned_timestamp,
                         current_phase_begin, current_phase_end, phase) {
-    this.url_root = url_root;
+    this.contest_root = contest_root;
     this.last_notification = timestamp;
     this.server_timestamp = timestamp;
     this.server_timezoned_timestamp = timezoned_timestamp;
@@ -48,7 +48,7 @@ CMS.CWSUtils = function(url_root, timestamp, timezoned_timestamp,
 CMS.CWSUtils.prototype.update_notifications = function() {
     var self = this;
     $.get(
-        this.url_root + "/notifications",
+        this.contest_root + "/notifications",
         {"last_notification": this.last_notification},
         function(data) {
             var counter = 0;

--- a/cms/server/contest/static/cws_utils.js
+++ b/cms/server/contest/static/cws_utils.js
@@ -209,7 +209,7 @@ CMS.CWSUtils.prototype.update_time = function(usaco_like_contest) {
     case -2:
         // Contest hasn't started yet.
         if (server_time >= this.current_phase_end) {
-            window.location.href = this.url_root + "/";
+            window.location.href = this.contest_root;
         }
         $("#countdown_label").text(
             $("#translation_until_contest_starts").text());
@@ -233,7 +233,7 @@ CMS.CWSUtils.prototype.update_time = function(usaco_like_contest) {
     case 0:
         // Contest is currently running.
         if (server_time >= this.current_phase_end) {
-            window.location.href = this.url_root + "/";
+            window.location.href = this.contest_root;
         }
         $("#countdown_label").text($("#translation_time_left").text());
         $("#countdown").text(
@@ -243,7 +243,7 @@ CMS.CWSUtils.prototype.update_time = function(usaco_like_contest) {
         // User has already finished its time but contest hasn't
         // finished yet.
         if (server_time >= this.current_phase_end) {
-            window.location.href = this.url_root + "/";
+            window.location.href = this.contest_root;
         }
         $("#countdown_label").text(
             $("#translation_until_contest_ends").text());
@@ -268,7 +268,7 @@ CMS.CWSUtils.prototype.rel_to_abs = function(sRelPath) {
 }
 
 CMS.CWSUtils.prototype.switch_lang = function() {
-    var cookie_path = this.rel_to_abs(this.url_root + "/");
+    var cookie_path = this.rel_to_abs(this.contest_root);
     var lang = $("#lang").val();
     if (lang === "") {
         document.cookie = "language="

--- a/cms/server/contest/templates/base.html
+++ b/cms/server/contest/templates/base.html
@@ -1,213 +1,23 @@
-{% import re %}
-{% import time %}
-{% import json %}
-{% from cms import LANGUAGE_NAMES, LANGUAGE_TO_SOURCE_EXT_MAP %}
-{% from cms.server import format_amount_of_time, format_time, format_datetime, format_datetime_smart, get_score_class, encode_for_url %}
-{% from cms.grading import COMPILATION_MESSAGES, EVALUATION_MESSAGES %}
-{% from cms.db import SubmissionResult %}
-{% from cmscommon.datetime import make_timestamp, utc %}
-{% from cmscommon.isocodes import translate_language_country_code %}
 <!DOCTYPE html>
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script type="text/javascript">
-        </script>
+
+        <title>{% block title %}{% end %}</title>
+
         <link rel="shortcut icon" href="{{ url_root }}/static/favicon.ico" />
-        <script type="text/javascript" src="{{ url_root }}/static/jq/jquery-1.7.1.min.js"></script>
-        <script type="text/javascript" src="{{ url_root }}/static/js/bootstrap.js"></script>
-        <script type="text/javascript" src="{{ url_root }}/static/cws_utils.js"></script>
         <link rel="stylesheet" href="{{ url_root }}/static/css/bootstrap.css">
         <link rel="stylesheet" href="{{ url_root }}/static/cws_style.css">
 
-        <title>{{ contest.description }}</title>
+        <script type="text/javascript" src="{{ url_root }}/static/jq/jquery-1.7.1.min.js"></script>
+        <script type="text/javascript" src="{{ url_root }}/static/js/bootstrap.js"></script>
+        <script type="text/javascript" src="{{ url_root }}/static/cws_utils.js"></script>
 
-        <script type="text/javascript">
-{% if current_user is None %}
-var utils = new CMS.CWSUtils("{{ url_root }}",
-                             0, 0, 0, 0, 0);
-{% else %}
-// FIXME use Date objects
-var utils = new CMS.CWSUtils("{{ url_root }}",
-                             {{ make_timestamp(timestamp) }},
-                             {% comment What we do is: if timezone is +HH:MM we return the UNIX timestamp + 3600*HH + 60*MM. %}
-                             {{ make_timestamp(timestamp.replace(tzinfo=utc).astimezone(timezone).replace(tzinfo=None)) }},
-                             {{ make_timestamp(current_phase_begin) }},
-                             {{ make_timestamp(current_phase_end) }},
-                             {{ actual_phase }});
-$(document).ready(function () {
-    utils.update_time({{ "true" if contest.per_user_time is not None else "false" }});
-    setInterval(function() {
-        utils.update_time({{ "true" if contest.per_user_time is not None else "false" }});
-    }, 1000);
-    utils.update_notifications();
-    setInterval(function() { utils.update_notifications(); }, 30000);
-    $('#main').css('top', $('#navigation_bar').outerHeight());
-});
-
-{% block js %}{% end %}
-{% end%}
-        </script>
-
+        {% block js %}{% end %}
     </head>
-    <body id="body">
-        <div id="navigation_bar" class="navbar navbar-fixed-top">
-            <div class="navbar-inner">
-                <div class="container">
-                    <a class="brand" href="{{ url_root }}/">{{ contest.description }}</a>
-{% if len(lang_names) > 1 %}
-                    <p class="navbar-text pull-right">
-                        <select id="lang" class="form-control btn btn-info" onchange="utils.switch_lang()">
-                            <option value=""{% if cookie_lang is None %} selected{% end %}>{{ _("Automatic (%s)") % lang_names[browser_lang] }}</option>
-                        {% for lang_code, lang_name in sorted(lang_names.iteritems(), key=lambda x: x[1]) %}
-                            <option value="{{ lang_code }}"{% if cookie_lang == lang_code %} selected{% end %}>{{ lang_name }}</option>
-                        {% end %}
-                        </select>
-                    </p>
-{% end %}
-{% if current_user is not None %}
-                    <p class="navbar-text pull-right">
-                        {% raw _("Logged in as <strong>%(first_name)s %(last_name)s</strong> <em>(%(username)s)</em>") % {"first_name": escape(current_user.user.first_name), "last_name": escape(current_user.user.last_name), "username": escape(current_user.user.username)} %}
-                        <a class="btn btn-warning" href="{{ url_root }}/logout">{{ _("Logout") }}</a>
-                    </p>
-{% end %}
-                </div>
-            </div>
-        </div>
-{% if current_user is None %}
-    {% if handler.get_argument("login_error", "") != "" %}
-        <div id="notifications" class="notifications">
-            <div class="alert alert-block alert-error notification">
-                <a class="close" data-dismiss="alert" href="#">&#xD7;</a>
-                <h4 class="alert-heading">{{ _("Failed to log in.") }}</h4>
-            </div>
-        </div>
-    {% end %}
-        <div class="login_container">
-            <div class="login_box hero-unit">
-                <h1>{{ _("Welcome") }}</h1>
-                <p>{{ _("Please log in") }}</p>
-                <form class="form-horizontal" action="{{ url_root }}/login" method="POST">
-                    <input type="hidden" name="next" value="{{ handler.get_argument("next", "/") }}">
-                    <fieldset>
-                        <div class="control-group">
-                            <label class="control-label" for="input01">{{ _("Username") }}</label>
-                            <div class="controls">
-                                <input type="text" class="input-xlarge" name="username">
-                            </div>
-                        </div>
-                        <div class="control-group">
-                            <label class="control-label" for="input01">{{ _("Password") }}</label>
-                            <div class="controls">
-                                <input type="password" class="input-xlarge" name="password">
-                            </div>
-                        </div>
-                        <div class="control-group">
-                            <div class="controls">
-                                <button type="submit" class="btn btn-primary btn-large">{{ _("Login") }}</button>
-                                <button type="reset" class="btn btn-large">{{ _("Reset") }}</button>
-                            </div>
-                        </div>
-                    </fieldset>
-                </form>
-            </div>
-        </div>
-{% else %}
-        <div id="notifications" class="notifications"></div>
-        <!-- Some hidden divs to provide translations of strings used by JS -->
-        <div style="display: none" id="translation_new_message">
-            {{ _("New message") }}
-        </div>
-        <div style="display: none" id="translation_new_announcement">
-            {{ _("New announcement") }}
-        </div>
-        <div style="display: none" id="translation_new_answer">
-            {{ _("New answer") }}
-        </div>
-        <div style="display: none" id="translation_unread">
-            {{ _("%d unread") }}
-        </div>
-        <div style="display: none" id="translation_until_contest_starts">
-            {{ _("Until contest starts:") }}
-        </div>
-        <div style="display: none" id="translation_until_contest_ends">
-            {{ _("Until contest ends:") }}
-        </div>
-        <div style="display: none" id="translation_time_left">
-            {{ _("Time left:") }}
-        </div>
-        <!-- End -->
-        <div id="main" class="container">
-            <div class="row">
-                <div class="span3">
-                    <h3 id="server_time_box">
-                        <span id="server_time_label">{{ _("Server time:") }}</span>
-                        <span id="server_time"></span>
-                    </h3>
-                    <h3 id="countdown_box">
-                        <span id="countdown_label"></span>
-                        <span id="countdown"></span>
-                    </h3>
-                    <div class="well" style="padding: 8px 0;">
-                        <ul class="nav nav-list">
 
-                            <li{% if request.path == '/' %} class="active"{% end %}>
-                                <a href="{{ url_root }}/">{{ _("Overview") }}</a>
-                            </li>
-    {% set unread_count = handler.get_secure_cookie("unread_count") %}
-                            <li{% if request.path == '/communication' %}{% set unread_count = 0 %} class="active"{% end %}>
-                                <a href="{{ url_root }}/communication">{{ _("Communication") }}
-    {% if unread_count is None or int(unread_count) == 0 %}
-                                    <span id="unread_count" class="label label-warning no_unread">{{ _("%d unread") % 0 }}</span>
-    {% else %}
-                                    <script>$(document).ready(function () { utils.unread_count = {{ int(unread_count) }};});</script>
-                                    <span id="unread_count" class="label label-warning">{{ _("%d unread") % int(unread_count) }}</span>
-    {% end %}
-                                    </a>
-                            </li>
-    {% if actual_phase == 0 or current_user.unrestricted %}
-        {% for t_iter in contest.tasks %}
-                            <li class="nav-header">
-                                {{ t_iter.name }}
-                            </li>
-                            <li{% if request.path == '/tasks/%s/description' % encode_for_url(t_iter.name) %} class="active"{% end %}>
-                                <a href="{{ url_root }}/tasks/{{ encode_for_url(t_iter.name) }}/description">{{ _("Statement") }}</a>
-                            </li>
-                            <li{% if request.path == '/tasks/%s/submissions' % encode_for_url(t_iter.name) %} class="active"{% end %}>
-                                <a href="{{ url_root }}/tasks/{{ encode_for_url(t_iter.name) }}/submissions">{{ _("Submissions") }}</a>
-                            </li>
-        {% end %}
-    {% end %}
-                            <li class="divider"></li>
-                            <li{% if request.path == '/documentation' %} class="active"{% end %}>
-                                <a href="{{ url_root }}/documentation">{{ _("Documentation") }}</a>
-                            </li>
-    {% if actual_phase == 0 or current_user.unrestricted %}{% comment FIXME maybe >= 0? %}
-        {% if testing_enabled %}
-                            <li{% if request.path == '/testing' %} class="active"{% end %}>
-                                <a href="{{ url_root }}/testing">{{ _("Testing") }}</a>
-                            </li>
-        {% end %}
-        {% if printing_enabled %}
-                            <li{% if request.path == '/printing' %} class="active"{% end %}>
-                                <a href="{{ url_root }}/printing">{{ _("Printing") }}</a>
-                            </li>
-        {% end %}
-    {% end %}
-                        </ul>
-                    </div>
-                    <span class="license_notice">
-                    <a href="http://github.com/cms-dev/cms/" rel="author noreferrer" target="_blank">{{ _("Contest Management System") }}</a>
-                    {{ _("is released under the") }}
-                    <a href="http://www.gnu.org/licenses/agpl" rel="license noreferrer" target="_blank">{{ _("GNU Affero General Public License") }}</a>
-                    .
-                    </span>
-                </div>
-    {% block core %}{% end %}
-            </div>
-        </div>
-
-{% end %}
+    <body>
+        {% block body %}{% end %}
     </body>
 </html>

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -1,4 +1,4 @@
-{% extends base.html %}
+{% extends contest.html %}
 {% block core %}
 <div class="span9">
 
@@ -33,7 +33,7 @@
 
 <h2>{{ _("Questions") }}</h2>
 <div class="well question_submit">
-    <form class="form-horizontal" action="{{ url_root }}/question" method="POST">
+    <form class="form-horizontal" action="{{ contest_root }}/question" method="POST">
         <fieldset>
             <div class="control-group">
                 <label class="control-label" for="input_subject">{{ _("Subject") }}</label>

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -1,0 +1,205 @@
+{% extends base.html %}
+
+{% block title %}
+    {{ contest.description }}
+{% end %}
+
+{% block js %}
+
+{% import re %}
+{% import time %}
+{% import json %}
+{% from cms import LANGUAGE_NAMES, LANGUAGE_TO_SOURCE_EXT_MAP %}
+{% from cms.server import format_amount_of_time, format_time, format_datetime, format_datetime_smart, get_score_class, encode_for_url %}
+{% from cms.grading import COMPILATION_MESSAGES, EVALUATION_MESSAGES %}
+{% from cms.db import SubmissionResult %}
+{% from cmscommon.datetime import make_timestamp, utc %}
+{% from cmscommon.isocodes import translate_language_country_code %}
+
+    <script type="text/javascript">
+    {% if current_user is None %}
+    var utils = new CMS.CWSUtils("{{ contest_root }}",
+                                 0, 0, 0, 0, 0);
+    {% else %}
+    // FIXME use Date objects
+    var utils = new CMS.CWSUtils("{{ contest_root }}",
+                                 {{ make_timestamp(timestamp) }},
+                                 {% comment What we do is: if timezone is +HH:MM we return the UNIX timestamp + 3600*HH + 60*MM. %}
+                                 {{ make_timestamp(timestamp.replace(tzinfo=utc).astimezone(timezone).replace(tzinfo=None)) }},
+                                 {{ make_timestamp(current_phase_begin) }},
+                                 {{ make_timestamp(current_phase_end) }},
+                                 {{ actual_phase }});
+    $(document).ready(function () {
+        utils.update_time({{ "true" if contest.per_user_time is not None else "false" }});
+        setInterval(function() {
+            utils.update_time({{ "true" if contest.per_user_time is not None else "false" }});
+        }, 1000);
+        utils.update_notifications();
+        setInterval(function() { utils.update_notifications(); }, 30000);
+        $('#main').css('top', $('#navigation_bar').outerHeight());
+    });
+    {% end%}
+
+    {% block additional_js %}{% end %}
+    </script>
+{% end %}
+
+{% block body %}
+        <div id="navigation_bar" class="navbar navbar-fixed-top">
+            <div class="navbar-inner">
+                <div class="container">
+                    <a class="brand" href="{{ contest_root }}">{{ contest.description }}</a>
+{% if len(lang_names) > 1 %}
+                    <p class="navbar-text pull-right">
+                        <select id="lang" class="form-control btn btn-info" onchange="utils.switch_lang()">
+                            <option value=""{% if cookie_lang is None %} selected{% end %}>{{ _("Automatic (%s)") % lang_names[browser_lang] }}</option>
+                        {% for lang_code, lang_name in sorted(lang_names.iteritems(), key=lambda x: x[1]) %}
+                            <option value="{{ lang_code }}"{% if cookie_lang == lang_code %} selected{% end %}>{{ lang_name }}</option>
+                        {% end %}
+                        </select>
+                    </p>
+{% end %}
+{% if current_user is not None %}
+                    <p class="navbar-text pull-right">
+                        {% raw _("Logged in as <strong>%(first_name)s %(last_name)s</strong> <em>(%(username)s)</em>") % {"first_name": escape(current_user.user.first_name), "last_name": escape(current_user.user.last_name), "username": escape(current_user.user.username)} %}
+                        <a class="btn btn-warning" href="{{ contest_root }}/logout">{{ _("Logout") }}</a>
+                    </p>
+{% end %}
+                </div>
+            </div>
+        </div>
+{% if current_user is None %}
+    {% if handler.get_argument("login_error", "") != "" %}
+        <div id="notifications" class="notifications">
+            <div class="alert alert-block alert-error notification">
+                <a class="close" data-dismiss="alert" href="#">&#xD7;</a>
+                <h4 class="alert-heading">{{ _("Failed to log in.") }}</h4>
+            </div>
+        </div>
+    {% end %}
+        <div class="login_container">
+            <div class="login_box hero-unit">
+                <h1>{{ _("Welcome") }}</h1>
+                <p>{{ _("Please log in") }}</p>
+                <form class="form-horizontal" action="{{ contest_root }}/login" method="POST">
+                    <input type="hidden" name="next" value="{{ handler.get_argument("next", real_contest_root) }}">
+                    <fieldset>
+                        <div class="control-group">
+                            <label class="control-label" for="input01">{{ _("Username") }}</label>
+                            <div class="controls">
+                                <input type="text" class="input-xlarge" name="username">
+                            </div>
+                        </div>
+                        <div class="control-group">
+                            <label class="control-label" for="input01">{{ _("Password") }}</label>
+                            <div class="controls">
+                                <input type="password" class="input-xlarge" name="password">
+                            </div>
+                        </div>
+                        <div class="control-group">
+                            <div class="controls">
+                                <button type="submit" class="btn btn-primary btn-large">{{ _("Login") }}</button>
+                                <button type="reset" class="btn btn-large">{{ _("Reset") }}</button>
+                            </div>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+{% else %}
+        <div id="notifications" class="notifications"></div>
+        <!-- Some hidden divs to provide translations of strings used by JS -->
+        <div style="display: none" id="translation_new_message">
+            {{ _("New message") }}
+        </div>
+        <div style="display: none" id="translation_new_announcement">
+            {{ _("New announcement") }}
+        </div>
+        <div style="display: none" id="translation_new_answer">
+            {{ _("New answer") }}
+        </div>
+        <div style="display: none" id="translation_unread">
+            {{ _("%d unread") }}
+        </div>
+        <div style="display: none" id="translation_until_contest_starts">
+            {{ _("Until contest starts:") }}
+        </div>
+        <div style="display: none" id="translation_until_contest_ends">
+            {{ _("Until contest ends:") }}
+        </div>
+        <div style="display: none" id="translation_time_left">
+            {{ _("Time left:") }}
+        </div>
+        <!-- End -->
+        <div id="main" class="container">
+            <div class="row">
+                <div class="span3">
+                    <h3 id="server_time_box">
+                        <span id="server_time_label">{{ _("Server time:") }}</span>
+                        <span id="server_time"></span>
+                    </h3>
+                    <h3 id="countdown_box">
+                        <span id="countdown_label"></span>
+                        <span id="countdown"></span>
+                    </h3>
+                    <div class="well" style="padding: 8px 0;">
+                        <ul class="nav nav-list">
+
+                            <li{% if request.path == '/' %} class="active"{% end %}>
+                                <a href="{{ contest_root }}">{{ _("Overview") }}</a>
+                            </li>
+    {% set unread_count = handler.get_secure_cookie("unread_count") %}
+                            <li{% if request.path == '/communication' %}{% set unread_count = 0 %} class="active"{% end %}>
+                                <a href="{{ contest_root }}/communication">{{ _("Communication") }}
+    {% if unread_count is None or int(unread_count) == 0 %}
+                                    <span id="unread_count" class="label label-warning no_unread">{{ _("%d unread") % 0 }}</span>
+    {% else %}
+                                    <script>$(document).ready(function () { utils.unread_count = {{ int(unread_count) }};});</script>
+                                    <span id="unread_count" class="label label-warning">{{ _("%d unread") % int(unread_count) }}</span>
+    {% end %}
+                                    </a>
+                            </li>
+    {% if actual_phase == 0 or current_user.unrestricted %}
+        {% for t_iter in contest.tasks %}
+                            <li class="nav-header">
+                                {{ t_iter.name }}
+                            </li>
+                            <li{% if request.path == '/tasks/%s/description' % encode_for_url(t_iter.name) %} class="active"{% end %}>
+                                <a href="{{ contest_root }}/tasks/{{ encode_for_url(t_iter.name) }}/description">{{ _("Statement") }}</a>
+                            </li>
+                            <li{% if request.path == '/tasks/%s/submissions' % encode_for_url(t_iter.name) %} class="active"{% end %}>
+                                <a href="{{ contest_root }}/tasks/{{ encode_for_url(t_iter.name) }}/submissions">{{ _("Submissions") }}</a>
+                            </li>
+        {% end %}
+    {% end %}
+                            <li class="divider"></li>
+                            <li{% if request.path == '/documentation' %} class="active"{% end %}>
+                                <a href="{{ contest_root }}/documentation">{{ _("Documentation") }}</a>
+                            </li>
+    {% if actual_phase == 0 or current_user.unrestricted %}{% comment FIXME maybe >= 0? %}
+        {% if testing_enabled %}
+                            <li{% if request.path == '/testing' %} class="active"{% end %}>
+                                <a href="{{ contest_root }}/testing">{{ _("Testing") }}</a>
+                            </li>
+        {% end %}
+        {% if printing_enabled %}
+                            <li{% if request.path == '/printing' %} class="active"{% end %}>
+                                <a href="{{ contest_root }}/printing">{{ _("Printing") }}</a>
+                            </li>
+        {% end %}
+    {% end %}
+                        </ul>
+                    </div>
+                    <span class="license_notice">
+                    <a href="http://github.com/cms-dev/cms/" rel="author noreferrer" target="_blank">{{ _("Contest Management System") }}</a>
+                    {{ _("is released under the") }}
+                    <a href="http://www.gnu.org/licenses/agpl" rel="license noreferrer" target="_blank">{{ _("GNU Affero General Public License") }}</a>
+                    .
+                    </span>
+                </div>
+    {% block core %}{% end %}
+            </div>
+        </div>
+
+{% end %}
+{% end %}

--- a/cms/server/contest/templates/contest_list.html
+++ b/cms/server/contest/templates/contest_list.html
@@ -1,0 +1,16 @@
+{% extends base.html %}
+{% block title %}
+    Choose a contest
+{% end %}
+{% block body %}
+    <div class="hero-unit contest-list">
+        <h3>Choose a contest</h3>
+        <ul class="nav nav-list">
+    {% for c_name, c_iter in contest_list.iteritems() %}
+            <li>
+                <a {% if c_iter.stop < datetime.datetime.now() %} style="color: #adadad" {% end %} href="{{ url_root }}/{{ c_iter.name }}">{{ c_iter.description }}</a>
+            </li>
+    {% end %}
+        </ul>
+    </div>
+{% end %}

--- a/cms/server/contest/templates/documentation.html
+++ b/cms/server/contest/templates/documentation.html
@@ -1,4 +1,4 @@
-{% extends base.html %}
+{% extends contest.html %}
 {% block core %}
 <div class="span9">
 
@@ -8,7 +8,7 @@
 
 <h2>{{ _("Programming languages and libraries") }}</h2>
 
-<a href="{{ url_root }}/stl/index.html">{{ _("Standard Template Library") }}</a>
+<a href="{{ contest_root }}/stl/index.html">{{ _("Standard Template Library") }}</a>
 
 <h2>{{ _("Submission details for compilation") }}</h2>
 

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -1,4 +1,4 @@
-{% extends base.html %}
+{% extends contest.html %}
 {% block core %}
 
 {% from cms.server import format_token_rules, format_datetime_smart %}
@@ -128,8 +128,8 @@
             </p>
 
     {% if actual_phase == -1 %}
-        <form action="{{ url_root }}/start" method="POST" style="margin: 0">
-            <input type="hidden" name="next" value="{{ url_root + request.path }}">
+        <form action="{{ contest_root }}/start" method="POST" style="margin: 0">
+            <input type="hidden" name="next" value="{{ contest_root + request.path }}">
             <button type="submit" class="btn btn-danger btn-large" style="width:100%;-moz-box-sizing:border-box;box-sizing:border-box;" type="submit">{{ _("Start!") }}</button>
         </form>
     {% end %}

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -1,4 +1,4 @@
-{% extends base.html %}
+{% extends contest.html %}
 
 {% block core %}
 
@@ -20,7 +20,7 @@
     {% end %}
 
 <div id="print" class="row">
-    <form class="form-horizontal" enctype="multipart/form-data" action="{{ url_root }}/printing" method="POST">
+    <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_root }}/printing" method="POST">
         <fieldset>
             <div class="control-group">
                 <label class="control-label" for="input">{% if pdf_printing_allowed %}{{ _("File (text or PDF)") }}{% else %}{{ _("File (text)") }}{% end %}</label>

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -92,7 +92,7 @@
             {% if s.language is not None %}
                 {% set filename = re.sub("\.%l$", ".%s" % s.language, filename) %}
             {% end %}
-        <a class="btn" href="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/submissions/{{ s_idx }}/files/{{ encode_for_url(filename) }}">
+        <a class="btn" href="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/submissions/{{ s_idx }}/files/{{ encode_for_url(filename) }}">
             {{ _("Download") }}
         </a>
         {% else %}
@@ -110,7 +110,7 @@
                     {% end %}
                 {% end %}
                 <li>
-                    <a href="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/submissions/{{ s_idx }}/files/{{ encode_for_url(filename) }}">
+                    <a href="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/submissions/{{ s_idx }}/files/{{ encode_for_url(filename) }}">
                         {{ filename }}
                     </a>
                 </li>
@@ -127,7 +127,7 @@
         {% else %}
             {% comment TODO If the expiration or generation time are greater than valid_phase_end they "don't exist". It's useless to show "Wait..." in those cases. %}
             {% if can_play_token and not need_to_wait %}
-        <form action="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/submissions/{{ s_idx }}/token" method="POST">
+        <form action="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/submissions/{{ s_idx }}/token" method="POST">
             <button type="submit" class="btn btn-warning">{{ _("Play!") }}</button>
         </form>
             {% elif (can_play_token and need_to_wait) or (not can_play_token and tokens_info[1] is not None) %}

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -1,4 +1,4 @@
-{% extends base.html %}
+{% extends contest.html %}
 {% block core %}
 
 {% from cms.server import format_token_rules, format_size %}
@@ -27,7 +27,7 @@
 <div class="row statement one_statement">
     <div class="span9">
     {% for lang_code in task.statements %}
-        <a href="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/statements/{{ encode_for_url(lang_code) }}" class="btn btn-large btn-success">{{ _("Download task statement") }}</a>
+        <a href="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/statements/{{ encode_for_url(lang_code) }}" class="btn btn-large btn-success">{{ _("Download task statement") }}</a>
     {% end %}
     </div>
 </div>
@@ -42,7 +42,7 @@
     {% set task_primary = json.loads(task.primary_statements) %}
     {% for statement in sorted(task.statements.itervalues(), key=lambda x: x.language_name) %}
         {% if statement.language in task_primary %}
-        <a href="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/statements/{{ encode_for_url(statement.language) }}" class="btn btn-large btn-success">
+        <a href="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/statements/{{ encode_for_url(statement.language) }}" class="btn btn-large btn-success">
             {% if statement.language != statement.language_name %}
                 {% raw _("Statement in <b>%s</b>") % escape(statement.language_name) %}
             {% else %}
@@ -54,7 +54,7 @@
     {% set user_primary = json.loads(current_user.user.preferred_languages) %}
     {% for statement in sorted(task.statements.itervalues(), key=lambda x: x.language_name) %}
         {% if statement.language in user_primary and statement.language not in task_primary %}
-        <a href="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/statements/{{ encode_for_url(statement.language) }}" class="btn btn-large">
+        <a href="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/statements/{{ encode_for_url(statement.language) }}" class="btn btn-large">
             {% if statement.language != statement.language_name %}
                 {% raw _("Statement in <b>%s</b>") % escape(statement.language_name) %}
             {% else %}
@@ -69,7 +69,7 @@
             <ul>
     {% for statement in sorted(task.statements.itervalues(), key=lambda x: x.language_name) %}
                 <li>
-                    <a href="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/statements/{{ encode_for_url(statement.language) }}">
+                    <a href="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/statements/{{ encode_for_url(statement.language) }}">
         {% if statement.language != statement.language_name %}
             {% raw _("<b>%s</b>") % escape(statement.language_name) %}
         {% else %}
@@ -151,7 +151,7 @@
         </p>
     {% elif tokens_tasks == 2 %}
         <p>
-        {% raw _("You can find the rules for the %(type_pl)s on the <a href=\"%(url_root)s/\">contest overview page</a>.") % {"type_pl": _("tokens"), "url_root": url_root} %}
+        {% raw _("You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>.") % {"type_pl": _("tokens"), "contest_root": contest_root} %}
         </p>
     {% else %}
         <p>
@@ -161,7 +161,7 @@
 
         <p>
         {{ _("Remeber that to see the detailed result of a submission you need to use both a contest-token and a task-token.") }}
-        {% raw _("You can find the rules for the %(type_pl)s on the <a href=\"%(url_root)s/\">contest overview page</a>.") % {"type_pl": _("contest-tokens"), "url_root": url_root} %}
+        {% raw _("You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>.") % {"type_pl": _("contest-tokens"), "contest_root": contest_root} %}
         </p>
     {% end %}
     </td>
@@ -188,7 +188,7 @@
         {% end %}
         {% set file_size = handler.application.service.file_cacher.get_size(attachment.digest) %}
             <li>
-                <a href="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/attachments/{{ encode_for_url(filename) }}" class="btn">
+                <a href="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/attachments/{{ encode_for_url(filename) }}" class="btn">
             {% if type_icon is not None %}
                     <img src="{{ url_root }}/static/img/mimetypes/{{ type_icon }}.png"/>
             {% else %}

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -1,13 +1,13 @@
-{% extends base.html %}
+{% extends contest.html %}
 
-{% block js %}
+{% block additional_js %}
 
 $(document).on("click", "#submission_list tbody tr td.status .details", function (event) {
     var submission_id = $(this).parent().parent().attr("data-submission");
     var modal = $("#submission_detail");
     var modal_body = modal.children(".modal-body");
     modal_body.html('<div class="loading"><img src="{{ url_root }}/static/loading.gif"/>{{ _("loading...") }}</div>');
-    modal_body.load("{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/submissions/" + submission_id + "/details", function() {
+    modal_body.load("{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/submissions/" + submission_id + "/details", function() {
         $(".score_details .subtask .subtask-head").each(function () {
             $(this).prepend("<i class=\"icon-chevron-right\"></i>");
         });
@@ -60,7 +60,7 @@ update_submission_row = function (submission_id, data) {
 
 schedule_update_submission_row = function (submission_id) {
     setTimeout(function () {
-        $.get("{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/submissions/" + submission_id, function (data) {
+        $.get("{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/submissions/" + submission_id, function (data) {
             update_submission_row(submission_id, data);
         });
     }, 10000);
@@ -97,7 +97,7 @@ $(document).ready(function () {
 
 <div id="submit_solution" class="row">
     <div class="span5">
-        <form class="form-horizontal" enctype="multipart/form-data" action="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/submit" method="POST">
+        <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/submit" method="POST">
             <fieldset>
 {% for idx, filename in enumerate(x.filename for x in task.submission_format) %}
                 <div class="control-group">
@@ -118,7 +118,7 @@ $(document).ready(function () {
     </div>
 {% if len(task.submission_format) > 1 %}
     <div class="span4">
-        <form class="form-horizontal" enctype="multipart/form-data" action="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/submit" method="POST">
+        <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/submit" method="POST">
             <fieldset>
                 <div class="control-group">
                     <label class="control-label" for="input_zip">{{ _("submission.zip") }}</label>

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -1,7 +1,6 @@
-{% extends base.html %}
+{% extends contest.html %}
 
-{% block js %}
-
+{% block additional_js %}
 $(document).on("click", ".user_test_list tbody tr td.status .details", function (event) {
     var $this = $(this);
     var task_id = $this.parent().parent().parent().parent().attr("data-task");
@@ -9,7 +8,7 @@ $(document).on("click", ".user_test_list tbody tr td.status .details", function 
     var modal = $("#user_test_detail");
     var modal_body = modal.children(".modal-body");
     modal_body.html('<div class="loading"><img src="{{ url_root }}/static/loading.gif"/>{{ _("loading...") }}</div>');
-    modal_body.load("{{ url_root }}/tasks/" + encodeURIComponent(task_id) + "/tests/" + user_test_id + "/details");
+    modal_body.load("{{ contest_root }}/tasks/" + encodeURIComponent(task_id) + "/tests/" + user_test_id + "/details");
     modal.modal("show");
 });
 
@@ -22,7 +21,7 @@ update_user_test_row = function (task_id, user_test_id, data) {
             var btn = row.children("td.output").children("a.btn");
             btn.text('{{ _("Download") }}');
             btn.removeClass("disabled");
-            btn.attr("href", "{{ url_root }}/tasks/" + encodeURIComponent(task_id) + "/tests/" + user_test_id + "/output");
+            btn.attr("href", "{{ contest_root }}/tasks/" + encodeURIComponent(task_id) + "/tests/" + user_test_id + "/output");
         } else {
             row.children("td.output").children("a.btn").text("{{ _("N/A") }}");
         }
@@ -43,7 +42,7 @@ update_user_test_row = function (task_id, user_test_id, data) {
 
 schedule_update_user_test_row = function (task_id, user_test_id) {
     setTimeout(function () {
-        $.get("{{ url_root }}/tasks/" + encodeURIComponent(task_id) + "/tests/" + user_test_id, function (data) {
+        $.get("{{ contest_root }}/tasks/" + encodeURIComponent(task_id) + "/tests/" + user_test_id, function (data) {
             update_user_test_row(task_id, user_test_id, data);
         });
     }, 2000);
@@ -55,7 +54,6 @@ $(document).ready(function () {
         schedule_update_user_test_row($this.parent().parent().attr("data-task"), $this.attr("data-user-test"));
     });
 });
-
 {% end %}
 
 {% block core %}
@@ -98,7 +96,7 @@ $(document).ready(function () {
 
 <div class="submit_test row">
     <div class="span5">
-        <form class="form-horizontal" enctype="multipart/form-data" action="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/test" method="POST">
+        <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/test" method="POST">
             <fieldset>
 {% for idx, filename in enumerate([x.filename for x in task.submission_format] + task_type.get_user_managers(task.submission_format)) %}
                 <div class="control-group">
@@ -124,7 +122,7 @@ $(document).ready(function () {
         </form>
     </div>
     <div class="span4">
-        <form class="form-horizontal" enctype="multipart/form-data" action="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/test" method="POST">
+        <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/test" method="POST">
             <fieldset>
                 <div class="control-group">
                     <label class="control-label" for="input_zip">{{ _("submission.zip") }}</label>

--- a/cms/server/contest/templates/user_test_row.html
+++ b/cms/server/contest/templates/user_test_row.html
@@ -50,7 +50,7 @@
     </td>
 {% end %}
     <td class="input">
-        <a class="btn" href="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/tests/{{ t_idx }}/input">
+        <a class="btn" href="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/tests/{{ t_idx }}/input">
             {{ _("Download") }}
         </a>
     </td>
@@ -65,7 +65,7 @@
             {{ _("N/A") }}
         </a>
         {% else %}
-        <a class="btn btn-primary" href="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/tests/{{ t_idx }}/output">
+        <a class="btn btn-primary" href="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/tests/{{ t_idx }}/output">
             {{ _("Download") }}
         </a>
         {% end %}
@@ -82,7 +82,7 @@
         </a>
         {% elif len(files) == 1 %}
             {% set filename = t.files.keys()[0] %}
-        <a class="btn" href="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/tests/{{ t_idx }}/files/{{ encode_for_url(filename) }}">
+        <a class="btn" href="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/tests/{{ t_idx }}/files/{{ encode_for_url(filename) }}">
             {{ _("Download") }}
         </a>
         {% else %}
@@ -99,7 +99,7 @@
                     {% set real_filename = filename %}
                 {% end %}
                 <li>
-                    <a href="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/tests/{{ t_idx }}/files/{{ encode_for_url(filename) }}">
+                    <a href="{{ contest_root }}/tasks/{{ encode_for_url(task.name) }}/tests/{{ t_idx }}/files/{{ encode_for_url(filename) }}">
                         {{ real_filename }}
                     </a>
                 </li>

--- a/cms/server/util.py
+++ b/cms/server/util.py
@@ -711,13 +711,19 @@ class CommonRequestHandler(RequestHandler):
         return self.application.service
 
     def redirect(self, url):
-        url = get_url_root(self.request.path) + url
+        """This method overrides tornado.web.RequestHandler.redirect()
 
-        # We would prefer to just use this:
-        #   tornado.web.RequestHandler.redirect(self, url)
-        # but unfortunately that assumes it knows the full path to the current
-        # page to generate an absolute URL. This may not be the case if we are
-        # hidden behind a proxy which is remapping part of its URL space to us.
+        We would prefer not to override this, but the parent method assumes it
+        knows the full path to the current page to generate an absolute URL.
+        This may not be the case if we are hidden behind a proxy which is
+        remapping part of its URL space to us.
+
+        url (string): a URL starting with a forward slash, e.g. "/stuff"
+
+        """
+        # We don't use os.path.join here, because we need something like this:
+        # ".." + "/stuff" to become: "../stuff" not: "/stuff"
+        url = get_url_root(self.request.path) + url
 
         self.set_status(302)
         self.set_header("Location", url)

--- a/cms/server/util.py
+++ b/cms/server/util.py
@@ -7,6 +7,7 @@
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2012-2016 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
+# Copyright © 2016 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -178,6 +179,22 @@ def compute_actual_phase(timestamp, contest_start, contest_stop, per_user_time,
     return (actual_phase,
             current_phase_begin, current_phase_end,
             actual_start, actual_stop)
+
+
+def multi_contest(f):
+    """Return decorator allowing not to specify the "contest_name"
+    parameter, whenever a method requires it.
+
+    """
+    def wrapped_f(*args):
+        # If no contest was selected
+        if args[0].application.service.contest is None:
+            # Send all URL parameters
+            f(*args)
+        else:
+            # Send a fake "contest_name" URL parameter
+            f(args[0], None, *(args[1:]))
+    return wrapped_f
 
 
 def actual_phase_required(*actual_phases):

--- a/cms/util.py
+++ b/cms/util.py
@@ -6,6 +6,7 @@
 # Copyright © 2010-2014 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2013 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2016 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -231,19 +232,20 @@ def default_argument_parser(description, cls, ask_contest=None):
                           "no shard specified for service %s, "
                           "quitting." % (cls.__name__))
 
-    if ask_contest is not None:
-        if args.contest_id is not None:
-            # Test if there is a contest with the given contest id.
-            from cms.db import is_contest_id
-            if not is_contest_id(args.contest_id):
-                print("There is no contest with the specified id. "
-                      "Please try again.", file=sys.stderr)
-                sys.exit(1)
-            return cls(args.shard, args.contest_id)
-        else:
-            return cls(args.shard, ask_contest())
+    if args.contest_id is not None:
+        contest_id = args.contest_id
+    elif ask_contest is not None:
+        contest_id = ask_contest()
     else:
         return cls(args.shard)
+
+    # Test if there is a contest with the given contest id.
+    from cms.db import is_contest_id
+    if not is_contest_id(contest_id):
+        print("There is no contest with the specified id. "
+              "Please try again.", file=sys.stderr)
+        sys.exit(1)
+    return cls(args.shard, contest_id)
 
 
 def _find_local_addresses():

--- a/scripts/cmsContestWebServer
+++ b/scripts/cmsContestWebServer
@@ -30,7 +30,7 @@ import logging
 import sys
 
 from cms import ConfigError, default_argument_parser
-from cms.db import ask_for_contest, test_db_connection
+from cms.db import test_db_connection
 from cms.server.contest import ContestWebServer
 
 
@@ -43,8 +43,7 @@ def main():
     """
     test_db_connection()
     return default_argument_parser("Contestants' web server for CMS.",
-                                   ContestWebServer,
-                                   ask_contest=ask_for_contest).run()
+                                   ContestWebServer).run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With this patch, ContestWebServer does not require a `-c` flag anymore. When you start CWS, it will expose a list of all available contests on `/`, and you can click on the contest that you're interested in.

The former cookie behavior was to save 2 cookies: `login` and `unread_count`. The new cookie behavior is to save 2*N cookies where N is the number of contests. Each cookie will either be `<contest-name>_login` or `<contest-name>_unread_count`.

This PR depends on #545

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/594)

<!-- Reviewable:end -->
