### PR TITLE
Prevent rpc error from leaking connection and reduce resource refresh size.

### DIFF
--- a/cms/io/web_rpc.py
+++ b/cms/io/web_rpc.py
@@ -141,8 +141,7 @@ class RPCMiddleware(object):
         result = self._service.remote_services[remote_service].execute_rpc(
             args['method'], data)
 
-        # XXX We could set a timeout on the .wait().
-        result.wait()
+        result.wait(timeout=60)
 
         response = Response()
 

--- a/cms/server/admin/templates/resources.html
+++ b/cms/server/admin/templates/resources.html
@@ -269,8 +269,8 @@ var plotOptions = {
 {% end %}
 
 {% block js_init %}
-
-for (var i = 0; i < {{ resource_shards }}; i++)
+var shards = {% raw json_encode(resource_addresses) %};
+for (var i in shards)
 {
     getters[i] = new RSgetter(i, plotOptions);
     var f = utils.bind_func(getters[i], getters[i].update_resources);


### PR DESCRIPTION
I managed to accidentally make the AWS unusable by closing my laptop with resource usage page opened.

Here is what happens:

* opening resource usage page sets last_time,
* closing laptop keeps the page opened without updating resource stats,
* after opening laptop javascript tries to request information about what happened during the hour laptop was closed,
* `RemoteServiceBase` ignores request "because it was larger than %d",
* `RPCMiddleware` keeps waiting the ignored request forever keeping the connection opened,
* browser continues sending requests until AWS runs out of file descriptors.

Limiting time period returned by `get_resources` should prevent this type of bad request. Adding a timeout should prevent number of waiting connections from accumulating. It won't protect it from being intentionally overwhelmed, but that could be done using sufficient amount of any request.

Additionally I changed resource template so that it only requests and tries to draw information about currently opened machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/682)
<!-- Reviewable:end -->
