### PR TITLE
Fixed multiple errors in TwoSteps' implementation.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -37,5 +37,6 @@ Kenneth Wong <kenneth@wong.pro>
 Minwei Xu (aka vanshady) <faceswilliam@gmail.com>
 Myungwoo Chun <mc.tamaki@gmail.com>
 wafrelka <wafrelka@gmail.com>
+Petar Veličković <pv273@cam.ac.uk>
 And many other people that didn't write code, but provided useful
 comments, suggestions and feedback. :-)

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -32,8 +32,9 @@ from cms import LANGUAGES, LANGUAGE_TO_SOURCE_EXT_MAP, \
     LANGUAGE_TO_HEADER_EXT_MAP, config
 from cms.grading.Sandbox import wait_without_std
 from cms.grading import get_compilation_commands, compilation_step, \
-    evaluation_step_before_run, evaluation_step_after_run, \
-    is_evaluation_passed, human_evaluation_message, white_diff_step
+    evaluation_step, evaluation_step_before_run, evaluation_step_after_run, \
+    is_evaluation_passed, human_evaluation_message, \
+    extract_outcome_and_text, white_diff_step
 from cms.grading.TaskType import TaskType, \
     create_sandbox, delete_sandbox
 from cms.db import Executable
@@ -71,21 +72,27 @@ class TwoSteps(TaskType):
         res = dict()
         for language in LANGUAGES:
             source_ext = LANGUAGE_TO_SOURCE_EXT_MAP[language]
-            header_ext = LANGUAGE_TO_HEADER_EXT_MAP[language]
+            header_ext = None
+            # Fixing error 500---add only headers for languages that have a defined header_ext!
+            if language in LANGUAGE_TO_HEADER_EXT_MAP:
+                header_ext = LANGUAGE_TO_HEADER_EXT_MAP[language]
             source_filenames = []
+            # Manager 
+            # (N.B. needs to go first, otherwise Pascal compilation command will be wrong!).
+            manager_source_filename = "manager%s" % source_ext
+            source_filenames.append(manager_source_filename)
+            # Manager's header.     
+            if header_ext != None:
+                manager_header_filename = "manager%s" % header_ext
+                source_filenames.append(manager_header_filename)
+
             for filename in submission_format:
                 source_filename = filename.replace(".%l", source_ext)
                 source_filenames.append(source_filename)
-                # Headers.
-                header_filename = filename.replace(".%l", header_ext)
-                source_filenames.append(header_filename)
-
-            # Manager.
-            manager_source_filename = "manager%s" % source_ext
-            source_filenames.append(manager_source_filename)
-            # Manager's header.
-            manager_header_filename = "manager%s" % header_ext
-            source_filenames.append(manager_header_filename)
+                # Headers (Fixing error 500 again here).
+                if header_ext != None:
+                    header_filename = filename.replace(".%l", header_ext)
+                    source_filenames.append(header_filename)
 
             # Get compilation command and compile.
             executable_filename = "manager"
@@ -102,7 +109,9 @@ class TwoSteps(TaskType):
         # before accepting it.
         language = job.language
         source_ext = LANGUAGE_TO_SOURCE_EXT_MAP[language]
-        header_ext = LANGUAGE_TO_HEADER_EXT_MAP[language]
+        header_ext = None
+        if language in LANGUAGE_TO_HEADER_EXT_MAP:
+            header_ext = LANGUAGE_TO_HEADER_EXT_MAP[language]
 
         # TODO: here we are sure that submission.files are the same as
         # task.submission_format. The following check shouldn't be
@@ -121,28 +130,34 @@ class TwoSteps(TaskType):
         job.sandboxes.append(sandbox.path)
         files_to_get = {}
 
-        # User's submissions and headers.
         source_filenames = []
-        for filename, file_ in job.files.iteritems():
-            source_filename = filename.replace(".%l", source_ext)
-            source_filenames.append(source_filename)
-            files_to_get[source_filename] = file_.digest
-            # Headers.
-            header_filename = filename.replace(".%l", header_ext)
-            source_filenames.append(header_filename)
-            files_to_get[header_filename] = \
-                job.managers[header_filename].digest
-
+   
         # Manager.
+        # Once again, must move it to the front, for Pascal to produce
+        # the proper compilation command.
         manager_filename = "manager%s" % source_ext
         source_filenames.append(manager_filename)
         files_to_get[manager_filename] = \
             job.managers[manager_filename].digest
         # Manager's header.
