### PR TITLE
Added sign up interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cms.egg-info
 cache/
 lib/
 log/
+.idea/

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -42,5 +42,6 @@ Petar Veličković <pv273@cam.ac.uk>
 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
 Kārlis Seņko <karlis3p70l1ij@gmail.com>
 Peyman Jabbarzade Ganje <peyman.jabarzade@gmail.com>
+Tudor Nazarie <nazarietudor@gmail.com>
 And many other people that didn't write code, but provided useful
 comments, suggestions and feedback. :-)

--- a/cms/db/contest.py
+++ b/cms/db/contest.py
@@ -99,6 +99,12 @@ class Contest(Base):
         nullable=False,
         default=True)
 
+    # Whether to allow people to sign up for the contest via the web interface
+    allow_signup = Column(
+        Boolean,
+        nullable=False,
+        default=False)
+
     # Whether to prevent hidden participations to log in.
     block_hidden_participations = Column(
         Boolean,

--- a/cms/server/admin/handlers/contest.py
+++ b/cms/server/admin/handlers/contest.py
@@ -101,6 +101,7 @@ class ContestHandler(SimpleContestHandler("contest.html")):
             self.get_bool(attrs, "submissions_download_allowed")
             self.get_bool(attrs, "allow_questions")
             self.get_bool(attrs, "allow_user_tests")
+            self.get_bool(attrs, "allow_signup")
             self.get_bool(attrs, "block_hidden_participations")
             self.get_bool(attrs, "allow_password_authentication")
             self.get_bool(attrs, "ip_restriction")

--- a/cms/server/admin/templates/contest.html
+++ b/cms/server/admin/templates/contest.html
@@ -76,6 +76,15 @@
     </tr>
     <tr>
       <td>
+        <span class="info" title="Whether to allow people to sign up for the contest."></span>
+        <label for="allow_signup">Allow sign up</label>
+      </td>
+      <td>
+        <input type="checkbox" id="allow_signup" name="allow_signup" {{ "checked" if contest.allow_signup else "" }}/>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <span class="info" title="The number of decimal places the scores will be rounded to.
                                   Example: '2' to allow 98.76."></span>
         Score decimal places

--- a/cms/server/contest/handlers/__init__.py
+++ b/cms/server/contest/handlers/__init__.py
@@ -61,6 +61,9 @@ from .taskusertest import \
 from .communication import \
     CommunicationHandler, \
     QuestionHandler
+from .signup import \
+    SignupHandler, \
+    RegisterHandler
 
 
 HANDLERS = [
@@ -70,6 +73,8 @@ HANDLERS = [
     (r"/", MainHandler),
     (r"/login", LoginHandler),
     (r"/logout", LogoutHandler),
+    (r"/signup", SignupHandler),
+    (r"/register", RegisterHandler),
     (r"/start", StartHandler),
     (r"/notifications", NotificationsHandler),
     (r"/printing", PrintingHandler),

--- a/cms/server/contest/handlers/signup.py
+++ b/cms/server/contest/handlers/signup.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2017 Tudor Nazarie <nazarietudor@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Handlers related to the signup interface
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import datetime
+
+import tornado.web
+
+from cms.db import Participation, User, SessionGen, Contest, Team
+from cmscommon.crypto import generate_random_password
+
+from .base import BaseHandler
+
+from sqlalchemy.exc import IntegrityError
+
+logger = logging.getLogger(__name__)
+
+
+def add_user(first_name, last_name, username, password, email, timezone=None,
+             preferred_languages=None):
+    if password is None:
+        password = generate_random_password()
+    if preferred_languages is None or preferred_languages == "":
+        preferred_languages = "[]"
+    else:
+        preferred_languages = \
+            "[" + ",".join("\"" + lang + "\""
+                           for lang in preferred_languages.split(",")) + "]"
+
+    user = User(
+        first_name=first_name,
+        last_name=last_name,
+        username=username,
+        password=password,
+        email=email,
+        timezone=timezone,
+        preferred_languages=preferred_languages
+    )
+
+    try:
+        with SessionGen() as session:
+            session.add(user)
+            session.commit()
+    except IntegrityError:
+        return False
+
+    logger.info("Registered user {} with password {}".format(username,
+                                                             password))
+    return True
+
+
+def add_participation(username, contest_id, ip=None, delay_time=None,
+                      extra_time=None, password=None, team_code=None,
+                      hidden=False, unrestricted=False):
+    delay_time = delay_time if delay_time is not None else 0
+    extra_time = extra_time if extra_time is not None else 0
+
+    try:
+        with SessionGen() as session:
+            user = \
+                session.query(User).filter(User.username == username).first()
+            if user is None:
+                return False
+            contest = Contest.get_from_id(contest_id, session)
+            if contest is None:
+                return False
+            team = None
+            if team_code is not None:
+                team = \
+                    session.query(Team).filter(Team.code == team_code).first()
+                if team is None:
+                    return False
+            participation = Participation(
+                user=user,
+                contest=contest,
+                ip=ip,
+                delay_time=datetime.timedelta(seconds=delay_time),
+                extra_time=datetime.timedelta(seconds=extra_time),
+                password=password,
+                team=team,
+                hidden=hidden,
+                unrestricted=unrestricted
+            )
+
+            session.add(participation)
+            session.commit()
+    except IntegrityError:
+        return False
+    logger.info("Added participation for user {}".format(username))
+    return True
+
+
+class SignupHandler(BaseHandler):
+    """Displays the signup interface
+    """
+    def get(self):
+        participation = self.current_user
+
+        if not self.contest.allow_signup:
+            raise tornado.web.HTTPError(404)
+
+        if participation is not None:
+            self.redirect("/")
+            return
+
+        self.render("signup.html", **self.r_params)
+
+
+class RegisterHandler(BaseHandler):
+    """Register handler
+    """
+    def post(self):
+        username = self.get_argument("username", "")
+        first_name = self.get_argument("first_name", "")
+        last_name = self.get_argument("last_name", "")
+        email = self.get_argument("email", "")
+        password = self.get_argument("password", "")
+        confirm_password = self.get_argument("confirm_password", "")
+
+        if not self.contest.allow_signup:
+            raise tornado.web.HTTPError(404)
+
+        if self.contest.phase(self.timestamp) != -1:
+            self.redirect("/")
+            return
+
+        if password != confirm_password:
+            self.redirect("/signup?password_no_match=true")
+            return
+
+        user = self.sql_session.query(User)\
+            .filter(User.username == username)\
+            .first()
+        participation = self.sql_session.query(Participation)\
+            .filter(Participation.contest == self.contest)\
+            .filter(Participation.user == user)\
+            .first()
+
+        if user is not None and participation is not None:
+            self.redirect("/signup?user_exists=true")
+            return
+
+        if user is None:
+            add_user(
+                first_name=first_name,
+                last_name=last_name,
+                username=username,
+                password=password,
+                email=email
+            )
+        add_participation(
+            username=username,
+            password=password,
+            contest_id=self.contest.id
+        )
+        self.redirect("/?signup_successful=true")
+        return

--- a/cms/server/contest/templates/base.html
+++ b/cms/server/contest/templates/base.html
@@ -97,6 +97,14 @@ $(document).ready(function () {
             </div>
         </div>
     {% end %}
+        {% if handler.get_argument("signup_successful", "") != "" %}
+        <div id="notifications" class="notifications">
+            <div class="alert alert-block alert-success notification">
+                <a class="close" data-dismiss="alert" href="#">&#xD7;</a>
+                <h4 class="alert-heading">{{ _("Registration successful. You may now log in.") }}</h4>
+            </div>
+        </div>
+    {% end %}
         <div class="login_container">
             <div class="login_box hero-unit">
                 <h1>{{ _("Welcome") }}</h1>
@@ -125,6 +133,9 @@ $(document).ready(function () {
                         </div>
                     </fieldset>
                 </form>
+              {% if contest.allow_signup and phase == -1 %}
+              <a href="{{ url_root }}/signup">Sign up for the contest</a>
+              {% end %}
             </div>
         </div>
 {% else %}

--- a/cms/server/contest/templates/signup.html
+++ b/cms/server/contest/templates/signup.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <link rel="shortcut icon" href="{{ url_root }}/static/favicon.ico"/>
+  <script type="text/javascript" src="{{ url_root }}/static/jq/jquery-1.7.1.min.js"></script>
+  <script type="text/javascript" src="{{ url_root }}/static/js/bootstrap.js"></script>
+  <script type="text/javascript" src="{{ url_root }}/static/cws_utils.js"></script>
+  <link rel="stylesheet" href="{{ url_root }}/static/css/bootstrap.css">
+  <link rel="stylesheet" href="{{ url_root }}/static/cws_style.css">
+
+  <title>Sign up for {{ contest.description }}</title>
+
+  <script type="text/javascript">
+    var utils = new CMS.CWSUtils("{{ url_root }}",
+                                 0, 0, 0, 0, 0);
+  </script>
+</head>
+<body id="body">
+<div id="navigation_bar" class="navbar navbar-fixed-top">
+  <div class="navbar-inner">
+    <div class="container">
+      <a class="brand" href="{{ url_root }}/">{{ contest.description }}</a>
+      {% if len(lang_names) > 1 %}
+      <p class="navbar-text pull-right">
+        <select id="lang" class="form-control btn btn-info" onchange="utils.switch_lang()">
+          <option value=""{% if cookie_lang is None %} selected{% end %}>{{ _("Automatic (%s)") % lang_names[browser_lang] }}</option>
+          {% for lang_code, lang_name in sorted(lang_names.iteritems(), key=lambda x: x[1]) %}
+            <option value="{{ lang_code }}"{% if cookie_lang == lang_code %} selected{% end %}>{{ lang_name }}</option>
+          {% end %}
+        </select>
+      </p>
+      {% end %}
+    </div>
+  </div>
+</div>
+
+{% if handler.get_argument("password_no_match", "") != "" %}
+        <div id="notifications" class="notifications">
+            <div class="alert alert-block alert-error notification">
+                <a class="close" data-dismiss="alert" href="#">&#xD7;</a>
+                <h4 class="alert-heading">{{ _("Passwords do not match") }}</h4>
+            </div>
+        </div>
+{% end %}
+
+{% if handler.get_argument("user_exists", "") != "" %}
+        <div id="notifications" class="notifications">
+            <div class="alert alert-block alert-error notification">
+                <a class="close" data-dismiss="alert" href="#">&#xD7;</a>
+                <h4 class="alert-heading">{{ _("A user with that username already exists") }}</h4>
+            </div>
+        </div>
+{% end %}
+
+<div class="login_container">
+  <div class="login_box hero-unit">
+    {% if phase == -1 %}
+    <h1>{{ _("Sign up") }}</h1>
+    <p>{{ _("Please enter your data") }}</p>
+    <form class="form-horizontal" action="{{ url_root }}/register" method="POST">
+      {% module xsrf_form_html() %}
+      <input type="hidden" name="next" value="{{ handler.get_argument("next", "/signup_successful=true") }}">
+      <fieldset>
+        <div class="control-group">
+          <label class="control-label" for="first_name">{{ _("First Name") }}</label>
+          <div class="controls">
+            <input type="text" class="input-xlarge" name="first_name" id="first_name">
+          </div>
+        </div>
+
+        <div class="control-group">
+          <label class="control-label" for="last_name">{{ _("Last Name") }}</label>
+          <div class="controls">
+            <input type="text" class="input-xlarge" name="last_name" id="last_name">
+          </div>
+        </div>
+
+        <div class="control-group">
+          <label class="control-label" for="email">{{ _("Email") }}</label>
+          <div class="controls">
+            <input type="text" class="input-xlarge" name="email" id="email">
+          </div>
+        </div>
+
+        <div class="control-group">
+          <label class="control-label" for="username">{{ _("Username") }}</label>
+          <div class="controls">
+            <input type="text" class="input-xlarge" name="username" id="username" required>
+          </div>
+        </div>
+
+        <div class="control-group">
+          <label class="control-label" for="password">{{ _("Password") }}</label>
+          <div class="controls">
+            <input type="password" class="input-xlarge" name="password" id="password" required>
+          </div>
+        </div>
+
+        <div class="control-group">
+          <label class="control-label" for="confirm_password">{{ _("Confirm password") }}</label>
+          <div class="controls">
+            <input type="password" class="input-xlarge" name="confirm_password" id="confirm_password" required>
+          </div>
+        </div>
+
+        <div class="control-group">
+          <div class="controls">
+            <button type="submit" class="btn btn-primary btn-large">{{ _("Register") }}</button>
+            <button type="reset" class="btn btn-large">{{ _("Reset") }}</button>
+          </div>
+        </div>
+      </fieldset>
+    </form>
+    {% end %}
+
+    {% if phase == 0 %}
+    <h1>{{ _("The contest has already begun") }}</h1>
+    <p>{{ _("You can only sign up before the start of the contest") }}</p>
+    {% end %}
+
+    {% if phase == 1 %}
+    <h1>{{ _("The contest has ended") }}</h1>
+    <p>{{ _("You can only sign up before the start of the contest") }}</p>
+    {% end %}
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Hello everybody. This PR adds a functionality that I felt like was needed in CMS, namely a way to sign up for a contest without an administrator's help.

When organizing the Romanian Master of Informatics 2016 contest last autumn, we wanted to have an open round, where people can sign up and compete alongside the official contest, using the same interface we use for the contest, but we bumped into a problem. CMS didn't have an official way of letting people sign up. At that time, we hacked together something that would fit the bill, but now the need is coming up again and I've decided to implement the functionality in CMS. 

This PR does just that. It adds a boolean field in the contest table of the DB, storing whether or not people are allowed to sign up, changes the AWS to be able to modify that field and adds a page to the CWS containing the sign up form.

This is my first contribution to CMS, so if I messed something up, I'll try to fix it.