### PR TITLE
Improve CSRF protection

### DIFF
--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -311,7 +311,8 @@ class BaseHandler(CommonRequestHandler):
         that. So far I'm leaving it to minimize changes.
 
         """
-        self.sql_session.close()
+        if self.sql_session:  # Request was stopped early, no session to close.
+            self.sql_session.close()
         try:
             tornado.web.RequestHandler.finish(self, *args, **kwds)
         except IOError:

--- a/cms/server/admin/handlers/dataset.py
+++ b/cms/server/admin/handlers/dataset.py
@@ -322,7 +322,7 @@ class ToggleAutojudgeDatasetHandler(BaseHandler):
 
     """
     @require_permission(BaseHandler.PERMISSION_ALL)
-    def get(self, dataset_id):
+    def post(self, dataset_id):
         dataset = self.safe_get_item(Dataset, dataset_id)
 
         dataset.autojudge = not dataset.autojudge
@@ -337,7 +337,7 @@ class ToggleAutojudgeDatasetHandler(BaseHandler):
             self.application.service\
                 .scoring_service.search_operations_not_done()
 
-        self.redirect("/task/%s" % dataset.task_id)
+        self.write("./%d" % dataset.task_id)
 
 
 class AddManagerHandler(BaseHandler):
@@ -395,7 +395,7 @@ class DeleteManagerHandler(BaseHandler):
 
     """
     @require_permission(BaseHandler.PERMISSION_ALL)
-    def get(self, dataset_id, manager_id):
+    def delete(self, dataset_id, manager_id):
         manager = self.safe_get_item(Manager, manager_id)
         dataset = self.safe_get_item(Dataset, dataset_id)
 
@@ -403,12 +403,12 @@ class DeleteManagerHandler(BaseHandler):
         if manager.dataset is not dataset:
             raise tornado.web.HTTPError(404)
 
-        task = manager.dataset.task
+        task_id = dataset.task_id
 
         self.sql_session.delete(manager)
 
         self.try_commit()
-        self.redirect("/task/%s" % task.id)
+        self.write("./%d" % task_id)
 
 
 class AddTestcaseHandler(BaseHandler):
@@ -549,7 +549,7 @@ class DeleteTestcaseHandler(BaseHandler):
 
     """
     @require_permission(BaseHandler.PERMISSION_ALL)
-    def get(self, dataset_id, testcase_id):
+    def delete(self, dataset_id, testcase_id):
         testcase = self.safe_get_item(Testcase, testcase_id)
         dataset = self.safe_get_item(Dataset, dataset_id)
 
@@ -557,14 +557,14 @@ class DeleteTestcaseHandler(BaseHandler):
         if dataset is not testcase.dataset:
             raise tornado.web.HTTPError(404)
 
-        task = testcase.dataset.task
+        task_id = testcase.dataset.task_id
 
         self.sql_session.delete(testcase)
 
         if self.try_commit():
             # max_score and/or extra_headers might have changed.
             self.application.service.proxy_service.reinitialize()
-        self.redirect("/task/%s" % task.id)
+        self.write("./%d" % task_id)
 
 
 class DownloadTestcasesHandler(FileHandler):

--- a/cms/server/admin/handlers/main.py
+++ b/cms/server/admin/handlers/main.py
@@ -90,7 +90,7 @@ class LogoutHandler(BaseHandler):
     """Logout handler.
 
     """
-    def get(self):
+    def post(self):
         self.service.auth_handler.clear()
         self.redirect("/")
 

--- a/cms/server/admin/server.py
+++ b/cms/server/admin/server.py
@@ -64,6 +64,7 @@ class AdminWebServer(WebService):
             "auth_middleware": AWSAuthMiddleware,
             "rpc_enabled": True,
             "rpc_auth": self.is_rpc_authorized,
+            "xsrf_cookies": True,
         }
         super(AdminWebServer, self).__init__(
             config.admin_listen_port,

--- a/cms/server/admin/static/aws_style.css
+++ b/cms/server/admin/static/aws_style.css
@@ -100,7 +100,9 @@ ul.normal_list {
     padding-left: 0.5em;
 }
 
-
+.inline {
+    display: inline;
+}
 
 
 

--- a/cms/server/admin/static/aws_utils.js
+++ b/cms/server/admin/static/aws_utils.js
@@ -653,14 +653,14 @@ CMS.AWSUtils.prototype.ajax_request = function(url, args, callback) {
     });
 };
 
