### PR TITLE
Fixed issue with polygon task importer and custom checker.

### DIFF
--- a/cmscontrib/loaders/polygon.py
+++ b/cmscontrib/loaders/polygon.py
@@ -187,9 +187,13 @@ class PolygonTaskLoader(TaskLoader):
             outfile_param = judging.attrib['output-file']
 
             checker_src = os.path.join(self.path, "files", "check.cpp")
+            if not os.path.exists(checker_src):
+                checker_src = os.path.join(self.path, "check.cpp")
+            checker_dir = os.path.dirname(self.path)
+
             if os.path.exists(checker_src):
                 logger.info("Checker found, compiling")
-                checker_exe = os.path.join(self.path, "files", "checker")
+                checker_exe = os.path.join(checker_dir, "checker")
                 testlib_path = "/usr/local/include/cms/testlib.h"
                 if not config.installed:
                     testlib_path = os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
- Previously it won't import the checker if the name of the checker's
  source file is not "check.cpp"

This is related to this [issue](https://github.com/cms-dev/cms/issues/637)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/638)
<!-- Reviewable:end -->
