### PR TITLE
Restore default database pool size and increase pool timeout instead

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -87,7 +87,7 @@ __all__ = [
 version = 24
 
 engine = create_engine(config.database, echo=config.database_debug,
-                       pool_size=20, max_overflow=20, pool_recycle=120)
+                       pool_timeout=60, pool_recycle=120)
 
 
 from .session import Session, ScopedSession, SessionGen, \

--- a/cms/server/admin/templates/contest.html
+++ b/cms/server/admin/templates/contest.html
@@ -5,13 +5,7 @@
   <h1>Contest configuration</h1>
 </div>
 
-{% if len(config.contest_listen_port) > 0 %}
-  {% set ratio = round(len(contest.participations) * 1.0 / len(config.contest_listen_port), 2) %}
-  {% if ratio >= 40 %}
-    At the moment, you have {{ ratio }} users for each ContestWebServer, on average.<br/>
-    A CWS can handle 40 simultaneous request. This situation might cause many requests to fail.
-  {% end %}
-{% end %}
+{% include fragments/overload_warning.html %}
 
 <!-- We use "multipart/form-data" to have Tornado distinguish between missing and empty values. -->
 <form enctype="multipart/form-data" action="{{ url_root }}/contest/{{ contest.id }}" method="POST" name="edit_contest">

--- a/cms/server/admin/templates/contest_users.html
+++ b/cms/server/admin/templates/contest_users.html
@@ -5,13 +5,7 @@
   <h1>Users list</h1>
 </div>
 
-{% if len(config.contest_listen_port) > 0 %}
-  {% set ratio = round(len(contest.participations) * 1.0 / len(config.contest_listen_port), 2) %}
-  {% if ratio >= 40 %}
-    At the moment, you have {{ ratio }} users for each ContestWebServer, on average.<br/>
-    A CWS can handle 40 simultaneous request. This situation might cause many requests to fail.
-  {% end %}
-{% end %}
+{% include fragments/overload_warning.html %}
 
 <form action="{{ url_root }}/contest/{{ contest.id }}/users/add" method="POST">
   Add a new user:

--- a/cms/server/admin/templates/fragments/overload_warning.html
+++ b/cms/server/admin/templates/fragments/overload_warning.html
@@ -1,0 +1,20 @@
+{# This snippet warns admins about too many users per contest server #}
+
+{#
+  Data from https://github.com/cms-dev/cms/issues/375 shows that a CWS can
+  reasonably handle about 100 simultaneous requests. In a real contest, users
+  won't continuously send requests one after another, so the real user count
+  a CWS can handle is higher. Still, we can be conservative and display the
+  warning early on.
+#}
+
+{% if len(config.contest_listen_port) > 0 %}
+  {% set ratio = round(len(contest.participations) * 1.0 / len(config.contest_listen_port), 2) %}
+  {% if ratio > 100 %}
+<p>
+  At the moment, you have {{ ratio }} users for each ContestWebServer, on average.<br/>
+  One CWS can reasonably handle about 100 simultaneous requests. This situation might
+  cause long request delays or failures.
+</p>
+  {% end %}
+{% end %}

--- a/docs/Troubleshooting.rst
+++ b/docs/Troubleshooting.rst
@@ -20,10 +20,12 @@ Database
 
   *Possible cause.* The default configuration of PostgreSQL may allow insufficiently many incoming connections on the database engine. You can raise this limit by tweaking the ```max_connections``` parameter in ```postgresql.conf``` (`see docs <http://www.postgresql.org/docs/9.1/static/runtime-config-connection.html>`_). This, in turn, requires more shared memory for the PostgreSQL process (see ```shared_buffers``` parameter in `docs <http://www.postgresql.org/docs/9.1/static/runtime-config-resource.html>`_), which may overflow the maximum limit allowed by the operating system. In such case see the suggestions in http://www.postgresql.org/docs/9.1/static/kernel-resources.html#SYSVIPC. Users reported that another way to go is to use a connection pooler like `PgBouncer <https://wiki.postgresql.org/wiki/PgBouncer>`_.
 
-  Slightly different, but related, is another issue: CMS may be unable to create new connections to the database because its pool is exhausted. In this case you probably want to modify the ```pool_size``` argument in :gh_blob:`cms/db/__init__.py` or try to spread your users over more instances of ContestWebServer.
-
 Servers
 =======
+
+- *Symptom.* Some HTTP requests to ContestWebServer take a long time and fail with 500 Internal Server Error. ContestWebServer logs contain entries such as :samp:`TimeoutError('QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 60',)`.
+
+  *Possible cause.* The server may be overloaded with user requests. You can try to increase the ```pool_timeout``` argument in :gh_blob:`cms/db/__init__.py` or, preferably, spread your users over more instances of ContestWebServer.
 
 - *Symptom.* Message from ContestWebServer such as: :samp:`WARNING:root:Invalid cookie signature KFZzdW5kdWRlCnAwCkkxMzI5MzQzNzIwCnRw...`
 


### PR DESCRIPTION
Large pool size causes increased memory usage through spawned PostgreSQL processes. Tests show that the default pool size achieves the same throughput, but has different response time distribution. To accommodate for this, database pool timeout is increased from 30 to 60 seconds.

Related documentation and warning about user count per server are also adjusted.

See #375 for more information and discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/698)
<!-- Reviewable:end -->
