### PR TITLE
ExportSubmissions: Avoid utf-8 decoding when --add-info is not given

### DIFF
--- a/cmscontrib/ExportSubmissions.py
+++ b/cmscontrib/ExportSubmissions.py
@@ -193,9 +193,9 @@ def main():
             fso = FSObject.get_from_digest(f_digest, session)
             assert fso is not None
             with fso.get_lobject(mode="rb") as file_obj:
-                data = file_obj.read().decode('utf-8')
 
                 if args.add_info:
+                    raw_data = file_obj.read().decode('utf-8')
                     data = TEMPLATE[s_language] % (
                         u_name,
                         u_fname,
@@ -203,9 +203,13 @@ def main():
                         t_name,
                         sr_score,
                         s_timestamp
-                    ) + data
+                    ) + raw_data
+                    out_options = {"encoding": "utf-8"}
+                else:
+                    data = file_obj.read()
+                    out_options = {}
 
-                with codecs.open(filename, "w", encoding="utf-8") as file_out:
+                with codecs.open(filename, "w", **out_options) as file_out:
                     file_out.write(data)
 
             done += 1


### PR DESCRIPTION
With this patch, we can avoid utf-8 conversion errors when a submission includes invalid chars. (It can happen when a contestant writes some comments in source code with an encoding other than utf-8)
Additionally, we can save time of unnecessary utf-8 conversion.

Maybe it is good to deal with utf-8 conversion error when --add-info is given, but I don't know how to.
(Ignoring invalid chars using `codecs.decode` function with `errors=ignore`, or concatenating utf-8 encoded additional info and source code as byte sequences?)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/627)
<!-- Reviewable:end -->
