### PR TITLE
Add support for bcrypt password encryption for users

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -42,5 +42,6 @@ Petar Veličković <pv273@cam.ac.uk>
 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
 Kārlis Seņko <karlis3p70l1ij@gmail.com>
 Peyman Jabbarzade Ganje <peyman.jabarzade@gmail.com>
+Valentin Rosca <rosca.valentin2012@gmail.com>
 And many other people that didn't write code, but provided useful
 comments, suggestions and feedback. :-)

--- a/cms/db/user.py
+++ b/cms/db/user.py
@@ -38,7 +38,7 @@ from sqlalchemy.types import Boolean, Integer, String, Unicode, DateTime, \
     Interval
 from sqlalchemy.orm import relationship, backref
 
-from cmscommon.crypto import generate_random_password_with_method
+from cmscommon.crypto import generate_random_password_text
 
 from . import Base, Contest
 
@@ -71,7 +71,7 @@ class User(Base):
     password = Column(
         Unicode,
         nullable=False,
-        default=generate_random_password_with_method)
+        default=generate_random_password_text)
 
     # Email for any communications in case of remote contest.
     email = Column(

--- a/cms/db/user.py
+++ b/cms/db/user.py
@@ -38,7 +38,7 @@ from sqlalchemy.types import Boolean, Integer, String, Unicode, DateTime, \
     Interval
 from sqlalchemy.orm import relationship, backref
 
-from cmscommon.crypto import generate_random_password
+from cmscommon.crypto import generate_random_password_with_method
 
 from . import Base, Contest
 
@@ -71,7 +71,7 @@ class User(Base):
     password = Column(
         Unicode,
         nullable=False,
-        default=generate_random_password)
+        default=generate_random_password_with_method)
 
     # Email for any communications in case of remote contest.
     email = Column(

--- a/cms/server/admin/handlers/contestuser.py
+++ b/cms/server/admin/handlers/contestuser.py
@@ -199,6 +199,8 @@ class ParticipationHandler(BaseHandler):
                 participation.password = ""
         else:
             participation.method = "text"
+            participation.password = ""
+
         self.r_params["participation"] = participation
         self.r_params["selected_user"] = participation.user
         self.r_params["teams"] = self.sql_session.query(Team).all()
@@ -228,7 +230,7 @@ class ParticipationHandler(BaseHandler):
             password = attrs["password"]
             if password is not None:
                 attrs["password"] = hash_password(password, attrs["method"])
-                del attrs["method"]
+            del attrs["method"]
 
             self.get_ip_address_or_subnet(attrs, "ip")
             self.get_datetime(attrs, "starting_time")

--- a/cms/server/admin/handlers/user.py
+++ b/cms/server/admin/handlers/user.py
@@ -83,8 +83,16 @@ class UserHandler(BaseHandler):
             self.get_string(attrs, "method", empty="text")
             if "method" not in attrs:
                 attrs["method"] = "text"
-            attrs["password"] = hash_password(attrs["password"],
-                                              method=attrs["method"])
+
+            password = attrs["password"]
+            method = attrs["method"]
+            if method != "text" and password == "":
+                # Preserve old password if password is empty
+                # and method is not text
+                attrs["password"] = user.password
+            else:
+                attrs["password"] = hash_password(password, method)
+
             del attrs["method"]
             self.get_string(attrs, "email")
             self.get_string(attrs, "preferred_languages")

--- a/cms/server/admin/handlers/user.py
+++ b/cms/server/admin/handlers/user.py
@@ -9,6 +9,7 @@
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
 # Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
+# Copyright © 2017 Valentin Rosca <rosca.valentin2012@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -33,6 +34,8 @@ from __future__ import unicode_literals
 
 from cms.db import Contest, Participation, Submission, Team, User
 from cmscommon.datetime import make_datetime
+from cmscommon.crypto import hash_password
+from cmscommon.crypto import parse_authentication
 
 from .base import BaseHandler, SimpleHandler, require_permission
 
@@ -44,6 +47,13 @@ class UserHandler(BaseHandler):
 
         self.r_params = self.render_params()
         self.r_params["user"] = user
+        method, payload = parse_authentication(user.password)
+        user.method = method
+        if method == 'text':
+            user.password = payload
+        else:
+            user.password = ""
+
         self.r_params["participations"] = \
             self.sql_session.query(Participation)\
                 .filter(Participation.user == user)\
@@ -70,6 +80,12 @@ class UserHandler(BaseHandler):
             self.get_string(attrs, "last_name")
             self.get_string(attrs, "username", empty=None)
             self.get_string(attrs, "password")
+            self.get_string(attrs, "method", empty="text")
+            if "method" not in attrs:
+                attrs["method"] = "text"
+            attrs["password"] = hash_password(attrs["password"],
+                                              method=attrs["method"])
+            del attrs["method"]
             self.get_string(attrs, "email")
             self.get_string(attrs, "preferred_languages")
             self.get_string(attrs, "timezone", empty=None)
@@ -233,6 +249,12 @@ class AddUserHandler(SimpleHandler("add_user.html", permission_all=True)):
             self.get_string(attrs, "last_name")
             self.get_string(attrs, "username", empty=None)
             self.get_string(attrs, "password")
+            self.get_string(attrs, "method", empty="text")
+            if "method" not in attrs:
+                attrs["method"] = "text"
+            attrs["password"] = hash_password(attrs["password"],
+                                              method=attrs["method"])
+            del attrs["method"]
             self.get_string(attrs, "email")
 
             assert attrs.get("username") is not None, \

--- a/cms/server/admin/templates/add_user.html
+++ b/cms/server/admin/templates/add_user.html
@@ -38,6 +38,12 @@
         </td>
         <!-- FIXME: Plain text? -->
         <td><input type="text" name="password" /></td>
+        <td>
+          <select name="method">
+            <option value="text">text</option>
+            <option value="bcrypt">bcrypt</option>
+          </select>
+        </td>
       </tr>
       <tr>
         <td>

--- a/cms/server/admin/templates/base.html
+++ b/cms/server/admin/templates/base.html
@@ -11,6 +11,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="shortcut icon" href="{{ url_root }}/static/favicon.ico" />
     <link rel="stylesheet" type="text/css" href="{{ url_root }}/static/reset.css">
+    <link rel="stylesheet" type="text/css" href="{{ url_root }}/static/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="{{ url_root }}/static/aws_style.css">
     <script type="text/javascript" src="{{ url_root }}/static/web_rpc.js"></script>
     <script type="text/javascript" src="{{ url_root }}/static/aws_utils.js"></script>

--- a/cms/server/admin/templates/base.html
+++ b/cms/server/admin/templates/base.html
@@ -11,7 +11,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="shortcut icon" href="{{ url_root }}/static/favicon.ico" />
     <link rel="stylesheet" type="text/css" href="{{ url_root }}/static/reset.css">
-    <link rel="stylesheet" type="text/css" href="{{ url_root }}/static/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="{{ url_root }}/static/aws_style.css">
     <script type="text/javascript" src="{{ url_root }}/static/web_rpc.js"></script>
     <script type="text/javascript" src="{{ url_root }}/static/aws_utils.js"></script>

--- a/cms/server/admin/templates/participation.html
+++ b/cms/server/admin/templates/participation.html
@@ -80,7 +80,13 @@ function update_additional_answer(element, invoker)
           Password
         </td>
         <!-- FIXME: Plain text? -->
-        <td><input type="text" name="password" value="{{ participation.password if participation.password is not None else "" }}"/></td>
+        <td><input type="text" name="password" value="{{ participation.password }}" placeholder="{{ 'Password is encrypted. Type the password here to change it' if participation.method != 'text' else '' "" }}"/>
+            <select name="method">
+              <option value="text">text</option>
+              <option value="bcrypt">bcrypt</option>
+            </select>
+          <script>$("[name='method']").val("{{ participation.method }}");</script>
+        </td>
       </tr>
       <tr>
         <td>

--- a/cms/server/admin/templates/user.html
+++ b/cms/server/admin/templates/user.html
@@ -97,7 +97,15 @@
           Password
         </td>
         <!-- FIXME: Plain text? -->
-        <td><input type="text" name="password" value="{{ user.password }}"/></td>
+        <td><input type="text" name="password"
+                   value="{{ user.password }}"
+                   placeholder="{{ 'Password is encrypted. Type the password here to change it' if user.method != 'text' else '' }}"/>
+        <select name="method">
+            <option value="text">text</option>
+            <option value="bcrypt">bcrypt</option>
+          </select>
+          <script>$("[name='method']").val("{{ user.method }}");</script>
+        </td>
       </tr>
       <tr>
         <td>

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -42,6 +42,7 @@ from cms import config
 from cms.db import Participation, PrintJob, User
 from cms.server import actual_phase_required, filter_ascii
 from cmscommon.datetime import make_datetime, make_timestamp
+from cmscommon.crypto import validate_password
 
 from .base import BaseHandler, check_ip, \
     NOTIFICATION_ERROR, NOTIFICATION_SUCCESS
@@ -94,7 +95,7 @@ class LoginHandler(BaseHandler):
         filtered_user = filter_ascii(username)
         filtered_pass = filter_ascii(password)
 
-        if password != correct_password:
+        if not validate_password(correct_password, password):
             logger.info("Login error: user=%s pass=%s remote_ip=%s." %
                         (filtered_user, filtered_pass, self.request.remote_ip))
             self.redirect("/?login_error=true")

--- a/cmscommon/crypto.py
+++ b/cmscommon/crypto.py
@@ -6,6 +6,7 @@
 # Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2012 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2017 Valentin Rosca <rosca.valentin2012@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -35,7 +36,6 @@ from string import ascii_lowercase
 
 from Crypto.Cipher import AES
 
-
 __all__ = [
     "is_random_secure",
 
@@ -44,16 +44,16 @@ __all__ = [
     "encrypt_string", "decrypt_string",
     "encrypt_number", "decrypt_number",
 
-    "generate_random_password",
+    "generate_random_password", "generate_random_password_with_method",
 
-    "validate_password", "hash_password",
-    ]
-
+    "validate_password", "hash_password", "parse_authentication",
+]
 
 # Some older versions of pycrypto don't provide a Random module
 # If that's the case, fallback to weak standard library PRG
 try:
     from Crypto import Random
+
     get_random_bits = Random.new().read
     is_random_secure = True
 except ImportError:
@@ -172,6 +172,35 @@ def generate_random_password():
     return "".join((random.choice(ascii_lowercase) for _ in range(6)))
 
 
+def generate_random_password_with_method(method="text"):
+    """Utility method to generate a random password
+    and encrypt with the given method.
+
+    return (string): method:a random string.
+
+    """
+    return hash_password(password=generate_random_password(),
+                         method=method)
+
+
+def parse_authentication(authentication):
+    """Parse the given password and return the method
+    used for hashing and and payload field
+
+    authentication (string): an authentication string as stored in the db.
+
+    return (string, string): the method and the payload
+
+    raise (ValueError): when the authentication string is not valid.
+
+    """
+    if authentication.find(":") == -1:
+        raise ValueError("Authentication string not parsable.")
+
+    method, payload = authentication.split(":", 1)
+    return method, payload
+
+
 def validate_password(authentication, password):
     """Validate the given password for the required authentication.
 
@@ -184,14 +213,13 @@ def validate_password(authentication, password):
         the method is not known.
 
     """
-    if authentication.find(":") == -1:
-        raise ValueError("Authentication string not parsable.")
-
-    method, payload = authentication.split(":", 1)
+    method, payload = parse_authentication(authentication)
     if method == "bcrypt":
         password = password.encode('utf-8')
         payload = payload.encode('utf-8')
         return bcrypt.hashpw(password, payload) == payload
+    elif method == "text":
+        return payload == password
     else:
         raise ValueError("Authentication method not known.")
 
@@ -210,6 +238,8 @@ def hash_password(password, method="bcrypt"):
     if method == "bcrypt":
         password = password.encode('utf-8')
         payload = bcrypt.hashpw(password, bcrypt.gensalt())
+    elif method == "text":
+        payload = password.encode('utf-8')
     else:
         raise ValueError("Authentication method not known.")
 

--- a/cmscommon/crypto.py
+++ b/cmscommon/crypto.py
@@ -44,7 +44,7 @@ __all__ = [
     "encrypt_string", "decrypt_string",
     "encrypt_number", "decrypt_number",
 
-    "generate_random_password", "generate_random_password_with_method",
+    "generate_random_password", "generate_random_password_text",
 
     "validate_password", "hash_password", "parse_authentication",
 ]
@@ -172,15 +172,15 @@ def generate_random_password():
     return "".join((random.choice(ascii_lowercase) for _ in range(6)))
 
 
-def generate_random_password_with_method(method="text"):
+def generate_random_password_text():
     """Utility method to generate a random password
-    and encrypt with the given method.
+    in the format text:password.
 
     return (string): method:a random string.
 
     """
     return hash_password(password=generate_random_password(),
-                         method=method)
+                         method="text")
 
 
 def parse_authentication(authentication):

