### PR TITLE
Allow password authentication with enabled autologin

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -9,6 +9,7 @@
 # Copyright © 2013 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
 # Copyright © 2016 Masaki Hara <ackie.h.gmai@gmail.com>
+# Copyright © 2016 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -83,8 +84,7 @@ __all__ = [
 
 # Instantiate or import these objects.
 
-version = 23
-
+version = 24
 
 engine = create_engine(config.database, echo=config.database_debug,
                        pool_size=20, max_overflow=20, pool_recycle=120)

--- a/cms/db/contest.py
+++ b/cms/db/contest.py
@@ -107,6 +107,12 @@ class Contest(Base):
         nullable=False,
         default=False)
 
+    # Whether to allow username/password authentication
+    allow_password_authentication = Column(
+        Boolean,
+        nullable=False,
+        default=True)
+
     # Whether to enforce that the IP address of the request matches
     # the IP address or subnet specified for the participation (if
     # present).

--- a/cms/server/admin/handlers/contest.py
+++ b/cms/server/admin/handlers/contest.py
@@ -9,6 +9,7 @@
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
 # Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
+# Copyright © 2016 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -101,6 +102,7 @@ class ContestHandler(SimpleContestHandler("contest.html")):
             self.get_bool(attrs, "allow_questions")
             self.get_bool(attrs, "allow_user_tests")
             self.get_bool(attrs, "block_hidden_participations")
+            self.get_bool(attrs, "allow_password_authentication")
             self.get_bool(attrs, "ip_restriction")
             self.get_bool(attrs, "ip_autologin")
 

--- a/cms/server/admin/templates/contest.html
+++ b/cms/server/admin/templates/contest.html
@@ -101,6 +101,15 @@
     </tr>
     <tr>
       <td>
+        <span class="info" title="If checked, contestants will be able to log in using username and password."></span>
+        <label for="allow_password_authentication">Allow password authentication</label>
+      </td>
+      <td>
+        <input type="checkbox" id="allow_password_authentication" name="allow_password_authentication" {{ "checked" if contest.allow_password_authentication else "" }}/>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <span class="info" title="If true, contestants with an IP address specified for this contest will only be able to log in from that address."></span>
         <label for="ip_restriction">IP based login restriction</label>
       </td>

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -11,6 +11,7 @@
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
 # Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
 # Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
+# Copyright © 2016 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -126,19 +127,31 @@ class BaseHandler(CommonRequestHandler):
         remote_ip = self.request.remote_ip
         if self.contest.ip_autologin:
             self.clear_cookie("login")
+
             participations = self.sql_session.query(Participation)\
                 .filter(Participation.contest == self.contest)\
-                .filter(Participation.ip == remote_ip)\
-                .all()
+                .filter(Participation.ip == remote_ip)
+
+            # If hidden users are blocked we ignore them completely.
+            if self.contest.block_hidden_participations:
+                participations = participations\
+                    .filter(Participation.hidden == False)
+
+            participations = participations.all()
+
             if len(participations) == 1:
                 return participations[0]
 
+            # Having more than participation with the same IP,
+            # is a mistake and should not happen. In such case,
+            # we disallow login for that IP completely, in order to
+            # make sure the problem is noticed.
             if len(participations) > 1:
-                logger.error("Multiple users have IP %s." % (remote_ip))
-            else:
-                logger.error("No user has IP %s" % (remote_ip))
+                logger.error("Multiple participants have IP %s while"
+                             "auto-login feature is enabled." % remote_ip)
+                return None
 
-            # If IP autologin is set, we do not allow password logins.
+        if not self.contest.allow_password_authentication:
             return None
 
         if self.get_secure_cookie("login") is None:

--- a/cmscontrib/updaters/update_24.py
+++ b/cmscontrib/updaters/update_24.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2016 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A class to update a dump created by CMS.
+
+Used by ContestImporter and DumpUpdater.
+
+This updater just adds the default values for the new field
+(allow_password_authentication).
+
+"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+
+class Updater(object):
+
+    def __init__(self, data):
+        assert data["_version"] == 23
+        self.objs = data
+
+    def run(self):
+        for k, v in self.objs.iteritems():
+            if k.startswith("_"):
+                continue
+            if v["_class"] == "Contest":
+                v["allow_password_authentication"] = True
+
+        return self.objs

--- a/cmstestsuite/testrunner.py
+++ b/cmstestsuite/testrunner.py
@@ -3,6 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2016 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -148,6 +149,7 @@ class TestRunner(object):
             name="testcontest" + str(self.rand),
             description="A test contest #%s." % self.rand,
             languages=LANGUAGES,
+            allow_password_authentication="checked",
             start=start_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
             stop=stop_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
             timezone=get_system_timezone(),


### PR DESCRIPTION
Fixing the problem mentioned in #596.
Added a new boolean to contests to enable/disable password authentication. If enabled it can be used even when IP auto-login feature is available. However it may only be used when the current IP isn't assigned to any user that can login(i.e. If the IP is assigned only to hidden users and hidden users are blocked it can still login using password authentication method).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/603)
<!-- Reviewable:end -->
