### PR TITLE
Refactor the code for AWS authentication

### DIFF
--- a/cms/io/web_service.py
+++ b/cms/io/web_service.py
@@ -5,7 +5,7 @@
 # Copyright © 2010-2013 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
 # Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
-# Copyright © 2013-2015 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2013-2016 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -33,7 +33,7 @@ import tornado.wsgi
 from gevent.pywsgi import WSGIServer
 
 from werkzeug.wsgi import DispatcherMiddleware, SharedDataMiddleware
-from werkzeug.contrib.fixers import HeaderRewriterFix, ProxyFix
+from werkzeug.contrib.fixers import ProxyFix
 
 from .service import Service
 from .web_rpc import RPCMiddleware
@@ -46,20 +46,6 @@ class WebService(Service):
     """RPC service with Web server capabilities.
 
     """
-
-    # TODO: the following are headers used to communicate between
-    # middlewares inside CMS. If this list grows more, it would be
-    # better to have an easy way to remove all X-Cms headers at once,
-    # to make sure there are no such headers injected from the
-    # outside.
-
-    # A WSGI application receiving this header can assume that the
-    # user with the given id is authenticated.
-    AUTHENTICATED_USER_HEADER = "X-Cms-Authenticated-User"
-
-    # A WSGI application can set this header to ask to create a new
-    # authentication cookie, refresh an existing cookie, or delete it.
-    AUTHENTICATED_COOKIE_HEADER = "X-Cms-Authenticated-Cookie"
 
     def __init__(self, listen_port, handlers, parameters, shard=0,
                  listen_address=""):
@@ -82,13 +68,12 @@ class WebService(Service):
             self.wsgi_app = DispatcherMiddleware(
                 self.wsgi_app, {"/rpc": RPCMiddleware(self, rpc_auth)})
 
-        # Remove any authentication header that a user may try to fake.
-        self.wsgi_app = HeaderRewriterFix(
-            self.wsgi_app,
-            remove_headers=[WebService.AUTHENTICATED_USER_HEADER])
-
+        # The authentication middleware needs to be applied before the
+        # ProxyFix as otherwise the remote address it gets is the one
+        # of the proxy.
         if auth_middleware is not None:
             self.wsgi_app = auth_middleware(self.wsgi_app)
+            self.auth_handler = self.wsgi_app
 
         # If is_proxy_used is set to True we'll use the content of the
         # X-Forwarded-For HTTP header (if provided) to determine the