--- a/cmscontrib/AddParticipation.py
+++ b/cmscontrib/AddParticipation.py
@@ -39,6 +39,7 @@ import sys
 from cms import utf8_decoder
 from cms.db import Contest, Participation, SessionGen, Team, User, \
     ask_for_contest
+from cmscommon.crypto import hash_password
 
 from sqlalchemy.exc import IntegrityError
 
@@ -47,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 
 def add_participation(username, contest_id, ip, delay_time, extra_time,
-                      password, team_code, hidden, unrestricted):
+                      password, use_bcrypt, team_code, hidden, unrestricted):
     logger.info("Creating the user's participation in the database.")
     delay_time = delay_time if delay_time is not None else 0
     extra_time = extra_time if extra_time is not None else 0
@@ -70,6 +71,10 @@ def add_participation(username, contest_id, ip, delay_time, extra_time,
                 if team is None:
                     logger.error("No team with code `%s' found.", team_code)
                     return False
+            if password is not None:
+                method = "bcrypt" if use_bcrypt else "text"
+                password = hash_password(password, method)
+
             participation = Participation(
                 user=user,
                 contest=contest,
@@ -115,6 +120,8 @@ def main():
                         help="if the participation is hidden")
     parser.add_argument("-u", "--unrestricted", action="store_true",
                         help="if the participation is unrestricted")
+    parser.add_argument("-B", "--bcrypt", action="store_true",
+                        help="use bcrypt to encrypt participation password")
 
     args = parser.parse_args()
 
@@ -123,7 +130,7 @@ def main():
 
     success = add_participation(args.username, args.contest_id,
                                 args.ip, args.delay_time, args.extra_time,
-                                args.password, args.team,
+                                args.password, args.bcrypt, args.team,
                                 args.hidden, args.unrestricted)
     return 0 if success is True else 1
 

--- a/cmscontrib/AddUser.py
+++ b/cmscontrib/AddUser.py
@@ -28,6 +28,7 @@ from __future__ import unicode_literals
 # We enable monkey patching to make many libraries gevent-friendly
 # (for instance, urllib3, used by requests)
 import gevent.monkey
+
 gevent.monkey.patch_all()
 
 import argparse
@@ -36,19 +37,23 @@ import sys
 
 from cms import utf8_decoder
 from cms.db import SessionGen, User
-from cmscommon.crypto import generate_random_password
+from cmscommon.crypto import generate_random_password_with_method, \
+    hash_password
 
 from sqlalchemy.exc import IntegrityError
-
 
 logger = logging.getLogger(__name__)
 
 
-def add_user(first_name, last_name, username, password, email, timezone,
-             preferred_languages):
+def add_user(first_name, last_name, username, password, use_bcrypt, email,
+             timezone, preferred_languages):
     logger.info("Creating the user in the database.")
     if password is None:
-        password = generate_random_password()
+        password = generate_random_password_with_method()
+    else:
+        method = "bcrypt" if use_bcrypt else "text"
+        password = hash_password(password, method)
+
     if preferred_languages is None or preferred_languages == "":
         preferred_languages = "[]"
     else:
@@ -94,12 +99,14 @@ def main():
                         help="timezone of the user, e.g. Europe/London")
     parser.add_argument("-l", "--languages", action="store", type=utf8_decoder,
                         help="comma-separated list of preferred languages")