-
 /**
  * Sends a delete request and on success redirect to the page
  * specified in the response, if present.
  */
 CMS.AWSUtils.ajax_delete = function(url) {
   var settings = {
-    'type': 'DELETE'
+    'type': 'DELETE',
+    headers: {"X-XSRFToken": get_cookie("_xsrf")}
   };
   settings['success'] = function(data_redirect_url) {
     if (data_redirect_url) {

--- a/cms/server/admin/static/aws_utils.js
+++ b/cms/server/admin/static/aws_utils.js
@@ -653,13 +653,14 @@ CMS.AWSUtils.prototype.ajax_request = function(url, args, callback) {
     });
 };
 
+
 /**
- * Sends a delete request and on success redirect to the page
+ * Sends a request and on success redirect to the page
  * specified in the response, if present.
  */
-CMS.AWSUtils.ajax_delete = function(url) {
+CMS.AWSUtils.ajax_request = function(type, url) {
   var settings = {
-    'type': 'DELETE',
+    'type': type,
     headers: {"X-XSRFToken": get_cookie("_xsrf")}
   };
   settings['success'] = function(data_redirect_url) {
@@ -668,4 +669,22 @@ CMS.AWSUtils.ajax_delete = function(url) {
     }
   };
   $.ajax(url, settings);
+};
+
+
+/**
+ * Sends a delete request and on success redirect to the page
+ * specified in the response, if present.
+ */
+CMS.AWSUtils.ajax_delete = function(url) {
+  CMS.AWSUtils.ajax_request('DELETE', url);
+};
+
+
+/**
+ * Sends a post request and on success. See AWSUtils.ajax_request
+ * for more details.
+ */
+CMS.AWSUtils.ajax_post = function(url) {
+  CMS.AWSUtils.ajax_request('POST', url);
 };

--- a/cms/server/admin/static/aws_utils.js
+++ b/cms/server/admin/static/aws_utils.js
@@ -658,17 +658,17 @@ CMS.AWSUtils.prototype.ajax_request = function(url, args, callback) {
  * Sends a request and on success redirect to the page
  * specified in the response, if present.
  */
-CMS.AWSUtils.ajax_request = function(type, url) {
-  var settings = {
-    'type': type,
-    headers: {"X-XSRFToken": get_cookie("_xsrf")}
-  };
-  settings['success'] = function(data_redirect_url) {
-    if (data_redirect_url) {
-      window.location.replace(data_redirect_url);
-    }
-  };
-  $.ajax(url, settings);
+CMS.AWSUtils.ajax_edit_request = function(type, url) {
+    var settings = {
+        "type": type,
+        headers: {"X-XSRFToken": get_cookie("_xsrf")}
+    };
+    settings["success"] = function(data_redirect_url) {
+        if (data_redirect_url) {
+            window.location.replace(data_redirect_url);
+        }
+    };
+    $.ajax(url, settings);
 };
 
 
@@ -677,7 +677,7 @@ CMS.AWSUtils.ajax_request = function(type, url) {
  * specified in the response, if present.
  */
 CMS.AWSUtils.ajax_delete = function(url) {
-  CMS.AWSUtils.ajax_request('DELETE', url);
+    CMS.AWSUtils.ajax_edit_request("DELETE", url);
 };
 
 
@@ -686,5 +686,5 @@ CMS.AWSUtils.ajax_delete = function(url) {
  * for more details.
  */
 CMS.AWSUtils.ajax_post = function(url) {
-  CMS.AWSUtils.ajax_request('POST', url);
+    CMS.AWSUtils.ajax_edit_request("POST", url);
 };

--- a/cms/server/admin/static/web_rpc.js
+++ b/cms/server/admin/static/web_rpc.js
@@ -21,7 +21,7 @@
 
 function get_cookie(name) {
     var r = document.cookie.match("(^|;)\\s*" + name + "=([^;]*)(;|$)");
-    return r ? r[2] : undefined;
+    return r ? r[2] : void(0);
 }
 
 /**
@@ -42,8 +42,8 @@ function cmsrpc_request(url_root, service, shard, method, args, callback) {
         type: "POST",
         url: url,
         data: JSON.stringify(args),
-        contentType: 'application/json',
-        dataType: 'json',
+        contentType: "application/json",
+        dataType: "json",
         headers: {"X-XSRFToken": get_cookie("_xsrf")}
     });
 
@@ -69,4 +69,4 @@ function cmsrpc_request(url_root, service, shard, method, args, callback) {
     });
 
     return jqxhr;
-};
+}

--- a/cms/server/admin/static/web_rpc.js
+++ b/cms/server/admin/static/web_rpc.js
@@ -18,6 +18,12 @@
 
 "use strict";
 
+
+function get_cookie(name) {
+    var r = document.cookie.match("(^|;)\\s*" + name + "=([^;]*)(;|$)");
+    return r ? r[2] : undefined;
+}
+
 /**
  * Call a RPC method of a remote service, proxied by AWS.
  *
@@ -37,7 +43,8 @@ function cmsrpc_request(url_root, service, shard, method, args, callback) {
         url: url,
         data: JSON.stringify(args),
         contentType: 'application/json',
-        dataType: 'json'
+        dataType: 'json',
+        headers: {"X-XSRFToken": get_cookie("_xsrf")}
     });
 
     jqxhr.done(function(data) {

--- a/cms/server/admin/templates/activate_dataset.html
+++ b/cms/server/admin/templates/activate_dataset.html
@@ -58,6 +58,7 @@ below, and wait for it to complete.
 </p>
 
 <form action="{{ url_root }}/dataset/{{ dataset.id }}/activate" method="POST">
+{% module xsrf_form_html() %}
 {% if len(changes) == 0 %}
 <p>Good news! At present, switching to this dataset will have no effect on the
 scores. No notifications will be sent.</p>

--- a/cms/server/admin/templates/add_admin.html
+++ b/cms/server/admin/templates/add_admin.html
@@ -8,6 +8,7 @@
 
 <!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
 <form enctype="multipart/form-data" action="{{ url_root }}/admins/add" method="post" >
+  {% module xsrf_form_html() %}
   <h2>Admin information</h2>
 
   {% include fragments/admin_form.html %}

--- a/cms/server/admin/templates/add_attachment.html
+++ b/cms/server/admin/templates/add_attachment.html
@@ -5,6 +5,7 @@
   <h1><a href="{{ url_root }}/task/{{ task.id }}">{{ task.title }} ({{ task.name }})</a> - Upload attachment</h1>
 </div>
 <form enctype="multipart/form-data" action="{{ url_root }}/task/{{ task.id }}/attachments/add" method="POST">
+  {% module xsrf_form_html() %}
   <input type="file" name="attachment"/><br/>
   <input type="submit" value="Upload">
   <input type="Reset" >

--- a/cms/server/admin/templates/add_contest.html
+++ b/cms/server/admin/templates/add_contest.html
@@ -11,6 +11,7 @@
 
 <!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
 <form enctype="multipart/form-data" action="{{ url_root }}/contests/add" method="POST" name="add_contest">
+  {% module xsrf_form_html() %}
   <span class="info" title="A short name for the contest, preferably using only letters, numbers and underscores."></span>
   Name:
   <input type="text" name="name">

--- a/cms/server/admin/templates/add_dataset.html
+++ b/cms/server/admin/templates/add_dataset.html
@@ -28,6 +28,7 @@ $("select[name=task_type]").change(showTaskTypeOption);
 You are cloning the dataset "{{ original_dataset.description }}".
 <form enctype="multipart/form-data" action="{{ url_root }}/dataset/{{ clone_id }}/clone" method="POST">
 {% end %}
+  {% module xsrf_form_html() %}
   <table>
     <tr><td colspan=2><h2>Dataset information</h2></td></tr>
     <tr>

--- a/cms/server/admin/templates/add_manager.html
+++ b/cms/server/admin/templates/add_manager.html
@@ -5,6 +5,7 @@
   <h1><a href="{{ url_root }}/task/{{ task.id }}">{{ task.title }} ({{ task.name }})</a> - Upload manager</h1>
 </div>
 <form enctype="multipart/form-data" action="{{ url_root }}/dataset/{{ dataset.id }}/managers/add" method="POST">
+  {% module xsrf_form_html() %}
   <input type="file" name="manager"/><br/>
   <input type="submit" value="Upload">
   <input type="Reset" >

--- a/cms/server/admin/templates/add_statement.html
+++ b/cms/server/admin/templates/add_statement.html
@@ -5,6 +5,7 @@
   <h1><a href="{{ url_root }}/task/{{ task.id }}">{{ task.title }} ({{ task.name }})</a> - Upload statement</h1>
 </div>
 <form enctype="multipart/form-data" action="{{ url_root }}/task/{{ task.id }}/statements/add" method="POST">
+  {% module xsrf_form_html() %}
   Language code: <input type="text" name="language"/><br/>
   <input type="file" name="statement"/><br/>
   <input type="submit" value="Upload">

--- a/cms/server/admin/templates/add_task.html
+++ b/cms/server/admin/templates/add_task.html
@@ -8,6 +8,7 @@
 
 <!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
 <form enctype="multipart/form-data" action="{{ url_root }}/tasks/add" method="post" >
+  {% module xsrf_form_html() %}
   <span class="info" title="A short name for the task, preferably using only letters, numbers and underscores."></span>
   Name:
   <input type="text" name="name">

--- a/cms/server/admin/templates/add_team.html
+++ b/cms/server/admin/templates/add_team.html
@@ -8,6 +8,7 @@
 <div id="general_info">
   <!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
   <form enctype="multipart/form-data" action="{{ url_root }}/teams/add" method="POST">
+    {% module xsrf_form_html() %}
     <table>
       <tr>
         <td>Code</td>

--- a/cms/server/admin/templates/add_testcase.html
+++ b/cms/server/admin/templates/add_testcase.html
@@ -5,6 +5,7 @@
   <h1><a href="{{ url_root }}/task/{{ task.id }}">{{ task.title }} ({{ task.name }})</a> - Upload testcase</h1>
 </div>
 <form enctype="multipart/form-data" action="{{ url_root }}/dataset/{{ dataset.id }}/testcases/add" method="POST">
+  {% module xsrf_form_html() %}
   <table>
     <tr>
       <td>Codename:</td>

--- a/cms/server/admin/templates/add_testcases.html
+++ b/cms/server/admin/templates/add_testcases.html
@@ -5,6 +5,7 @@
   <h1><a href="{{ url_root }}/task/{{ task.id }}">{{ task.title }} ({{ task.name }})</a> - Upload testcases</h1>
 </div>
 <form enctype="multipart/form-data" action="{{ url_root }}/dataset/{{ dataset.id }}/testcases/add_multiple" method="POST">
+  {% module xsrf_form_html() %}
   <table>
     <tr>
       <td>Archive (a zip file containing files only):</td>

--- a/cms/server/admin/templates/add_user.html
+++ b/cms/server/admin/templates/add_user.html
@@ -8,6 +8,7 @@
 <div id="general_info">
   <!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
   <form enctype="multipart/form-data" action="{{ url_root }}/users/add" method="POST">
+    {% module xsrf_form_html() %}
     <table>
       <tr>
         <td>

--- a/cms/server/admin/templates/admin.html
+++ b/cms/server/admin/templates/admin.html
@@ -8,6 +8,7 @@
 
 <!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
 <form enctype="multipart/form-data" action="{{ url_root }}/admin/{{ admin.id }}" method="POST">
+  {% module xsrf_form_html() %}
   <h2>Admin information</h2>
 
   {% include fragments/admin_form.html %}

--- a/cms/server/admin/templates/announcements.html
+++ b/cms/server/admin/templates/announcements.html
@@ -12,6 +12,7 @@
     <div class="notification communication">
       <div class="notification_msg">
         <form method="post" action="{{ url_root }}/contest/{{ contest.id }}/announcements/add">
+          {% module xsrf_form_html() %}
           <div class="notification_subject">
             <label for="new_subject">Subject</label>
             <input type="text" name="subject" id="new_subject" style="width: 100%" list="task_names_list" autocomplete="off">

--- a/cms/server/admin/templates/base.html
+++ b/cms/server/admin/templates/base.html
@@ -75,7 +75,7 @@ $(document).ready(init);
         <div id="sidebar_header">
           <div class="login_notice">
             Hello, <a href="{{ url_root }}/admins">{{ current_user.name }}</a>.
-              Logout <a href="{{ url_root }}/logout">here</a>.
+              <form class="inline" action="{{ url_root }}/logout" method="POST">{% module xsrf_form_html() %}<input type="submit" value="Logout"></form>
           </div>
           {% if contest is None %}
           <h1 class="parent">Administration</h1>

--- a/cms/server/admin/templates/contest.html
+++ b/cms/server/admin/templates/contest.html
@@ -15,7 +15,7 @@
 
 <!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
 <form enctype="multipart/form-data" action="{{ url_root }}/contest/{{ contest.id }}" method="POST" name="edit_contest" style="display:inline;">
-
+  {% module xsrf_form_html() %}
   <table class="sub_table">
 
     <tr><td colspan=2><h2>Contest information</h2></td></tr>

--- a/cms/server/admin/templates/contest.html
+++ b/cms/server/admin/templates/contest.html
@@ -269,6 +269,7 @@
   <input type="reset" value="Reset">
 </form>
 <form action="{{ url_root }}/contests" method="POST" style="display:inline;">
+    {% module xsrf_form_html() %}
     <input type="hidden" name="contest_id" value="{{contest.id}}"/>
     <input type="submit"
          name="operation"

--- a/cms/server/admin/templates/contest_tasks.html
+++ b/cms/server/admin/templates/contest_tasks.html
@@ -6,6 +6,7 @@
 </div>
 
 <form action="{{ url_root }}/contest/{{ contest.id }}/tasks/add" method="POST">
+  {% module xsrf_form_html() %}
   Add a new task:
   <select name="task_id">
     <option value="null" selected>Select a new task</option>
@@ -23,6 +24,7 @@
 </form>
 
 <form action="{{ url_root }}/contest/{{ contest.id }}/tasks" method="POST">
+  {% module xsrf_form_html() %}
   Edit selected task:
   <input type="submit" name="operation"
 {% if not current_user.permission_all %}

--- a/cms/server/admin/templates/contest_users.html
+++ b/cms/server/admin/templates/contest_users.html
@@ -14,6 +14,7 @@
 {% end %}
 
 <form action="{{ url_root }}/contest/{{ contest.id }}/users/add" method="POST">
+  {% module xsrf_form_html() %}
   Add a new user:
   <select name="user_id">
     <option value="null" selected>Select a new user</option>
@@ -31,6 +32,7 @@
 </form>
 
 <form action="{{ url_root }}/contest/{{ contest.id }}/users" method="POST">
+  {% module xsrf_form_html() %}
   Edit selected user:
   <input type="submit"
          name="operation"

--- a/cms/server/admin/templates/contests.html
+++ b/cms/server/admin/templates/contests.html
@@ -7,6 +7,7 @@
 </div>
 
 <form action="{{ url_root }}/contests" method="POST">
+  {% module xsrf_form_html() %}
   Edit selected contest:
    <input type="submit"
          name="operation"

--- a/cms/server/admin/templates/delete_dataset.html
+++ b/cms/server/admin/templates/delete_dataset.html
@@ -6,6 +6,7 @@
 </div>
 
 <form action="{{ url_root }}/dataset/{{ dataset.id }}/delete" method="POST">
+    {% module xsrf_form_html() %}
 
     Are you sure you want to delete the dataset "{{ dataset.description }}" and all associated managers, test cases, and submission results?<br/>
 

--- a/cms/server/admin/templates/download_testcases.html
+++ b/cms/server/admin/templates/download_testcases.html
@@ -5,6 +5,7 @@
   <h1><a href="{{ url_root }}/task/{{ task.id }}">{{ task.title }} ({{ task.name }})</a> - Download all testcases</h1>
 </div>
 <form action="{{ url_root }}/dataset/{{ dataset.id }}/testcases/download" method="POST">
+  {% module xsrf_form_html() %}
   <table>
     <tr>
       <td>Zip file name</td>

--- a/cms/server/admin/templates/login.html
+++ b/cms/server/admin/templates/login.html
@@ -17,6 +17,7 @@
     {% end %}
 <p>Please log in:</p>
 <form action="{{ url_root }}/login" method="POST">
+  {% module xsrf_form_html() %}
   <input type="hidden" name="next" value="{{ handler.get_argument("next", "/") }}">
   <div class="section">
     <label>

--- a/cms/server/admin/templates/participation.html
+++ b/cms/server/admin/templates/participation.html
@@ -57,6 +57,7 @@ function update_additional_answer(element, invoker)
 <div id="participation_info">
   <!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
   <form enctype="multipart/form-data" action="{{ url_root }}/contest/{{ contest.id }}/user/{{ selected_user.id }}/edit" method="POST">
+    {% module xsrf_form_html() %}
     <table>
       <tr>
         <td>
@@ -158,6 +159,7 @@ function update_additional_answer(element, invoker)
         <div class="reply_question" >
           <hr/>
           <form class="reply_question_form" action="{{ url_root }}/contest/{{ contest.id }}/question/{{ msg.id }}/reply" method="POST">
+            {% module xsrf_form_html() %}
             <input type="hidden" name="ref" value="/contest/{{ contest.id }}/user/{{ selected_user.id }}"/>
             Precompiled answer:
             <select name="reply_question_quick_answer" onchange="update_additional_answer({{ msg_i }}, this);">
@@ -195,6 +197,7 @@ function update_additional_answer(element, invoker)
   <div class="notifications">
       <div class="notification communication">
         <form id="send_message_form" action="{{ url_root }}/contest/{{ contest.id }}/user/{{ selected_user.id }}/message" method="POST">
+          {% module xsrf_form_html() %}
           <div class="notification_msg">
             <div class="notification_subject">
               Subject:

--- a/cms/server/admin/templates/questions.html
+++ b/cms/server/admin/templates/questions.html
@@ -60,6 +60,7 @@ utils.show_page("questions", 1);
       {% if msg.reply_timestamp is None %}
       <div class="ignore_reply">
         <form class="ignore_question_form" action="{{ url_root }}/contest/{{ contest.id }}/question/{{ msg.id }}/ignore" name="ignore{{ msg.id }}" method="POST">
+          {% module xsrf_form_html() %}
           <input type="hidden" name="ref" value="/contest/{{ contest.id }}/questions"/>
           {% if not msg.ignored %}
           <input type="hidden" name="ignore" value="yes"/>
@@ -77,6 +78,7 @@ utils.show_page("questions", 1);
       <div class="reply_question" >
         <hr/>
         <form class="reply_question_form" action="{{ url_root }}/contest/{{ contest.id }}/question/{{ msg.id }}/reply" method="POST">
+          {% module xsrf_form_html() %}
           <input type="hidden" name="ref" value="/contest/{{ contest.id }}/questions"/>
           Precompiled answer:
           <select name="reply_question_quick_answer" onchange="update_additional_answer({{ msg_i }}, this);">

--- a/cms/server/admin/templates/rename_dataset.html
+++ b/cms/server/admin/templates/rename_dataset.html
@@ -6,6 +6,7 @@
 </div>
 
 <form action="{{ url_root }}/dataset/{{ dataset.id }}/rename" method="POST">
+  {% module xsrf_form_html() %}
   <table>
     <tr>
       <td>Edit description (each dataset must have a unique description):</td>

--- a/cms/server/admin/templates/submission.html
+++ b/cms/server/admin/templates/submission.html
@@ -122,6 +122,7 @@
 
 <div id="comment">
   <form enctype="multipart/form-data" action="{{ url_root }}/submission/{{ s.id }}/{{ shown_dataset.id }}/comment" method="POST">
+    {% module xsrf_form_html() %}
     <textarea name="comment" cols="40" rows="3">{{ s.comment }}</textarea><br/>
     <input
 {% if not current_user.permission_all %}

--- a/cms/server/admin/templates/task.html
+++ b/cms/server/admin/templates/task.html
@@ -478,6 +478,7 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
   <input type="reset" value="Reset" />
 </form>
 <form action="{{ url_root }}/tasks" method="POST" style="display:inline;">
+    {% module xsrf_form_html() %}
     <input type="hidden" name="task_id" value="{{task.id}}"/>
     <input type="submit"
          name="operation"

--- a/cms/server/admin/templates/task.html
+++ b/cms/server/admin/templates/task.html
@@ -288,7 +288,7 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
       <a href="{{ url_root }}/dataset/{{ dataset.id }}/delete">[Delete]</a>
       {% end %}
       {% if dataset is not task.active_dataset %}
-        <a href="{{ url_root }}/dataset/{{ dataset.id }}/autojudge">[{% if dataset.autojudge %}Disable{% else %}Enable{% end %} background judging]</a>
+        <a onclick="CMS.AWSUtils.ajax_post('{{ url_root }}/dataset/{{ dataset.id }}/autojudge');">[{% if dataset.autojudge %}Disable{% else %}Enable{% end %} background judging]</a>
       {% end %}
 {% end %}
       <a href="{{ url_root }}/dataset/{{ dataset.id }}">[View results]</a>
@@ -390,7 +390,7 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
               {% for manager in dataset.managers.values() %}
                 <div class="manager">
                   <a href="{{ url_root }}/file/{{ manager.digest }}/{{ manager.filename }}">{{ manager.filename }}</a>
-                  - <a href="{{ url_root }}/dataset/{{ dataset.id }}/manager/{{ manager.id }}/delete">Delete</a>
+                  - <a onclick="CMS.AWSUtils.ajax_delete('{{ url_root }}/dataset/{{ dataset.id }}/manager/{{ manager.id }}/delete');">Delete</a>
                 </div>
               {% end %}
             {% end %}
@@ -459,7 +459,7 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
               <a href="javascript:void(0);" onclick="utils.show_file('output_{{ testcase.codename }}','{{ url_root }}/file/{{ testcase.output }}/output_{{ testcase.codename }}')">Show output</a>
             </td>
             <td>
-              <a href="{{ url_root }}/dataset/{{ dataset.id }}/testcase/{{ testcase.id }}/delete">Delete</a>
+              <a onclick="CMS.AWSUtils.ajax_delete('{{ url_root }}/dataset/{{ dataset.id }}/testcase/{{ testcase.id }}/delete');">Delete</a>
             </td>
           </tr>
           {% end %}

--- a/cms/server/admin/templates/task.html
+++ b/cms/server/admin/templates/task.html
@@ -46,6 +46,7 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
 
 <!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
 <form enctype="multipart/form-data" action="{{ url_root }}/task/{{ task.id }}" method="POST" style="display:inline;">
+  {% module xsrf_form_html() %}
   <h2 id="title_task_configuration" class="toggling_on">Task configuration</h2>
   <div id="task_configuration">
     <table>

--- a/cms/server/admin/templates/tasks.html
+++ b/cms/server/admin/templates/tasks.html
@@ -7,6 +7,7 @@
 </div>
 
 <form action="{{ url_root }}/tasks" method="POST">
+  {% module xsrf_form_html() %}
   Edit selected task:
    <input type="submit"
          name="operation"

--- a/cms/server/admin/templates/team.html
+++ b/cms/server/admin/templates/team.html
@@ -8,6 +8,7 @@
 <div id="general_info">
   <!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
   <form enctype="multipart/form-data" action="{{ url_root }}/team/{{ team.id }}" method="POST">
+    {% module xsrf_form_html() %}
     <table>
       <tr>
         <td>Code</td>

--- a/cms/server/admin/templates/user.html
+++ b/cms/server/admin/templates/user.html
@@ -127,6 +127,7 @@
     <input type="reset" value="Reset" />
   </form>
   <form action="{{ url_root }}/users" method="POST" style="display:inline;">
+      {% module xsrf_form_html() %}
       <input type="hidden" name="user_id" value="{{user.id}}"/>
       <input type="submit"
            name="operation"

--- a/cms/server/admin/templates/user.html
+++ b/cms/server/admin/templates/user.html
@@ -10,6 +10,7 @@
 <div id="participations">
 
   <form action="{{ url_root }}/user/{{ user.id }}/add_participation" method="POST">
+    {% module xsrf_form_html() %}
     Add a new participation:
     <select name="contest_id">
       <option value="null" selected>Select a contest</option>
@@ -28,6 +29,7 @@
   <p>No participations found.</p>
   {% else %}
   <form action="{{ url_root }}/user/{{ user.id }}/edit_participation" method="POST">
+    {% module xsrf_form_html() %}
     Edit selected participation:
     <input type="submit" name="operation" value="Remove" />
     <table class="bordered">
@@ -66,6 +68,7 @@
 <div id="general_info">
   <!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
   <form enctype="multipart/form-data" action="{{ url_root }}/user/{{ user.id }}" method="POST" style="display:inline;">
+    {% module xsrf_form_html() %}
     <table>
       <tr>
         <td>

--- a/cms/server/admin/templates/users.html
+++ b/cms/server/admin/templates/users.html
@@ -7,6 +7,7 @@
 </div>
 
 <form action="{{ url_root }}/users" method="POST">
+  {% module xsrf_form_html() %}
   Edit selected user:
    <input type="submit"
          name="operation"

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -146,7 +146,7 @@ class LogoutHandler(BaseHandler):
     """Logout handler.
 
     """
-    def get(self):
+    def post(self):
         self.clear_cookie("login")
         self.redirect("/")
 

--- a/cms/server/contest/server.py
+++ b/cms/server/contest/server.py
@@ -72,6 +72,7 @@ class ContestWebServer(WebService):
             "debug": config.tornado_debug,
             "is_proxy_used": config.is_proxy_used,
             "num_proxies_used": config.num_proxies_used,
+            "xsrf_cookies": True,
         }
 
         try:

--- a/cms/server/contest/templates/base.html
+++ b/cms/server/contest/templates/base.html
@@ -67,9 +67,12 @@ $(document).ready(function () {
                     </p>
 {% end %}
 {% if current_user is not None %}
+                    <form action="{{ url_root }}/logout" method="POST" class="navbar-form pull-right">
+                        {% module xsrf_form_html() %}
+                        <button type="submit" class="btn btn-warning">{{ _('Logout') }}</button>
+                    </form>
                     <p class="navbar-text pull-right">
                         {% raw _("Logged in as <strong>%(first_name)s %(last_name)s</strong> <em>(%(username)s)</em>") % {"first_name": escape(current_user.user.first_name), "last_name": escape(current_user.user.last_name), "username": escape(current_user.user.username)} %}
-                        <a class="btn btn-warning" href="{{ url_root }}/logout">{{ _("Logout") }}</a>
                     </p>
 {% end %}
                 </div>

--- a/cms/server/contest/templates/base.html
+++ b/cms/server/contest/templates/base.html
@@ -89,6 +89,7 @@ $(document).ready(function () {
                 <h1>{{ _("Welcome") }}</h1>
                 <p>{{ _("Please log in") }}</p>
                 <form class="form-horizontal" action="{{ url_root }}/login" method="POST">
+                    {% module xsrf_form_html() %}
                     <input type="hidden" name="next" value="{{ handler.get_argument("next", "/") }}">
                     <fieldset>
                         <div class="control-group">

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -34,6 +34,7 @@
 <h2>{{ _("Questions") }}</h2>
 <div class="well question_submit">
     <form class="form-horizontal" action="{{ url_root }}/question" method="POST">
+        {% module xsrf_form_html() %}
         <fieldset>
             <div class="control-group">
                 <label class="control-label" for="input_subject">{{ _("Subject") }}</label>

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -129,6 +129,7 @@
 
     {% if actual_phase == -1 %}
         <form action="{{ url_root }}/start" method="POST" style="margin: 0">
+            {% module xsrf_form_html() %}
             <input type="hidden" name="next" value="{{ url_root + request.path }}">
             <button type="submit" class="btn btn-danger btn-large" style="width:100%;-moz-box-sizing:border-box;box-sizing:border-box;" type="submit">{{ _("Start!") }}</button>
         </form>

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -21,6 +21,7 @@
 
 <div id="print" class="row">
     <form class="form-horizontal" enctype="multipart/form-data" action="{{ url_root }}/printing" method="POST">
+        {% module xsrf_form_html() %}
         <fieldset>
             <div class="control-group">
                 <label class="control-label" for="input">{% if pdf_printing_allowed %}{{ _("File (text or PDF)") }}{% else %}{{ _("File (text)") }}{% end %}</label>

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -128,6 +128,7 @@
             {% comment TODO If the expiration or generation time are greater than valid_phase_end they "don't exist". It's useless to show "Wait..." in those cases. %}
             {% if can_play_token and not need_to_wait %}
         <form action="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/submissions/{{ s_idx }}/token" method="POST">
+            {% module xsrf_form_html() %}
             <button type="submit" class="btn btn-warning">{{ _("Play!") }}</button>
         </form>
             {% elif (can_play_token and need_to_wait) or (not can_play_token and tokens_info[1] is not None) %}

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -98,6 +98,7 @@ $(document).ready(function () {
 <div id="submit_solution" class="row">
     <div class="span5">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/submit" method="POST">
+            {% module xsrf_form_html() %}
             <fieldset>
 {% for idx, filename in enumerate(x.filename for x in task.submission_format) %}
                 <div class="control-group">
@@ -119,6 +120,7 @@ $(document).ready(function () {
 {% if len(task.submission_format) > 1 and not any(x.filename.endswith(".%l") for x in task.submission_format) %}
     <div class="span4">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/submit" method="POST">
+            {% module xsrf_form_html() %}
             <fieldset>
                 <div class="control-group">
                     <label class="control-label" for="input_zip">{{ _("submission.zip") }}</label>

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -99,6 +99,7 @@ $(document).ready(function () {
 <div class="submit_test row">
     <div class="span5">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/test" method="POST">
+            {% module xsrf_form_html() %}
             <fieldset>
 {% for idx, filename in enumerate([x.filename for x in task.submission_format] + task_type.get_user_managers(task.submission_format)) %}
                 <div class="control-group">
@@ -126,6 +127,7 @@ $(document).ready(function () {
 {% if not any(x.filename.endswith(".%l") for x in task.submission_format) %}
     <div class="span4">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ url_root }}/tasks/{{ encode_for_url(task.name) }}/test" method="POST">
+            {% module xsrf_form_html() %}
             <fieldset>
                 <div class="control-group">
                     <label class="control-label" for="input_zip">{{ _("submission.zip") }}</label>

--- a/cmstestsuite/__init__.py
+++ b/cmstestsuite/__init__.py
@@ -29,14 +29,13 @@ from __future__ import unicode_literals
 import io
 import json
 import logging
-import mechanize
 import os
 import re
 import subprocess
 import sys
 import time
 
-from cmstestsuite.web import browser_do_request
+from cmstestsuite.web import BrowserSession
 from cmstestsuite.web.AWSRequests import \
     AWSLoginRequest, AWSSubmissionViewRequest, AWSUserTestViewRequest
 from cmstestsuite.web.CWSRequests import \
@@ -71,32 +70,33 @@ CWS_BASE_URL = "http://localhost:8888/"
 
 
 # Persistent browsers to access AWS and CWS.
-aws_browser = None
-cws_browser = None
+aws_session = None
+cws_session = None
 
 
-def get_aws_browser():
-    global aws_browser
-    if aws_browser is None:
-        aws_browser = mechanize.Browser()
-        aws_browser.set_handle_robots(False)
-        AWSLoginRequest(aws_browser,
-                        admin_info["username"], admin_info["password"],
-                        base_url=AWS_BASE_URL).execute()
-    return aws_browser
+def get_aws_session():
+    global aws_session
+    if aws_session is None:
+        aws_session = BrowserSession()
+
+        lr = AWSLoginRequest(aws_session,
+                             admin_info["username"], admin_info["password"],
+                             base_url=AWS_BASE_URL)
+        aws_session.login(lr)
+    return aws_session
 
 
-def get_cws_browser(user_id):
-    global cws_browser
-    if cws_browser is None:
-        cws_browser = mechanize.Browser()
-        cws_browser.set_handle_robots(False)
-        cws_browser.set_handle_redirect(False)
+def get_cws_session(user_id):
+    global cws_session
+    if cws_session is None:
+        cws_session = BrowserSession()
+        cws_session.browser.set_handle_redirect(False)
         username = created_users[user_id]['username']
         password = created_users[user_id]['password']
-        CWSLoginRequest(
-            cws_browser, username, password, base_url=CWS_BASE_URL).execute()
-    return cws_browser
+        lr = CWSLoginRequest(
+            cws_session, username, password, base_url=CWS_BASE_URL)
+        cws_session.login(lr)
+    return cws_session
 
 
 class FrameworkException(Exception):
@@ -195,8 +195,8 @@ def admin_req(path, multipart_post=False, args=None, files=None):
     if multipart_post and files is None:
         files = []
 
-    browser = get_aws_browser()
-    return browser_do_request(browser, AWS_BASE_URL + path, args, files)
+    session = get_aws_session()
+    return session.do_request(AWS_BASE_URL + path, args, files)
 
 
 def get_tasks():
@@ -372,7 +372,7 @@ def cws_submit(contest_id, task_id, user_id, submission_format,
                filenames, language):
     task = (task_id, created_tasks[task_id]['name'])
 
-    browser = get_cws_browser(user_id)
+    browser = get_cws_session(user_id)
     sr = SubmitRequest(browser, task, base_url=CWS_BASE_URL,
                        submission_format=submission_format,
                        filenames=filenames)
@@ -389,7 +389,7 @@ def cws_submit_user_test(contest_id, task_id, user_id, submission_format,
                          filenames, language):
     task = (task_id, created_tasks[task_id]['name'])
 
-    browser = get_cws_browser(user_id)
+    browser = get_cws_session(user_id)
     sr = SubmitUserTestRequest(
         browser, task, base_url=CWS_BASE_URL,
         submission_format=submission_format,
@@ -409,7 +409,7 @@ def get_evaluation_result(contest_id, submission_id, timeout=60):
     COMPLETED_STATUS = re.compile(
         r'Compilation failed|Evaluated \(|Scored \(')
 
-    browser = get_aws_browser()
+    browser = get_aws_session()
     sleep_interval = 0.1
     while timeout > 0:
         timeout -= sleep_interval
@@ -440,7 +440,7 @@ def get_user_test_result(contest_id, user_test_id, timeout=60):
     COMPLETED_STATUS = re.compile(
         r'Compilation failed|Evaluated')
 
-    browser = get_aws_browser()
+    browser = get_aws_session()
     sleep_interval = 0.1
     while timeout > 0:
         timeout -= sleep_interval

--- a/cmstestsuite/web/AWSRequests.py
+++ b/cmstestsuite/web/AWSRequests.py
@@ -48,8 +48,8 @@ class AWSSubmissionViewRequest(GenericRequest):
     """Load the view of a submission in AWS.
 
     """
-    def __init__(self, browser, submission_id, base_url=None):
-        GenericRequest.__init__(self, browser, base_url)
+    def __init__(self, session, submission_id, base_url=None):
+        GenericRequest.__init__(self, session, base_url)
         self.submission_id = submission_id
         self.url = "%ssubmission/%s" % (self.base_url, submission_id)
 
@@ -102,8 +102,8 @@ class AWSSubmissionViewRequest(GenericRequest):
 
 class AWSUserTestViewRequest(GenericRequest):
     """Load the view of a user test in AWS."""
-    def __init__(self, browser, user_test_id, base_url=None):
-        GenericRequest.__init__(self, browser, base_url)
+    def __init__(self, session, user_test_id, base_url=None):
+        GenericRequest.__init__(self, session, base_url)
         self.user_test_id = user_test_id
         self.url = "%suser_test/%s" % (self.base_url, user_test_id)
 

--- a/cmstestsuite/web/CWSRequests.py
+++ b/cmstestsuite/web/CWSRequests.py
@@ -46,8 +46,8 @@ class HomepageRequest(GenericRequest):
     """Load the main page of CWS.
 
     """
-    def __init__(self, browser, username, loggedin, base_url=None):
-        GenericRequest.__init__(self, browser, base_url)
+    def __init__(self, session, username, loggedin, base_url=None):
+        GenericRequest.__init__(self, session, base_url)
         self.url = self.base_url
         self.username = username
         self.loggedin = loggedin
@@ -72,8 +72,8 @@ class TaskRequest(GenericRequest):
     """Load a task page in CWS.
 
     """
-    def __init__(self, browser, task_id, base_url=None):
-        GenericRequest.__init__(self, browser, base_url)
+    def __init__(self, session, task_id, base_url=None):
+        GenericRequest.__init__(self, session, base_url)
         self.url = "%stasks/%s/description" % (self.base_url, task_id)
         self.task_id = task_id
 
@@ -85,8 +85,8 @@ class TaskStatementRequest(GenericRequest):
     """Load a task statement in CWS.
 
     """
-    def __init__(self, browser, task_id, language_code, base_url=None):
-        GenericRequest.__init__(self, browser, base_url)
+    def __init__(self, session, task_id, language_code, base_url=None):
+        GenericRequest.__init__(self, session, base_url)
         self.url = "%stasks/%s/statements/%s" % (self.base_url,
                                                  task_id, language_code)
         self.task_id = task_id
@@ -102,9 +102,9 @@ class SubmitRequest(GenericRequest):
     """Submit a solution in CWS.
 
     """
-    def __init__(self, browser, task, submission_format,
+    def __init__(self, session, task, submission_format,
                  filenames, base_url=None):
-        GenericRequest.__init__(self, browser, base_url)
+        GenericRequest.__init__(self, session, base_url)
         self.url = "%stasks/%s/submit" % (self.base_url, task[1])
         self.task = task
         self.submission_format = submission_format
@@ -148,9 +148,9 @@ class SubmitRequest(GenericRequest):
 
 class SubmitUserTestRequest(GenericRequest):
     """Submit a user test in CWS."""
-    def __init__(self, browser, task, submission_format,
+    def __init__(self, session, task, submission_format,
                  filenames, base_url=None):
-        GenericRequest.__init__(self, browser, base_url)
+        GenericRequest.__init__(self, session, base_url)
         self.url = "%stasks/%s/test" % (self.base_url, task[1])
         self.task = task
         self.submission_format = submission_format
@@ -200,8 +200,8 @@ class TokenRequest(GenericRequest):
     """Release test a submission.
 
     """
-    def __init__(self, browser, task, submission_num, base_url=None):
-        GenericRequest.__init__(self, browser, base_url)
+    def __init__(self, session, task, submission_num, base_url=None):
+        GenericRequest.__init__(self, session, base_url)
         self.url = "%stasks/%s/submissions/%s/token" % (self.base_url,
                                                         task[1],
                                                         submission_num)
@@ -223,9 +223,9 @@ class SubmitRandomRequest(SubmitRequest):
     """Submit a solution in CWS.
 
     """
-    def __init__(self, browser, task, base_url=None,
+    def __init__(self, session, task, base_url=None,
                  submissions_path=None):
-        GenericRequest.__init__(self, browser, base_url)
+        GenericRequest.__init__(self, session, base_url)
         self.url = "%stasks/%s/submit" % (self.base_url, task[1])
         self.task = task
         self.submissions_path = submissions_path


### PR DESCRIPTION
### Changes
* Convert remaining state changing GET requests to POST or DELETE.
* Use Tornado CSRF protection to prevent CSRF attacks on POST requests as making requests POST by itself doesn't provide sufficient protection.

Fixes #453 . I couldn't find more state changing GET requests. There is unread message count, but I don't think it's worth the effort protecting that.
I checked all the forms in html templates,  aws_utils.js and tests runned by Travis. Those should be fine, but I am slightly worried that some more unusual requests might have slipped by. Are there any tests not executed by Travis or other js code making requests?

### Important information for all CMS devleopers
After merging these changes all forms making POST requests now need to contain hidden input field containing CSRF token. It can be done by adding `{% module xsrf_form_html() %}` to the form in  HTML template. See this pull request for examples or read http://www.tornadoweb.org/en/stable/guide/security.html#cross-site-request-forgery-protection for more details. All non GET requests without CSRF token will be automatically rejected. Requests done using `CMS.AWSUtils.ajax_delete` or admin/static/web_rpc.js don't need additional changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/690)
<!-- Reviewable:end -->