--- a/cms/server/admin/authentication.py
+++ b/cms/server/admin/authentication.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2016 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import json
+
+from werkzeug.wrappers import Request, Response
+from werkzeug.local import Local, LocalManager
+from werkzeug.contrib.securecookie import SecureCookie
+
+from cms import config
+from cmscommon.datetime import make_timestamp
+
+
+class JSONSecureCookie(SecureCookie):
+    serialization_method = json
+
+
+class AWSAuthMiddleware(object):
+    """Handler for the low-level tasks of admin authentication.
+
+    Intercepts all requests and responses to AWS, parses the auth
+    cookie to retrieve the admin, provides an interface for the rest of
+    the application to access and modify this information, and then
+    writes the headers to update the cookie.
+
+    A single instance of this class manages the cookies for all current
+    requests at the same time, using a Local object from Werkzeug.
+
+    """
+    COOKIE = "awslogin"
+
+    def __init__(self, app):
+        """Initialize the middleware, and chain it to the given app.
+
+        app (function): a WSGI application.
+
+        """
+        self._app = app
+
+        self._local = Local()
+        self._local_manager = LocalManager([self._local])
+        self.wsgi_app = self._local_manager.make_middleware(self.wsgi_app)
+
+        self._request = self._local("request")
+        self._cookie = self._local("cookie")
+
+    @property
+    def admin_id(self):
+        """Return the ID of the admin.
+
+        It's the value that has been read from the cookie and (if
+        modified by the rest of the application) will be written back.
+
+        returns (int or None): the ID of the admin, if logged in.
+
+        """
+        return self._cookie.get("id", None)
+
+    def set(self, admin_id):
+        """Set the admin ID that will be stored in the cookie.
+
+        admin_id (int): the ID of the admin (to unset don't pass None:
+            use clear()).
+
+        """
+        self._cookie["id"] = admin_id
+        self._cookie["ip"] = self._request.remote_addr
+        self.refresh()
+
+    def refresh(self):
+        """Update the timestamp that will be stored in the cookie.
+
+        """
+        self._cookie["timestamp"] = make_timestamp()
+
+    def clear(self):
+        """Remove all fields from the cookie.
+
+        This doesn't actually cause the client to remove the cookie, it
+        just makes it update the stored cookie to an empty value.
+
+        """
+        self._cookie.clear()
+
+    def __call__(self, environ, start_response):
+        """Invoke the class as a WSGI application.
+
+        environ (dict): the WSGI environment.
+        start_response (function): the WSGI start_response callable.
+        returns (iterable): the WSGI response data.
+
+        """
+        return self.wsgi_app(environ, start_response)
+
+    def wsgi_app(self, environ, start_response):
+        """Invoke the class as a WSGI application.
+
+        environ (dict): the WSGI environment.
+        start_response (function): the WSGI start_response callable.
+        returns (iterable): the WSGI response data.
+
+        """
+        self._local.request = Request(environ)
+        self._local.cookie = JSONSecureCookie.load_cookie(
+            self._request, AWSAuthMiddleware.COOKIE, config.secret_key)
+        self._verify_cookie()
+
+        def my_start_response(status, headers, exc_info=None):
+            """Wrapper for the server-provided start_response.
+
+            Once called by the application, modifies the received
+            parameters to add the Set-Cookie parameter (if needed)
+            and then forwards everything to the server.
+
+            """
+            response = Response(status=status, headers=headers)
+            self._cookie.save_cookie(
+                response, AWSAuthMiddleware.COOKIE, httponly=True)
+            return start_response(
+                status, response.headers.to_wsgi_list(), exc_info)
+
+        return self._app(environ, my_start_response)
+
+    def _verify_cookie(self):
+        """Check whether the cookie is valid, and if not clear it.
+
+        """
+        # Clearing an empty cookie marks it as modified and causes it
+        # to be sent in the response. This check prevents it.
+        if len(self._cookie) == 0:
+            return
+
+        admin_id = self._cookie.get("id", None)
+        remote_addr = self._cookie.get("ip", None)
+        timestamp = self._cookie.get("timestamp", None)
+
+        if admin_id is None or remote_addr is None or timestamp is None:
+            self.clear()
+            return
+
+        if not isinstance(admin_id, int) or not isinstance(timestamp, float):
+            self.clear()
+            return
+
+        if remote_addr != self._request.remote_addr:
+            self.clear()
+            return
+
+        if make_timestamp() - timestamp > config.admin_cookie_duration:
+            self.clear()
+            return

--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -5,7 +5,7 @@
 # Copyright © 2010-2013 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
 # Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
-# Copyright © 2012-2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2012-2016 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
 # Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
@@ -166,7 +166,7 @@ def require_permission(permission="authenticated", self_allowed=False):
 
             user = self.current_user
             permission_key = "permission_%s" % permission
-            if user.permission_all or user.__getattribute__(permission_key):
+            if user.permission_all or getattr(user, permission_key):
                 return func(self, *args, **kwargs)
             else:
                 if self_allowed and len(args) > 0 and int(args[0]) == user.id:
