### PR TITLE
Strip executables and use pipes when compiling C/C++

### DIFF
--- a/cms/grading/languages/c++11_g++.py
+++ b/cms/grading/languages/c++11_g++.py
@@ -62,6 +62,6 @@ class Cpp11Gpp(CompiledLanguage):
         command = ["/usr/bin/g++"]
         if for_evaluation:
             command += ["-DEVAL"]
-        command += ["-static", "-O2", "-std=c++11", "-o", executable_filename]
+        command += ["-std=c++11", "-O2", "-pipe", "-static", "-s", "-o", executable_filename]
         command += source_filenames
         return [command]

--- a/cms/grading/languages/c++11_g++.py
+++ b/cms/grading/languages/c++11_g++.py
@@ -62,6 +62,7 @@ class Cpp11Gpp(CompiledLanguage):
         command = ["/usr/bin/g++"]
         if for_evaluation:
             command += ["-DEVAL"]
-        command += ["-std=c++11", "-O2", "-pipe", "-static", "-s", "-o", executable_filename]
+        command += ["-std=c++11", "-O2", "-pipe", "-static",
+                    "-s", "-o", executable_filename]
         command += source_filenames
         return [command]

--- a/cms/grading/languages/c11_gcc.py
+++ b/cms/grading/languages/c11_gcc.py
@@ -62,7 +62,7 @@ class C11Gcc(CompiledLanguage):
         command = ["/usr/bin/gcc"]
         if for_evaluation:
             command += ["-DEVAL"]
-        command += ["-static", "-O2", "-std=c11", "-o", executable_filename]
+        command += ["-std=c11", "-O2", "-pipe", "-static", "-s", "-o", executable_filename]
         command += source_filenames
         command += ["-lm"]
         return [command]

--- a/cms/grading/languages/c11_gcc.py
+++ b/cms/grading/languages/c11_gcc.py
@@ -62,7 +62,8 @@ class C11Gcc(CompiledLanguage):
         command = ["/usr/bin/gcc"]
         if for_evaluation:
             command += ["-DEVAL"]
-        command += ["-std=c11", "-O2", "-pipe", "-static", "-s", "-o", executable_filename]
+        command += ["-std=c11", "-O2", "-pipe", "-static",
+                    "-s", "-o", executable_filename]
         command += source_filenames
         command += ["-lm"]
         return [command]


### PR DESCRIPTION
This pull request adds two well-known compiler options to the C/C++ compiler command line: `-s` and `-pipe`.

`-s` tells the compiler to strip symbols from executables. This will significantly reduce the size of compiled executables, which should help with database dumps and network communication. In my tests, a static C++ Hello World program is 2.0 MB unstripped and 1.6 MB stripped (20% size reduction).

`-pipe` tells the compiler to pipe assembly input directly to the assembler instead of using a temporary file. On my computer this gives about 1% compilation speed increase for a C++ Hello World.

I also rearranged the options to follow the usual `<CPPFLAGS> <CFLAGS> <LDFLAGS>` pattern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/702)
<!-- Reviewable:end -->
