### PR TITLE
Check r_params != None in case of error.

### DIFF
--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -416,7 +416,7 @@ class BaseHandler(CommonRequestHandler):
         # the data we need to display a basic template with the error
         # information. If r_params is not defined (i.e. something went
         # *really* bad) we simply return a basic textual error notice.
-        if hasattr(self, 'r_params'):
+        if getattr(self, 'r_params', None) is not None:
             self.render("error.html", status_code=status_code, **self.r_params)
         else:
             self.write("A critical error has occurred :-(")


### PR DESCRIPTION
When one (possibly accidentally) encounters CSRF token mismatch, it is supposed to show a 403 error page. In fact it doesn't. It only shows a blank page.

This seems to be because `r_param` is set to `None` when CSRF token mismatch occurs. In this patch, CMS falls back to the simple error page when `r_param == None`, in addition to the case `r_param` is not defined.


In fact we actually encountered CSRF token mismatch in the beginning of the contest. The cause is still under investigation, but is supposed to be related to caching.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/713)
<!-- Reviewable:end -->