+    parser.add_argument("-B", "--bcrypt", action="store_true",
+                        help="use bcrypt to encrypt user password")
 
     args = parser.parse_args()
 
     success = add_user(args.first_name, args.last_name,
-                       args.username, args.password, args.email,
-                       args.timezone, args.languages)
+                       args.username, args.password, args.bcrypt,
+                       args.email, args.timezone, args.languages)
     return 0 if success is True else 1
 
 

--- a/cmscontrib/AddUser.py
+++ b/cmscontrib/AddUser.py
@@ -37,7 +37,7 @@ import sys
 
 from cms import utf8_decoder
 from cms.db import SessionGen, User
-from cmscommon.crypto import generate_random_password_with_method, \
+from cmscommon.crypto import generate_random_password_text, \
     hash_password
 
 from sqlalchemy.exc import IntegrityError

--- a/cmscontrib/AddUser.py
+++ b/cmscontrib/AddUser.py
@@ -45,12 +45,12 @@ from sqlalchemy.exc import IntegrityError
 logger = logging.getLogger(__name__)
 
 
-def add_user(first_name, last_name, username, password, use_bcrypt, email,
-             timezone, preferred_languages):
+def add_user(first_name, last_name, username, password, use_bcrypt, is_raw,
+             email, timezone, preferred_languages):
     logger.info("Creating the user in the database.")
     if password is None:
         password = generate_random_password_with_method()
