### PR TITLE
Added 'Download submissions' button

### DIFF
--- a/cms/server/admin/handlers/__init__.py
+++ b/cms/server/admin/handlers/__init__.py
@@ -69,7 +69,8 @@ from .task import \
     AddAttachmentHandler, \
     AttachmentHandler, \
     TaskListHandler, \
-    RemoveTaskHandler
+    RemoveTaskHandler, \
+    DownloadSubmissionsHandler
 from .dataset import \
     DatasetSubmissionsHandler, \
     CloneDatasetHandler, \
@@ -172,6 +173,7 @@ HANDLERS = [
     (r"/task/([0-9]+)/statement/([0-9]+)", StatementHandler),
     (r"/task/([0-9]+)/attachments/add", AddAttachmentHandler),
     (r"/task/([0-9]+)/attachment/([0-9]+)", AttachmentHandler),
+    (r"/task/([0-9]+)/submissions/download", DownloadSubmissionsHandler),
 
     # Datasets
 

--- a/cms/server/admin/templates/dataset.html
+++ b/cms/server/admin/templates/dataset.html
@@ -21,6 +21,9 @@
            url_root,
            dataset_id=shown_dataset.id) %}
   </p>
+  {% if submission_count > 0 %}
+  <a href="{{ url_root }}/task/{{ task.id }}/submissions/download">Download all submissions for this task</a>
+  {% end %}
 
   {% set page_url = "/dataset/%s" % shown_dataset.id %}
   {% include fragments/submission_rows.html %}


### PR DESCRIPTION
While running the Romanian Master of Informatics 2016 contest last autumn, we wanted to make all the sources submitted public after the contest had ended. That way, everyone can learn and better themselves. Or something along those lines. Now, there was no easy way of doing that, so we eventually dropped the idea. This patch adds that functionality in case anyone ever needs it.

This patch adds:

- A link on the task submission page to a zip file containing the source files in the format `username_X.%l`, where X is the number of the submission, beginning with 1
- The handler code required to gather the sources and create the zip file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/724)
<!-- Reviewable:end -->