-        manager_filename = "manager%s" % header_ext
-        source_filenames.append(manager_filename)
-        files_to_get[manager_filename] = \
-            job.managers[manager_filename].digest
+        # Fixing compile err.---add only headers for languages that have a defined header_ext!
+        if header_ext != None:
+            manager_filename = "manager%s" % header_ext
+            source_filenames.append(manager_filename)
+            files_to_get[manager_filename] = \
+                job.managers[manager_filename].digest
+
+        # User's submissions and headers.
+        for filename, file_ in job.files.iteritems():
+            source_filename = filename.replace(".%l", source_ext)
+            source_filenames.append(source_filename)
+            files_to_get[source_filename] = file_.digest
+            # Headers (fixing compile error again here).
+            if header_ext != None:
+                header_filename = filename.replace(".%l", header_ext)
+            source_filenames.append(header_filename)
+            files_to_get[header_filename] = \
+                job.managers[header_filename].digest
 
         for filename, digest in files_to_get.iteritems():
             sandbox.create_file_from_storage(filename, digest)
@@ -293,13 +308,42 @@ class TwoSteps(TaskType):
                     second_sandbox.create_file_from_storage(
                         "res.txt",
                         job.output)
-
-                    outcome, text = white_diff_step(
-                        second_sandbox, "output.txt", "res.txt")
+                    
+                    # If a checker is not provided, use white-diff
+                    checker_filename = "checker"
+                    if checker_filename not in job.managers:
+                        outcome, text = white_diff_step(
+                            second_sandbox, "output.txt", "res.txt")
+                    else:
+                        second_sandbox.create_file_from_storage(
+                            checker_filename,
+                            job.managers[checker_filename].digest,
+                            executable=True)
+                        # Rewrite input file, as in Batch.py
+                        try:
+                            second_sandbox.remove_file("input.txt")
+                        except OSError as e:
+                            assert not second_sandbox.file_exists("input.txt")
+                        second_sandbox.create_file_from_storage(
+                            "input.txt",
+                            job.input)
+                        success, _ = evaluation_step(
+                            second_sandbox,
+                            [["./%s" % checker_filename,
+                              "input.txt", "res.txt", "output.txt"]])
+                        if success:
+                            try:
+                                outcome, text = \
+                                    extract_outcome_and_text(second_sandbox)
+                            except ValueError, e:
+                                logger.error("Invalid output from "
+                                             "comparator: %s", e.message,
+                                             extra={"operation": job.info})
+                                success = False
 
         # Whatever happened, we conclude.
         job.success = success
-        job.outcome = str(outcome)
+        job.outcome = str(outcome) if outcome is not None else None
         job.text = text
 
         delete_sandbox(first_sandbox)

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -92,16 +92,12 @@ class TwoSteps(TaskType):
         res = dict()
         for language in LANGUAGES:
             source_ext = LANGUAGE_TO_SOURCE_EXT_MAP[language]
-            header_ext = None
-            # Fixing error 500---add only headers for languages that have a defined header_ext!
-            if language in LANGUAGE_TO_HEADER_EXT_MAP:
-                header_ext = LANGUAGE_TO_HEADER_EXT_MAP[language]
+            header_ext = LANGUAGE_TO_HEADER_EXT_MAP.get(language, None)
             source_filenames = []
             # Manager 
-            # (N.B. needs to go first, otherwise Pascal compilation command will be wrong!).
             manager_source_filename = "manager%s" % source_ext
             source_filenames.append(manager_source_filename)
-            # Manager's header.     
+            # Manager's header.
             if header_ext != None:
                 manager_header_filename = "manager%s" % header_ext
                 source_filenames.append(manager_header_filename)
@@ -109,7 +105,7 @@ class TwoSteps(TaskType):
             for filename in submission_format:
                 source_filename = filename.replace(".%l", source_ext)
                 source_filenames.append(source_filename)
-                # Headers (Fixing error 500 again here).
+                # Headers
                 if header_ext != None:
                     header_filename = filename.replace(".%l", header_ext)
                     source_filenames.append(header_filename)
@@ -129,9 +125,7 @@ class TwoSteps(TaskType):
         # before accepting it.
         language = job.language
         source_ext = LANGUAGE_TO_SOURCE_EXT_MAP[language]
