### PR TITLE
Fix buggy equal count

### DIFF
--- a/cmsranking/static/HistoryStore.js
+++ b/cmsranking/static/HistoryStore.js
@@ -173,10 +173,10 @@ var HistoryStore = new function () {
                         above -= 1;
                         changed = true;
                     }
-                    if (d[user] == d[user_id]) {
+                    if (d[user] == d[user_id] && score != d[user_id]) {
                         equal -= 1;
                         changed = true;
-                    } else if (score == d[user_id]) {
+                    } else if (d[user] != d[user_id] && score == d[user_id]) {
                         equal += 1;
                         changed = true;
                     }
@@ -234,10 +234,10 @@ var HistoryStore = new function () {
                         above -= 1;
                         changed = true;
                     }
-                    if (d[user] == d[user_id]) {
+                    if (d[user] == d[user_id] && score != d[user_id]) {
                         equal -= 1;
                         changed = true;
-                    } else if (score == d[user_id]) {
+                    } else if (d[user] != d[user_id] && score == d[user_id]) {
                         equal += 1;
                         changed = true;
                     }
@@ -293,10 +293,10 @@ var HistoryStore = new function () {
                     above -= 1;
                     changed = true;
                 }
-                if (d[user] == d[user_id]) {
+                if (d[user] == d[user_id] && score != d[user_id]) {
                     equal -= 1;
                     changed = true;
-                } else if (score == d[user_id]) {
+                } else if (d[user] != d[user_id] && score == d[user_id]) {
                     equal += 1;
                     changed = true;
                 }


### PR DESCRIPTION
The count of users with equal score is incorrect if another equal user's score is updated without changing it. This is especially obvious at the start of a contest when there are many submits which all receive 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/641)
<!-- Reviewable:end -->
