### PR TITLE
Update links broken by remove user/contest/task changes

### DIFF
--- a/cms/server/admin/templates/fragments/user_test_row.html
+++ b/cms/server/admin/templates/fragments/user_test_row.html
@@ -16,7 +16,7 @@
 {% end %}
 <tr>
   <td><a href="{{ url_root }}/user_test/{{ ut.id }}">{{ str(ut.timestamp) }}</a></td>
-  <td><a href="{{ url_root }}/contest/{{ ut.participation.contest.id }}/user/{{ ut.participation.user.id }}">{{ ut.participation.user.username }}</a></td>
+  <td><a href="{{ url_root }}/contest/{{ ut.participation.contest.id }}/user/{{ ut.participation.user.id }}/edit">{{ ut.participation.user.username }}</a></td>
   <td><a href="{{ url_root }}/task/{{ ut.task.id }}">{{ ut.task.name }}</a></td>
   <td>
     {% if status == UserTestResult.COMPILING %}

--- a/cms/server/admin/templates/participation.html
+++ b/cms/server/admin/templates/participation.html
@@ -158,7 +158,7 @@ function update_additional_answer(element, invoker)
         <div class="reply_question" >
           <hr/>
           <form class="reply_question_form" action="{{ url_root }}/contest/{{ contest.id }}/question/{{ msg.id }}/reply" method="POST">
-            <input type="hidden" name="ref" value="/contest/{{ contest.id }}/user/{{ selected_user.id }}"/>
+            <input type="hidden" name="ref" value="/contest/{{ contest.id }}/user/{{ selected_user.id }}/edit"/>
             Precompiled answer:
             <select name="reply_question_quick_answer" onchange="update_additional_answer({{ msg_i }}, this);">
               <option value="yes">Yes</option>

--- a/cms/server/admin/templates/user.html
+++ b/cms/server/admin/templates/user.html
@@ -47,7 +47,7 @@
           <td>
             <input type="radio" name="contest_id" value="{{ p.contest.id }}"/>
           </td>
-          <td><a href="{{ url_root }}/contest/{{ p.contest.id }}/user/{{ p.user.id }}">{{ p.user.username }}</a></td>
+          <td><a href="{{ url_root }}/contest/{{ p.contest.id }}/user/{{ p.user.id }}/edit">{{ p.user.username }}</a></td>
           <td>{{ p.hidden }}</td>
           <td>{{ p.unrestricted }}</td>
           <td><a href="{{ url_root }}/contest/{{ p.contest.id }}">{{ p.contest.name }}</a></td>

--- a/cms/server/admin/templates/user_test.html
+++ b/cms/server/admin/templates/user_test.html
@@ -35,7 +35,7 @@
       </tr>
       <tr>
         <td>User</td>
-        <td><a href="{{ url_root }}/contest/{{ ut.participation.contest.id }}/user/{{ ut.participation.user.id }}">{{ ut.participation.user.username }}</a></td>
+        <td><a href="{{ url_root }}/contest/{{ ut.participation.contest.id }}/user/{{ ut.participation.user.id }}/edit">{{ ut.participation.user.username }}</a></td>
       </tr>
       <tr>
         <td>Files</td>


### PR DESCRIPTION
Some of the links in recent remove user  49c61f18d3097807c5003513a4071826cf1050f8 commit weren't properly updated resulting in links that lead to 404 .  `ParticipationHandler` was only one with significant changes in path, so assume that similar bug shouldn't affect other links.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/695)
<!-- Reviewable:end -->