-        header_ext = None
-        if language in LANGUAGE_TO_HEADER_EXT_MAP:
-            header_ext = LANGUAGE_TO_HEADER_EXT_MAP[language]
+        header_ext = LANGUAGE_TO_HEADER_EXT_MAP.get(language, None)
 
         # TODO: here we are sure that submission.files are the same as
         # task.submission_format. The following check shouldn't be
@@ -153,14 +147,11 @@ class TwoSteps(TaskType):
         source_filenames = []
    
         # Manager.
-        # Once again, must move it to the front, for Pascal to produce
-        # the proper compilation command.
         manager_filename = "manager%s" % source_ext
         source_filenames.append(manager_filename)
         files_to_get[manager_filename] = \
             job.managers[manager_filename].digest
         # Manager's header.
-        # Fixing compile err.---add only headers for languages that have a defined header_ext!
         if header_ext != None:
             manager_filename = "manager%s" % header_ext
             source_filenames.append(manager_filename)
@@ -175,9 +166,9 @@ class TwoSteps(TaskType):
             # Headers (fixing compile error again here).
             if header_ext != None:
                 header_filename = filename.replace(".%l", header_ext)
-            source_filenames.append(header_filename)
-            files_to_get[header_filename] = \
-                job.managers[header_filename].digest
+                source_filenames.append(header_filename)
+                files_to_get[header_filename] = \
+                    job.managers[header_filename].digest
 
         for filename, digest in files_to_get.iteritems():
             sandbox.create_file_from_storage(filename, digest)
@@ -328,7 +319,7 @@ class TwoSteps(TaskType):
                     second_sandbox.create_file_from_storage(
                         "res.txt",
                         job.output)
-                    
+                        
                     # If a checker is not provided, use white-diff
                     if self.parameters[0] == "diff":
                         outcome, text = white_diff_step(

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -80,6 +80,8 @@ class TwoSteps(TaskType):
          "comparator": "Outputs are compared by a comparator"})
 
     ACCEPTED_PARAMETERS = [_EVALUATION]
+    
+    checker_filename = "checker"
 
     @property
     def name(self):
@@ -326,7 +328,6 @@ class TwoSteps(TaskType):
                             second_sandbox, "output.txt", "res.txt")
                     
                     elif self.parameters[0] == "comparator":
-                        checker_filename = "checker"
                         if checker_filename not in job.managers:
                             logger.error("Configuration error: missing or "
                                          "invalid comparator (it must be "
@@ -374,4 +375,4 @@ class TwoSteps(TaskType):
 
     def get_user_managers(self, unused_submission_format):
         """See TaskType.get_user_managers."""
-        return []
+        return ["manager.%l"]

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -6,6 +6,7 @@
 # Copyright © 2010-2014 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2012-2013 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2016 Petar Veličković <pv273@cam.ac.uk>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -348,3 +349,7 @@ class TwoSteps(TaskType):
 
         delete_sandbox(first_sandbox)
         delete_sandbox(second_sandbox)
+
+    def get_user_managers(self, unused_submission_format):
+    """See TaskType.get_user_managers."""
+        return []

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -328,15 +328,15 @@ class TwoSteps(TaskType):
                             second_sandbox, "output.txt", "res.txt")
                     
                     elif self.parameters[0] == "comparator":
-                        if checker_filename not in job.managers:
+                        if self.checker_filename not in job.managers:
                             logger.error("Configuration error: missing or "
                                          "invalid comparator (it must be "
                                          "named `checker')", extra={"operation": job.info})
                             success = False
                         else:
                             second_sandbox.create_file_from_storage(
-                                checker_filename,
-                                job.managers[checker_filename].digest,
+                                self.checker_filename,
+                                job.managers[self.checker_filename].digest,
                                 executable=True)
                             # Rewrite input file, as in Batch.py
                             try:
@@ -348,7 +348,7 @@ class TwoSteps(TaskType):
                                 job.input)
                             success, _ = evaluation_step(
                                 second_sandbox,
-                                [["./%s" % checker_filename,
+                                [["./%s" % self.checker_filename,
                                   "input.txt", "res.txt", "output.txt"]])
                             if success:
                                 try:

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -80,8 +80,8 @@ class TwoSteps(TaskType):
          "comparator": "Outputs are compared by a comparator"})
 
     ACCEPTED_PARAMETERS = [_EVALUATION]
-    
-    checker_filename = "checker"
+
+    CHECKER_FILENAME = "checker"
 
     @property
     def name(self):
