### PR TITLE
Avoid JSON input for primary statements

### DIFF
--- a/cms/server/admin/handlers/task.py
+++ b/cms/server/admin/handlers/task.py
@@ -227,8 +227,8 @@ class AddStatementHandler(BaseHandler):
 
         task = self.safe_get_item(Task, task_id)
 
-        language = self.get_argument("language", None)
-        if language is None:
+        language = self.get_argument("language", "")
+        if language == "":
             self.application.service.add_notification(
                 make_datetime(),
                 "No language code specified",

--- a/cms/server/admin/handlers/task.py
+++ b/cms/server/admin/handlers/task.py
@@ -143,9 +143,9 @@ class TaskHandler(BaseHandler):
             primary_statements = {}
             for statement in task.statements:
                 self.get_bool(primary_statements,
-                              "statement_%s_primary" % statement)
+                              "primary_statement_%s" % statement)
             attrs["primary_statements"] = json.dumps(sorted([
-                k.replace("statement_", "").replace("_primary", "")
+                k.replace("primary_statement_", "", 1)
                 for k in primary_statements
                 if primary_statements[k]
             ]))

--- a/cms/server/admin/handlers/task.py
+++ b/cms/server/admin/handlers/task.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2010-2013 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
-# Copyright © 2010-2016 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2017 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2012-2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
@@ -31,6 +31,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import json
 import logging
 import traceback
 
@@ -114,6 +115,11 @@ class TaskHandler(BaseHandler):
 
         self.r_params = self.render_params()
         self.r_params["task"] = task
+        try:
+            self.r_params["primary_statements"] = \
+                json.loads(task.primary_statements)
+        except ValueError:
+            self.r_params["primary_statements"] = []
         self.r_params["submissions"] = \
             self.sql_session.query(Submission)\
                 .join(Task).filter(Task.id == task_id)\
@@ -132,7 +138,17 @@ class TaskHandler(BaseHandler):
 
             assert attrs.get("name") is not None, "No task name specified."
 
-            self.get_string(attrs, "primary_statements")
+            # Parsing of primary statements checkboxes. Their name is
+            # statement_XX_primary, where XX is the language code.
+            primary_statements = {}
+            for statement in task.statements:
+                self.get_bool(primary_statements,
+                              "statement_%s_primary" % statement)
+            attrs["primary_statements"] = json.dumps(sorted([
+                k.replace("statement_", "").replace("_primary", "")
+                for k in primary_statements
+                if primary_statements[k]
+            ]))
 
             self.get_submission_format(attrs)
 

--- a/cms/server/admin/templates/task.html
+++ b/cms/server/admin/templates/task.html
@@ -74,7 +74,7 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
       </tr>
       <tr>
         <td>
-          <span class="info" title="The statements of this task, by language code."></span>
+          <span class="info" title="The statements of this task, by language code. Primary statements are shown prominently to contestants."></span>
           Statements
 {% if current_user.permission_all %}
           [<a href="{{ url_root }}/task/{{ task.id }}/statements/add">add</a>]
@@ -84,24 +84,22 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
           {% if len(task.statements) == 0 %}
           No statements uploaded yet
           {% else %}
-          <ul>
-            <table>
-              <tbody>
+          <table>
+            <tbody>
             {% for statement in task.statements.values() %}
-                <tr>
-                  <td><a href="{{ url_root }}/file/{{ statement.digest }}/statement.pdf">Statement for language "{{ statement.language }}"</a></td>
-                  <td>
-                    <label>
-                      <input type="checkbox" name="statement_{{ statement.language }}_primary" {% if statement.language in primary_statements %}checked{% end %} />
-                      Primary?
-                    </label>
-                  </td>
-                  <td><a onclick="CMS.AWSUtils.ajax_delete('{{ url_root }}/task/{{ task.id }}/statement/{{ statement.id }}'); ">Delete</a></td>
-                </tr>
+              <tr>
+                <td><a href="{{ url_root }}/file/{{ statement.digest }}/statement.pdf">Statement for language "{{ statement.language }}"</a></td>
+                <td>
+                  <label>
+                    <input type="checkbox" name="primary_statement_{{ statement.language }}" {% if statement.language in primary_statements %}checked{% end %} />
+                    Primary?
+                  </label>
+                </td>
+                <td><a onclick="CMS.AWSUtils.ajax_delete('{{ url_root }}/task/{{ task.id }}/statement/{{ statement.id }}'); ">Delete</a></td>
+              </tr>
             {% end %}
-              </tbody>
-            </table>
-          </ul>
+            </tbody>
+          </table>
           {% end %}
         </td>
       </tr>

--- a/cms/server/admin/templates/task.html
+++ b/cms/server/admin/templates/task.html
@@ -85,21 +85,25 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
           No statements uploaded yet
           {% else %}
           <ul>
+            <table>
+              <tbody>
             {% for statement in task.statements.values() %}
-            <li><a href="{{ url_root }}/file/{{ statement.digest }}/statement.pdf">Statement for language "{{ statement.language }}"</a>
-              - <a onclick="CMS.AWSUtils.ajax_delete('{{ url_root }}/task/{{ task.id }}/statement/{{ statement.id }}'); ">Delete</a></li>
+                <tr>
+                  <td><a href="{{ url_root }}/file/{{ statement.digest }}/statement.pdf">Statement for language "{{ statement.language }}"</a></td>
+                  <td>
+                    <label>
+                      <input type="checkbox" name="statement_{{ statement.language }}_primary" {% if statement.language in primary_statements %}checked{% end %} />
+                      Primary?
+                    </label>
+                  </td>
+                  <td><a onclick="CMS.AWSUtils.ajax_delete('{{ url_root }}/task/{{ task.id }}/statement/{{ statement.id }}'); ">Delete</a></td>
+                </tr>
             {% end %}
+              </tbody>
+            </table>
           </ul>
           {% end %}
         </td>
-      </tr>
-      <tr>
-        <td>
-          <span class="info" title="A JSON-encoded list of language codes that are considered primaries with respect to the statements.
-                                    Example: '[&quot;en&quot;, &quot;ja&quot;]'."></span>
-          Primary statements
-        </td>
-        <td><input type="text" name="primary_statements" value="{{ task.primary_statements }}"/></td>
       </tr>
       <tr>
         <td>


### PR DESCRIPTION
The only debatable aspect is that this prevent admins to choose the order of the primary statements (they are sorted by language code). I don't think it is a problem.

Fully fixes #683

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/707)
<!-- Reviewable:end -->