@@ -221,10 +221,8 @@ class BaseHandler(CommonRequestHandler):
             the Admin object, otherwise None.
 
         """
-        admin_id = self.request.headers.get(
-            WebService.AUTHENTICATED_USER_HEADER, None)
+        admin_id = self.service.auth_handler.admin_id
         if admin_id is None:
-            self.set_cookie_action("delete")
             return None
 
         # Load admin.
@@ -233,23 +231,14 @@ class BaseHandler(CommonRequestHandler):
             .filter(Admin.enabled.is_(True))\
             .first()
         if admin is None:
-            self.set_cookie_action("delete")
+            self.service.auth_handler.clear()
             return None
 
         # Maybe refresh the cookie.
         if self.refresh_cookie:
-            self.set_cookie_action("refresh")
+            self.service.auth_handler.refresh()
 
         return admin
-
-    def set_cookie_action(self, action):
-        """Set the header to inform the upper WSGI layer to do the specified
-        action on the login cookie.
-
-        action (unicode): the value of the cookie.
-
-        """
-        self.set_header(WebService.AUTHENTICATED_COOKIE_HEADER, action)
 
     def safe_get_item(self, cls, ident, session=None):
         """Get item from database of class cls and id ident, using

--- a/cms/server/admin/handlers/main.py
+++ b/cms/server/admin/handlers/main.py
@@ -5,7 +5,7 @@
 # Copyright © 2010-2013 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
 # Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
-# Copyright © 2012-2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2012-2016 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
 #
@@ -82,7 +82,7 @@ class LoginHandler(SimpleHandler("login.html", authenticated=False)):
 
         logger.info("Admin logged in: %s from IP %s.",
                     filter_ascii(username), self.request.remote_ip)
-        self.set_cookie_action("create:%s" % admin.id)
+        self.service.auth_handler.set(admin.id)
         self.redirect(next_page)
 
 
@@ -91,7 +91,7 @@ class LogoutHandler(BaseHandler):
 
     """
     def get(self):
-        self.set_cookie_action("delete")
+        self.service.auth_handler.clear()
         self.redirect("/")
 
 

--- a/cms/server/admin/server.py
+++ b/cms/server/admin/server.py
@@ -5,7 +5,7 @@
 # Copyright © 2010-2013 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
 # Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
-# Copyright © 2012-2015 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2012-2016 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
 #
@@ -45,14 +45,11 @@ from cmscommon.datetime import make_timestamp
 
 from .handlers import HANDLERS
 from .handlers import views
+from .authentication import AWSAuthMiddleware
 from .rpc_authorization import rpc_authorization_checker
 
 
 logger = logging.getLogger(__name__)
-
-
-AUTHENTICATED_USER_HEADER_IN_ENV = "HTTP_" + \
-    WebService.AUTHENTICATED_USER_HEADER.upper().replace('-', '_')
 
 
 class AdminWebServer(WebService):
@@ -71,7 +68,7 @@ class AdminWebServer(WebService):
             "debug": config.tornado_debug,
             "auth_middleware": AWSAuthMiddleware,
             "rpc_enabled": True,
-            "rpc_auth": rpc_authorization_checker,
+            "rpc_auth": self.is_rpc_authorized,
         }
         super(AdminWebServer, self).__init__(
             config.admin_listen_port,
@@ -100,6 +97,10 @@ class AdminWebServer(WebService):
                 ServiceCoord("ResourceService", i)))
         self.logservice = self.connect_to(ServiceCoord("LogService", 0))
 
+    def is_rpc_authorized(self, service, shard, method):
+        return rpc_authorization_checker(self.auth_handler.admin_id,
+                                         service, shard, method)
+
     def add_notification(self, timestamp, subject, text):
         """Store a new notification to send at the first
         opportunity (i.e., at the first request for db notifications).