@@ -147,7 +147,7 @@ class TwoSteps(TaskType):
         files_to_get = {}
 
         source_filenames = []
-   
+
         # Manager.
         manager_filename = "manager%s" % source_ext
         source_filenames.append(manager_filename)
@@ -321,22 +321,22 @@ class TwoSteps(TaskType):
                     second_sandbox.create_file_from_storage(
                         "res.txt",
                         job.output)
-                        
+
                     # If a checker is not provided, use white-diff
                     if self.parameters[0] == "diff":
                         outcome, text = white_diff_step(
                             second_sandbox, "output.txt", "res.txt")
-                    
+
                     elif self.parameters[0] == "comparator":
-                        if self.checker_filename not in job.managers:
+                        if TwoSteps.CHECKER_FILENAME not in job.managers:
                             logger.error("Configuration error: missing or "
                                          "invalid comparator (it must be "
                                          "named `checker')", extra={"operation": job.info})
                             success = False
                         else:
                             second_sandbox.create_file_from_storage(
-                                self.checker_filename,
-                                job.managers[self.checker_filename].digest,
+                                TwoSteps.CHECKER_FILENAME,
+                                job.managers[TwoSteps.CHECKER_FILENAME].digest,
                                 executable=True)
                             # Rewrite input file, as in Batch.py
                             try:
@@ -348,7 +348,7 @@ class TwoSteps(TaskType):
                                 job.input)
                             success, _ = evaluation_step(
                                 second_sandbox,
-                                [["./%s" % self.checker_filename,
+                                [["./%s" % TwoSteps.CHECKER_FILENAME,
                                   "input.txt", "res.txt", "output.txt"]])
                             if success:
                                 try:

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -32,6 +32,7 @@ import tempfile
 from cms import LANGUAGES, LANGUAGE_TO_SOURCE_EXT_MAP, \
     LANGUAGE_TO_HEADER_EXT_MAP, config
 from cms.grading.Sandbox import wait_without_std
+from cms.grading.ParameterTypes import ParameterTypeChoice
 from cms.grading import get_compilation_commands, compilation_step, \
     evaluation_step, evaluation_step_before_run, evaluation_step_after_run, \
     is_evaluation_passed, human_evaluation_message, \
@@ -63,10 +64,28 @@ class TwoSteps(TaskType):
     Admins must provide also header files, named "foo{.h|lib.pas}" for
     the three sources (manager and user provided).
 
+    Parameters are given by a singleton list of strings (for possible
+    expansions in the future), which may be 'diff' or 'comparator',
+    specifying whether the evaluation is done using white diff or a
+    comparator.
+
     """
     ALLOW_PARTIAL_SUBMISSION = False
 
-    name = "Two steps"
+    _EVALUATION = ParameterTypeChoice(
+        "Output evaluation",
+        "output_eval",
+        "",
+        {"diff": "Outputs compared with white diff",
+         "comparator": "Outputs are compared by a comparator"})
+
+    ACCEPTED_PARAMETERS = [_EVALUATION]
+
+    @property
+    def name(self):
+        """See TaskType.name."""
+        # TODO add some details if a comparator is used, etc...
+        return "Two steps"
 
     def get_compilation_commands(self, submission_format):
         """See TaskType.get_compilation_commands."""
@@ -311,36 +330,48 @@ class TwoSteps(TaskType):
                         job.output)
                     
                     # If a checker is not provided, use white-diff
-                    checker_filename = "checker"
-                    if checker_filename not in job.managers:
+                    if self.parameters[0] == "diff":
                         outcome, text = white_diff_step(
                             second_sandbox, "output.txt", "res.txt")
-                    else:
-                        second_sandbox.create_file_from_storage(
-                            checker_filename,
-                            job.managers[checker_filename].digest,
-                            executable=True)
-                        # Rewrite input file, as in Batch.py
-                        try:
-                            second_sandbox.remove_file("input.txt")
-                        except OSError as e:
-                            assert not second_sandbox.file_exists("input.txt")
-                        second_sandbox.create_file_from_storage(
-                            "input.txt",
-                            job.input)
-                        success, _ = evaluation_step(
-                            second_sandbox,
-                            [["./%s" % checker_filename,
-                              "input.txt", "res.txt", "output.txt"]])
-                        if success:
+                    
+                    elif self.parameters[0] == "comparator":
+                        checker_filename = "checker"
+                        if checker_filename not in job.managers:
+                            logger.error("Configuration error: missing or "
+                                         "invalid comparator (it must be "
+                                         "named `checker')", extra={"operation": job.info})
+                            success = False
+                        else:
+                            second_sandbox.create_file_from_storage(
+                                checker_filename,
+                                job.managers[checker_filename].digest,
+                                executable=True)
+                            # Rewrite input file, as in Batch.py
                             try:
-                                outcome, text = \
-                                    extract_outcome_and_text(second_sandbox)
-                            except ValueError, e:
-                                logger.error("Invalid output from "
-                                             "comparator: %s", e.message,
-                                             extra={"operation": job.info})
-                                success = False
+                                second_sandbox.remove_file("input.txt")
+                            except OSError as e:
+                                assert not second_sandbox.file_exists("input.txt")
+                            second_sandbox.create_file_from_storage(
+                                "input.txt",
+                                job.input)
+                            success, _ = evaluation_step(
+                                second_sandbox,
+                                [["./%s" % checker_filename,
+                                  "input.txt", "res.txt", "output.txt"]])
+                            if success:
+                                try:
+                                    outcome, text = \
+                                        extract_outcome_and_text(second_sandbox)
+                                except ValueError, e:
+                                    logger.error("Invalid output from "
+                                                 "comparator: %s", e.message,
+                                                 extra={"operation": job.info})
+                                    success = False
+                    else:
+                        raise ValueError("Uncrecognized first parameter"
+                                         " `%s' for TwoSteps tasktype." %
+                                         self.parameters[0])
+                        success = False
 
         # Whatever happened, we conclude.
         job.success = success
@@ -351,5 +382,5 @@ class TwoSteps(TaskType):
         delete_sandbox(second_sandbox)
 
     def get_user_managers(self, unused_submission_format):
-    """See TaskType.get_user_managers."""
+        """See TaskType.get_user_managers."""
         return []

--- a/docs/Task types.rst
+++ b/docs/Task types.rst
@@ -85,8 +85,10 @@ Warning: use this task type only if you know what are you doing.
 
 In a TwoSteps task, contestants submit two source files implementing a function each (the idea is that the first function gets the input and compute some data from it with some restriction, and the second tries to retrieve the original data).
 
-The admins must provide a manager compiled together with both files. The resulting executable is run twice (one acting as the computer, one acting as the retriever. The manager in the computer executable must take care of reading the input from standard input; the one in the retriever executable of writing the outcome and the explanation message to standard output and error respectively. Both must take responsibility of the communication between them through a pipe.
+The admins must provide a manager, which is compiled together with both of the contestant-submitted files. The manager needs to be named :file:`manager.ext`, where ``ext`` is the standard extension of a source file in that language. Furthermore, for C/C++ and Pascal, appropriate header files for the two source files given by the contestants need to be provided, as well as manager header files (:file:`manager.h`, :file:`managerlib.pas`)---**even if they are empty**.
 
-More precisely, the executable are called with two arguments: the first is an integer which is 0 if the executable is the computer, and 1 if it is the retriever; the second is the name of the pipe to be used for communication between the processes.
+The resulting executable is run twice (one acting as the computer, one acting as the retriever). The manager in the computer executable must take care of reading the input from standard input; the one in the retriever executable of writing the retrieved data to standard output. Both must take responsibility of the communication between them through a pipe.
 
+More precisely, the executable is called with two arguments: the first is an integer which is 0 if the executable is the computer, and 1 if it is the retriever; the second is the name of the pipe to be used for communication between the processes.
 
+Normally, the standard output of the second invocation of the manager is compared to a provided reference output file using the white-diff comparator. However, the admins may provide a :file:`checker` executable, with the same properties as for Batch. If a file with such a name is found in the uploaded manager files, it will be run instead of the white-diff comparator.


### PR DESCRIPTION
- TwoSteps now supports a custom checker (uses white diff if none
provided).
- TwoSteps now ignores the header files for languages that don't have
them (i.e. Python/Java). This was causing compilation errors and Error
500s in the frontend.
- TwoSteps now makes the manager's files be extracted before the
contestant-submitted files. This is due to the way the compilation
command is constructed in Pascal (always takes the first argument as the
only file directly ordered to compile).
- TwoSteps is also now sporting an implemented get_user_managers method, which was causing an Error 500 on the Testing page of the frontend.
- Documentation has been updated appropriately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/608)
<!-- Reviewable:end -->
