### PR TITLE
Make documentation for DB configuration a bit more clear

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,15 @@ install:
   - sudo pip install -r dev-requirements.txt
   - sudo python setup.py install
 
-  - sudo -u postgres psql -c "CREATE USER cmsuser WITH PASSWORD 'password';"
-  - sudo -u postgres psql -c "CREATE DATABASE database WITH OWNER cmsuser;"
-  - sudo -u postgres psql database -c "ALTER SCHEMA public OWNER TO cmsuser"
-  - sudo -u postgres psql database -c "GRANT SELECT ON pg_largeobject TO cmsuser"
+  - psql --username=postgres --command="CREATE USER cmsuser WITH PASSWORD 'your_password_here';"
 
-  - sudo -u postgres psql -c "CREATE DATABASE databasefortesting WITH OWNER cmsuser;"
-  - sudo -u postgres psql databasefortesting -c "ALTER SCHEMA public OWNER TO cmsuser"
-  - sudo -u postgres psql databasefortesting -c "GRANT SELECT ON pg_largeobject TO cmsuser"
+  - createdb --username=postgres --owner=cmsuser cmsdb
+  - psql --username=postgres --dbname=cmsdb --command='ALTER SCHEMA public OWNER TO cmsuser'
+  - psql --username=postgres --dbname=cmsdb --command='GRANT SELECT ON pg_largeobject TO cmsuser'
+
+  - createdb --username=postgres --owner=cmsuser cmsdbfortesting
+  - psql --username=postgres --dbname=cmsdbfortesting --command='ALTER SCHEMA public OWNER TO cmsuser'
+  - psql --username=postgres --dbname=cmsdbfortesting --command='GRANT SELECT ON pg_largeobject TO cmsuser'
 
   - sudo chown root:$USER /usr/local/bin/isolate /usr/local/etc/cms.conf
   - sudo chmod 750 /usr/local/bin/isolate

--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -42,7 +42,7 @@
     "_section": "Database",
 
     "_help": "Connection string for the database.",
-    "database": "postgresql+psycopg2://cmsuser:password@localhost/database",
+    "database": "postgresql+psycopg2://cmsuser:your_password_here@localhost/cmsdb",
 
     "_help": "Whether SQLAlchemy prints DB queries on stdout.",
     "database_debug": false,

--- a/docs/Running CMS.rst
+++ b/docs/Running CMS.rst
@@ -8,11 +8,10 @@ The first thing to do is to create the user and the database. For PostgreSQL, th
 
 .. sourcecode:: bash
 
-    sudo su - postgres
-    createuser cmsuser -P
-    createdb -O cmsuser database
-    psql database -c 'ALTER SCHEMA public OWNER TO cmsuser'
-    psql database -c 'GRANT SELECT ON pg_largeobject TO cmsuser'
+    createuser --username=postgres --pwprompt cmsuser
+    createdb --username=postgres --owner=cmsuser cmsdb
+    psql --username=postgres --dbname=cmsdb --command='ALTER SCHEMA public OWNER TO cmsuser'
+    psql --username=postgres --dbname=cmsdb --command='GRANT SELECT ON pg_largeobject TO cmsuser'
 
 The last two lines are required to give the PostgreSQL user some privileges which it does not have by default, despite being the database owner.
 
@@ -32,7 +31,7 @@ Finally you have to create the database schema for CMS, by running:
 
     Moreover, you need to change the HBA (a sort of access control list for PostgreSQL) to accept login requests from outside localhost. Open the file :file:`pg_hba.conf` and add a line like this one::
 
-        host  database  cmsuser  192.168.0.0/24  md5
+        host  cmsdb  cmsuser  192.168.0.0/24  md5
 
 
 .. _running-cms_configuring-cms:


### PR DESCRIPTION
I believe that by using the `-U` argument instead of directly logging in as the postgres user, the DB configuration steps described in the documentation become more intuitive. Moreover, I found that using the expanded version of each flag (`--username` instead of `-U`) makes it even more clear to newcomers. It's always a good idea to have a vision of what's happening that is as clear as possible. I also changed the `database` and `password` defaults, which may look like keywords.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/656)
<!-- Reviewable:end -->
