### PR TITLE
Support open participation in contests + hidden contests

### DIFF
--- a/cms/db/contest.py
+++ b/cms/db/contest.py
@@ -127,6 +127,13 @@ class Contest(Base):
         nullable=False,
         default=False)
 
+    # Whether to automatically create a participation for users when they log in
+    # to this contest. Useful for multi-contest setups.
+    open_participation = Column(
+        Boolean,
+        nullable=False,
+        default=False)
+
     # The parameters that control contest-tokens follow. Note that
     # their effect during the contest depends on the interaction with
     # the parameters that control task-tokens, defined on each Task.

--- a/cms/db/contest.py
+++ b/cms/db/contest.py
@@ -134,6 +134,14 @@ class Contest(Base):
         nullable=False,
         default=False)
 
+    # Whether this contest is hidden from the contest list. Useful for hiding
+    # contests which shouldn't be accessed yet, or contests which aren't meant
+    # to be participated on (e.g. a contest which is not processed by CWS).
+    hidden = Column(
+        Boolean,
+        nullable=False,
+        default=False)
+
     # The parameters that control contest-tokens follow. Note that
     # their effect during the contest depends on the interaction with
     # the parameters that control task-tokens, defined on each Task.

--- a/cms/db/contest.py
+++ b/cms/db/contest.py
@@ -127,8 +127,8 @@ class Contest(Base):
         nullable=False,
         default=False)
 
-    # Whether to automatically create a participation for users when they log in
-    # to this contest. Useful for multi-contest setups.
+    # Whether to automatically create a participation for users when they log
+    # in to this contest. Useful for multi-contest setups.
     open_participation = Column(
         Boolean,
         nullable=False,

--- a/cms/server/admin/handlers/contest.py
+++ b/cms/server/admin/handlers/contest.py
@@ -107,6 +107,7 @@ class ContestHandler(SimpleContestHandler("contest.html")):
             self.get_bool(attrs, "ip_restriction")
             self.get_bool(attrs, "ip_autologin")
             self.get_bool(attrs, "open_participation")
+            self.get_bool(attrs, "hidden")
 
             self.get_string(attrs, "token_mode")
             self.get_int(attrs, "token_max_number")

--- a/cms/server/admin/handlers/contest.py
+++ b/cms/server/admin/handlers/contest.py
@@ -10,6 +10,7 @@
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
 # Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
 # Copyright © 2016 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
+# Copyright © 2016 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -105,6 +106,7 @@ class ContestHandler(SimpleContestHandler("contest.html")):
             self.get_bool(attrs, "allow_password_authentication")
             self.get_bool(attrs, "ip_restriction")
             self.get_bool(attrs, "ip_autologin")
+            self.get_bool(attrs, "open_participation")
 
             self.get_string(attrs, "token_mode")
             self.get_int(attrs, "token_max_number")

--- a/cms/server/admin/templates/contest.html
+++ b/cms/server/admin/templates/contest.html
@@ -85,6 +85,15 @@
     </tr>
     <tr>
       <td>
+        <span class="info" title="Whether users should be able to see this contest or not."></span>
+        <label for="hidden">Hidden</label>
+      </td>
+      <td>
+        <input type="checkbox" id="hidden" name="hidden" {{ "checked" if contest.hidden else "" }}/>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <span class="info" title="The number of decimal places the scores will be rounded to.
                                   Example: '2' to allow 98.76."></span>
         Score decimal places

--- a/cms/server/admin/templates/contest.html
+++ b/cms/server/admin/templates/contest.html
@@ -76,6 +76,15 @@
     </tr>
     <tr>
       <td>
+        <span class="info" title="Whether existing users can independently join this contest."></span>
+        <label for="open_participation">Open participation</label>
+      </td>
+      <td>
+        <input type="checkbox" id="open_participation" name="open_participation" {{ "checked" if contest.open_participation else "" }}/>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <span class="info" title="The number of decimal places the scores will be rounded to.
                                   Example: '2' to allow 98.76."></span>
         Score decimal places

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -79,7 +79,8 @@ class BaseHandler(CommonRequestHandler):
         self.contest_list = {}
         if self.is_multi_contest():
             for contest in self.sql_session.query(Contest).all():
-                self.contest_list[contest.name] = contest
+                if not contest.hidden:
+                    self.contest_list[contest.name] = contest
 
     def render_params(self):
         """Return the default render params used by almost all handlers.

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -85,9 +85,14 @@ class LoginHandler(ContestHandler):
             return
 
         if participation is None:
-            # TODO: notify the user that they're uninvited
-            self.redirect(fallback_page + "?login_error=true")
-            return
+            if self.contest.open_participation:
+                # Create a participation on the fly
+                participation = Participation(user=user, contest=self.contest)
+                self.sql_session.commit()
+            else:
+                # TODO: notify the user that they're uninvited
+                self.redirect(fallback_page + "?login_error=true")
+                return
 
         # If a contest-specific password is defined, use that. If it's
         # not, use the user's main password.


### PR DESCRIPTION
This is useful if you have some users already in the database, and you want them to be able to automatically sign up to one or more contests without having to create a participation for them.

This PR depends on #594

---

UPDATE: I also added a commit which introduces Contest.hidden, a way to hide contests from the list (useful for contests which aren't ready yet, e.g. the "day2" of a 2-day contest, or for special contests which are not meant to be consumed by CWS, as in my use case).

I didn't create another PR because:
1. that PR would also need to be based on the multi_cws branch so, when that is merged, I would need to rebase two PRs instead of just one
2. it's a quite small change, after all

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/646)

<!-- Reviewable:end -->
