### PR TITLE
Simple submission detail (ICPC Mode)

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -83,7 +83,7 @@ __all__ = [
 
 # Instantiate or import these objects.
 
-version = 23
+version = 24
 
 
 engine = create_engine(config.database, echo=config.database_debug,

--- a/cms/db/contest.py
+++ b/cms/db/contest.py
@@ -101,6 +101,13 @@ class Contest(Base):
         nullable=False,
         default=True)
 
+    # Whether show only first not correct testcase for each subtasks..
+    # It's useful for ICPC
+    simple_submission_detail = Column(
+        Boolean,
+        nullable=False,
+        default=False)
+
     # Whether to prevent hidden participations to log in.
     block_hidden_participations = Column(
         Boolean,

--- a/cms/grading/ScoreType.py
+++ b/cms/grading/ScoreType.py
@@ -73,7 +73,8 @@ class ScoreType(object):
         self.max_score, self.max_public_score, self.ranking_headers = \
             self.max_scores()
 
-    def get_html_details(self, score_details, translator=None):
+    def get_html_details(self, score_details, simple_submission_detail, \
+            translator=None):
         """Return an HTML string representing the score details of a
         submission.
 
@@ -95,6 +96,9 @@ class ScoreType(object):
                          "Try invalidating scores.")
             return translator("Score details temporarily unavailable.")
         else:
+            if simple_submission_detail:
+                return Template(self.SIMPLE_TEMPLATE).generate(
+                    details=score_details, _=translator)
             return Template(self.TEMPLATE).generate(details=score_details,
                                                     _=translator)
 
@@ -162,6 +166,62 @@ class ScoreTypeGroup(ScoreTypeAlone):
     N_("Execution time")
     N_("Memory used")
     N_("N/A")
+    SIMPLE_TEMPLATE = """\
+{% from cms.grading import format_status_text %}
+{% from cms.server import format_size %}
+{% set correct = True %}
+{% for st in details %}
+    {% for tc in st["testcases"] %}
+        {% if "outcome" in tc and "text" in tc and tc["outcome"] != "Correct" %}
+            {% set correct = False %}
+        {% end %}
+    {% end %}
+{% end %}
+{% if not correct %}
+        <table class="testcase-list">
+            <thead>
+                <tr>
+                    <th class="outcome">{{ _("Outcome") }}</th>
+                    <th class="details">{{ _("Details") }}</th>
+                    <th class="execution-time">{{ _("Execution time") }}</th>
+                    <th class="memory-used">{{ _("Memory used") }}</th>
+                </tr>
+            </thead>
+            <tbody>
+    {% for st in details %}
+        {% for tc in st["testcases"] %}
+            {% if "outcome" in tc and "text" in tc and tc["outcome"] != "Correct" %}
+                {% if tc["outcome"] == "Not correct" %}
+                <tr class="notcorrect">
+                {% else %}
+                <tr class="partiallycorrect">
+                {% end %}
+                    <td class="outcome">{{ _(tc["outcome"]) }}</td>
+                    <td class="details">
+                      {{ format_status_text(tc["text"], _) }}
+                    </td>
+                    <td class="execution-time">
+                {% if "time" in tc and tc["time"] is not None %}
+                        {{ _("%(seconds)0.3f s") % {'seconds': tc["time"]} }}
+                {% else %}
+                        {{ _("N/A") }}
+                {% end %}
+                    </td>
+                    <td class="memory-used">
+                {% if "memory" in tc and tc["memory"] is not None %}
+                        {{ format_size(tc["memory"]) }}
+                {% else %}
+                        {{ _("N/A") }}
+                {% end %}
+                    </td>
+                </tr>
+                {% break %}
+            {% end %}
+        {% end %}
+    {% end %}
+            </tbody>
+        </table>
+{% end %}"""
     TEMPLATE = """\
 {% from cms.grading import format_status_text %}
 {% from cms.server import format_size %}

--- a/cms/grading/ScoreType.py
+++ b/cms/grading/ScoreType.py
@@ -295,7 +295,7 @@ class ScoreTypeGroup(ScoreTypeAlone):
                     </td>
         {% else %}
                 <tr class="undefined">
-                    <td colspan="4">
+                    <td colspan="5">
                         {{ _("N/A") }}
                     </td>
                 </tr>

--- a/cms/locale/cms.pot
+++ b/cms/locale/cms.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-01 15:57+0900\n"
+"POT-Creation-Date: 2016-05-20 16:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -866,6 +866,12 @@ msgstr ""
 msgid "Standard error"
 msgstr ""
 
+msgid "Accepted"
+msgstr ""
+
+msgid "Rejected"
+msgstr ""
+
 msgid "None"
 msgstr ""
 
@@ -990,6 +996,9 @@ msgid "Public score"
 msgstr ""
 
 msgid "Total score"
+msgstr ""
+
+msgid "Result"
 msgstr ""
 
 msgid "Score"

--- a/cms/locale/ko/LC_MESSAGES/cms.po
+++ b/cms/locale/ko/LC_MESSAGES/cms.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-01 15:57+0900\n"
+"POT-Creation-Date: 2016-05-20 16:32+0000\n"
 "PO-Revision-Date: 2016-03-02 15:51+0900\n"
 "Last-Translator: Myungwoo Chun <mc.tamaki@gmail.com>\n"
 "Language-Team: Korean\n"
@@ -915,6 +915,12 @@ msgstr "표준 출력"
 msgid "Standard error"
 msgstr "표준 에러"
 
+msgid "Accepted"
+msgstr "Accepted"
+
+msgid "Rejected"
+msgstr "Rejected"
+
 msgid "None"
 msgstr "없음"
 
@@ -1044,6 +1050,9 @@ msgstr "공개 점수"
 
 msgid "Total score"
 msgstr "총 점수"
+
+msgid "Result"
+msgstr "결과"
 
 msgid "Score"
 msgstr "점수"

--- a/cms/server/admin/handlers/contest.py
+++ b/cms/server/admin/handlers/contest.py
@@ -100,6 +100,7 @@ class ContestHandler(SimpleContestHandler("contest.html")):
             self.get_bool(attrs, "submissions_download_allowed")
             self.get_bool(attrs, "allow_questions")
             self.get_bool(attrs, "allow_user_tests")
+            self.get_bool(attrs, "simple_submission_detail")
             self.get_bool(attrs, "block_hidden_participations")
             self.get_bool(attrs, "ip_restriction")
             self.get_bool(attrs, "ip_autologin")

--- a/cms/server/admin/templates/contest.html
+++ b/cms/server/admin/templates/contest.html
@@ -82,6 +82,15 @@
     </tr>
     <tr>
       <td>
+        <span class="info" title="Whether show only first not correct testcase for each subtask."></span>
+        <label for="simple_submission_detail">Simple submission detail</label>
+      </td>
+      <td>
+        <input type="checkbox" id="simple_submission_detail" name="simple_submission_detail" {{ "checked" if contest.simple_submission_detail else "" }}/>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <span class="info" title="The number of decimal places the scores will be rounded to.
                                   Example: '2' to allow 98.76."></span>
         Score decimal places

--- a/cms/server/admin/templates/fragments/submission_row.html
+++ b/cms/server/admin/templates/fragments/submission_row.html
@@ -78,7 +78,7 @@
       Scored ({{ sr.score }} / {{ max_score }})
       <div id="evaluation_{{ s.id }}" class="score_details" style="display: none;">
         {% try %}
-          {% raw score_type.get_html_details(sr.score_details) %}
+          {% raw score_type.get_html_details(sr.score_details, s.task.contest.simple_submission_detail) %}
         {% except %}
         [Cannot get score type - see logs]
         {% end %}

--- a/cms/server/admin/templates/submission.html
+++ b/cms/server/admin/templates/submission.html
@@ -139,9 +139,9 @@
 
   <div class="score_details" id="evaluation_{{ s.id }}">
     {% if s.tokened() %}
-      {% raw st.get_html_details(sr.score_details) %}
+      {% raw st.get_html_details(sr.score_details, s.task.contest.simple_submission_detail) %}
     {% else %}
-      {% raw st.get_html_details(sr.public_score_details) %}
+      {% raw st.get_html_details(sr.public_score_details, s.task.contest.simple_submission_detail) %}
     {% end %}
   </div>
 </div>

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -273,6 +273,7 @@ class BaseHandler(CommonRequestHandler):
         ret["printing_enabled"] = (config.printer is not None)
         ret["questions_enabled"] = self.contest.allow_questions
         ret["testing_enabled"] = self.contest.allow_user_tests
+        ret["simple_submission_detail"] = self.contest.simple_submission_detail
 
         if self.current_user is not None:
             participation = self.current_user

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -466,11 +466,24 @@ class SubmissionStatusHandler(BaseHandler):
                 self._("Evaluated"), self._("details"))
 
             score_type = get_score_type(dataset=task.active_dataset)
-            if score_type is not None and score_type.max_public_score != 0:
-                data["max_public_score"] = "%g" % \
-                    round(score_type.max_public_score, task.score_precision)
-            data["public_score"] = "%g" % \
-                round(sr.public_score, task.score_precision)
+            if submission.task.contest.simple_submission_detail and \
+                score_type.max_public_score == score_type.max_score:
+                if sr.public_score == score_type.max_public_score:
+                    data["public_message"] = self._("Accepted")
+                    data["score_class"] = "score_100"
+                elif sr.public_score > 0:
+                    data["public_message"] = self._("Rejected")
+                    data["score_class"] = "score_0_100"
+                else:
+                    data["public_message"] = self._("Rejected")
+                    data["score_class"] = "score_0"
+            else:
+                if score_type is not None and score_type.max_public_score != 0:
+                    data["max_public_score"] = "%g" % \
+                        round(score_type.max_public_score, task.score_precision)
+                data["public_score"] = "%g" % \
+                    round(sr.public_score, task.score_precision)
+
             if submission.token is not None:
                 if score_type is not None and score_type.max_score != 0:
                     data["max_score"] = "%g" % \
@@ -515,7 +528,10 @@ class SubmissionDetailsHandler(BaseHandler):
                 details = sr.public_score_details
 
             if sr.scored():
-                details = score_type.get_html_details(details, self._)
+                simple_submission_detail = \
+                    submission.task.contest.simple_submission_detail
+                details = score_type.get_html_details(details, \
+                    simple_submission_detail, self._)
             else:
                 details = None
 

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -62,7 +62,15 @@
 
     {% if score_type is not None and score_type.max_public_score != 0 %}
     <td class="public_score {{ get_score_class(sr.public_score, score_type.max_public_score) }}">
+        {% if simple_submission_detail and score_type.max_public_score == score_type.max_score %}
+            {% if sr.public_score == score_type.max_public_score %}
+                {{ _("Accepted") }}
+            {% else %}
+                {{ _("Rejected") }}
+            {% end %}
+        {% else %}
             {{ "%g" % round(sr.public_score, task.score_precision) }} / {{ "%g" % round(score_type.max_public_score, task.score_precision) }}
+        {% end %}
     </td>
     {% end %}
 

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -42,7 +42,13 @@ update_submission_row = function (submission_id, data) {
     row.attr("data-status", data["status"]);
     row.children("td.status").html(data["status_text"]);
     if (data["status"] == {{ SubmissionResult.SCORED }}) {
-        if (data["public_score"] != undefined) {
+        if (data["public_message"] != undefined) {
+            var public_message = data["public_message"];
+            var score_class = data["score_class"];
+            row.children("td.public_score").addClass(score_class);
+            row.children("td.public_score").removeClass("undefined").html(public_message);
+        }
+        else if (data["public_score"] != undefined) {
             var public_score = data["public_score"];
             if (data["max_public_score"] != undefined) {
                 row.children("td.public_score").addClass(get_score_class(parseFloat(data["public_score"]), parseFloat(data["max_public_score"])));
@@ -230,7 +236,11 @@ $(document).ready(function () {
             <th class="public_score">{{ _("Public score") }}</th>
             <th class="total_score">{{ _("Total score") }}</th>
 {% else %}
+    {% if simple_submission_detail %}
+            <th class="total_score">{{ _("Result") }}</th>
+    {% else %}
             <th class="total_score">{{ _("Score") }}</th>
+    {% end %}
 {% end %}
 {% if submissions_download_allowed %}
             <th class="files">{{ _("Files") }}</th>

--- a/cmscontrib/updaters/update_24.py
+++ b/cmscontrib/updaters/update_24.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A class to update a dump created by CMS.
+
+Used by ContestImporter and DumpUpdater.
+
+This updater just adds the default values for the new field
+(is_super_user).
+
+"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+
+class Updater(object):
+
+    def __init__(self, data):
+        assert data["_version"] == 23
+        self.objs = data
+
+    def run(self):
+        for k, v in self.objs.iteritems():
+            if k.startswith("_"):
+                continue
+            if v["_class"] == "Contest":
+                v["simple_submission_detail"] = False
+
+        return self.objs


### PR DESCRIPTION
One different between IOI and ICPC is the submission detail.
1) ICPC only shows the detail of first incorrect testcase, but IOI shows detail of all testcases.
2) In ICPC, there are only Accepted & Rejected (Correct or Incorrect), but in IOI there is score for the submission.

In this pull request,
I made **Simple Submission Detail mode** for a contest (I don't call it ICPC mode).

1) It is just available for grouping score types (GroupMin, GroupMul, but not sure for GroupThresold)
2) It only shows the detail of first incorrect(which is not "Correct") testcase, when I got full score there's no detail of any testcases.
3) It changed "score" column to "result" column in submissions table.
3-1) score-class remain same (red / yellow / green cell)
3-2) print message "Accepted" if submission got full-score.
3-3) print message "Rejected" otherwise

Finally, this pull request & #610 make CMS all ready to use for ICPC!

Please comment if there is any idea to handle this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/612)
<!-- Reviewable:end -->