@@ -110,123 +111,3 @@ class AdminWebServer(WebService):
 
         """
         self.notifications.append((timestamp, subject, text))
-
-
-class JSONSecureCookie(SecureCookie):
-    serialization_method = json
-
-
-class AWSAuthMiddleware(object):
-    """Authentication layer for AWS.
-
-    For incoming requests, check if the user's cookies grant them
-    access as a specific admin, and in that case adds
-    "X-Cms-Authenticated-User" header with value the id of the admin
-    (as an int). For outgoing requests, looks for the
-    "X-Cms-Authenticated-Cookie" header: if its value is "delete", it
-    deletes the user's cookie; if it is "refresh" it refreshes is,
-    extending its validity (maybe this implies creating it).
-
-    """
-
-    # Name of the cookie containing the authentication for AWS.
-    COOKIE = "awslogin"
-
-    def __init__(self, app):
-        """Create an authentication wrapper.
-
-        auth (function|None): underlying WSGI application..
-
-        """
-        self._app = app
-
-    def __call__(self, environ, start_response):
-        """Execute this instance as a WSGI application."""
-        request = Request(environ)
-        admin_id = self._authenticate(request)
-        if admin_id is not None:
-            environ[AUTHENTICATED_USER_HEADER_IN_ENV] = admin_id
-        response = self._app(
-            environ,
-            self._build_start_response(environ, start_response, admin_id))
-        return response
-
-    def _build_start_response(self, environ, start_response, admin_id=None):
-        """Return a modified start_response function handling cookies.
-
-        environ ({}): WSGI environ object.
-        start_response (function): original start_response function
-        admin_id (int|None): id of the admin in the cookie, if present.
-
-        return (function): modified start_response function that sets,
-            change or delete the cookie based on the decision of the
-            underlying application
-
-        """
-        def my_start_response(status, headers, exc_info=None):
-            cookie = ""
-            for i, header in enumerate(headers):
-                if header[0] == WebService.AUTHENTICATED_COOKIE_HEADER:
-                    cookie = header[1]
-                    del headers[i]
-                    break
-            response = Response(status=status, headers=headers)
-            remote_addr = environ.get("REMOTE_ADDR")
-            if cookie == "delete":
-                response.delete_cookie(AWSAuthMiddleware.COOKIE)
-            elif cookie == "refresh":
-                response.set_cookie(
-                    AWSAuthMiddleware.COOKIE,
-                    self._get_cookie(admin_id, remote_addr),
-                    httponly=True)
-            elif cookie.startswith("create:"):
-                response.set_cookie(
-                    AWSAuthMiddleware.COOKIE,
-                    self._get_cookie(int(cookie.replace("create:", "")),
-                                     remote_addr),
-                    httponly=True)
-            return response(environ, start_response)
-
-        return my_start_response
-
-    def _authenticate(self, request):
-        """Check if the cookie exists and is valid
-
-        request (werkzeug.wrappers.Request): werkzeug request object.
-
-        return (int|None): admin id in the cookie, if it is valid.
-
-        """
-        cookie = JSONSecureCookie.load_cookie(
-            request, AWSAuthMiddleware.COOKIE, config.secret_key)
-
-        admin_id = cookie.get("id", None)
-        remote_addr = cookie.get("ip", None)
-        timestamp = cookie.get("timestamp", None)
-        if admin_id is None or remote_addr is None or timestamp is None:
-            return None
-
-        if remote_addr != request.remote_addr:
-            return None
-
-        if make_timestamp() - timestamp > config.admin_cookie_duration:
-            return None
-
-        return int(admin_id)
-
-    def _get_cookie(self, admin_id, remote_addr):
-        """Return the cookie for the given admin.
-
-        admin_id (int): id to save in the cookie.
-        remote_addr (unicode): ip of the host making the request.
-
-        return (bytes): secure cookie for the given admin id and the
-            current time.
-
-        """
-        data = {
-            "id": admin_id,
-            "ip": remote_addr,
-            "timestamp": make_timestamp(),
-        }
-        return JSONSecureCookie(data, config.secret_key).serialize()

--- a/cms/server/util.py
+++ b/cms/server/util.py
@@ -5,7 +5,7 @@
 # Copyright © 2010-2013 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
 # Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
-# Copyright © 2012-2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2012-2016 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -688,6 +688,10 @@ class CommonRequestHandler(RequestHandler):
         self.set_header("Cache-Control", "no-cache, must-revalidate")
         self.sql_session = Session()
         self.sql_session.expire_all()
+
+    @property
+    def service(self):
+        return self.application.service
 
     def redirect(self, url):
         url = get_url_root(self.request.path) + url


### PR DESCRIPTION
Stop using the WSGI environment and the headers dictionary to communicate with the authentication middleware. Instead, store it as a service-level attribute, so that the application can access the instance and interact with a proper API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/623)
<!-- Reviewable:end -->
