### PR TITLE
Support JSON5 for the cms.conf and cms.ranking.conf files

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -28,7 +28,10 @@ from __future__ import unicode_literals
 
 import errno
 import io
-import json
+try:
+    import json5 as json
+except ImportError:
+    import json
 import logging
 import os
 import sys

--- a/cmsranking/Config.py
+++ b/cmsranking/Config.py
@@ -22,7 +22,10 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import io
-import json
+try:
+    import json5 as json
+except ImportError:
+    import json
 import os
 import pkg_resources
 import sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ gevent==1.0.2
 werkzeug==0.10.4
 patool==1.7
 bcrypt==2.0
+json5==0.2.4
 
 # Only for some importers:
 pyyaml==3.11


### PR DESCRIPTION
There was some discussion some time ago about moving to YAML, but the change was regarded as too drastic. This commit allows to use a better version of JSON (which allows comments, commas at the end of arrays/objects, and multi-line strings) while still keeping backwards compatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/614)
<!-- Reviewable:end -->