-    else:
+    elif not is_raw:
         method = "bcrypt" if use_bcrypt else "text"
         password = hash_password(password, method)
 
@@ -101,12 +101,15 @@ def main():
                         help="comma-separated list of preferred languages")
     parser.add_argument("-B", "--bcrypt", action="store_true",
                         help="use bcrypt to encrypt user password")
+    parser.add_argument("-r", "--raw", action="store_true",
+                        help="raw password")
 
     args = parser.parse_args()
 
     success = add_user(args.first_name, args.last_name,
                        args.username, args.password, args.bcrypt,
-                       args.email, args.timezone, args.languages)
+                       args.raw, args.email, args.timezone,
+                       args.languages)
     return 0 if success is True else 1
 
 


### PR DESCRIPTION
In relation to issue #710, I managed to add support for encrypting user passwords with bcrypt. They are  kept in the database as either clear text or hash, depending on how the account is created.

Options added:
 * Ability for admins to select either text or bcrypt when creating an user account, updating an user account or a participation to a contest
 * Users can login with the password, be it clear text or hash
 * Added bcrypt option to hash password for ```cmsAddUser``` and ```cmsAddParticipation```
 * Password now have the format algo:password in the database. Any password that does not match this format will raise an exception

Example of encryption selection:
![Example encryption select](http://image.prntscr.com/image/ade869c2f3c0437e9cfff2630341882e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/711)
<!-- Reviewable:end -->
