### PR TITLE
Fix misuse of gevent's StreamServer

### DIFF
--- a/cms/io/rpc.py
+++ b/cms/io/rpc.py
@@ -5,7 +5,7 @@
 # Copyright © 2010-2013 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
 # Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
-# Copyright © 2013 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2013-2017 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -190,8 +190,8 @@ class RemoteServiceBase(object):
             self._socket.shutdown(socket.SHUT_RDWR)
             self._socket.close()
         except socket.error as error:
-            logger.debug("Couldn't disconnect from %s: %s.",
-                         self._repr_remote(), error)
+            logger.warning("Couldn't disconnect from %s: %s.",
+                           self._repr_remote(), error)
         finally:
             self.finalize("Disconnection requested.")
         return True
@@ -302,7 +302,7 @@ class RemoteServiceServer(RemoteServiceBase):
 
     def handle(self, socket_):
         self.initialize(socket_, self.remote_address)
-        gevent.spawn(self.run)
+        self.run()
 
     def run(self):
         """Start listening for requests, and go on forever.

--- a/cmstestsuite/unit_tests/io/rpc_test.py
+++ b/cmstestsuite/unit_tests/io/rpc_test.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Contest Management System - http://cms-dev.github.io/
-# Copyright © 2014-2016 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2014-2017 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2015 Stefano Maggiolo <s.maggiolo@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -91,7 +91,7 @@ class TestRPC(unittest.TestCase):
         port (int): the port (0 causes any available port to be chosen)
 
         """
-        self._server = StreamServer((host, port), self.get_server)
+        self._server = StreamServer((host, port), self.handle_new_connection)
         self._server.start()
         self.host = self._server.server_host
         self.port = self._server.server_port
@@ -107,23 +107,21 @@ class TestRPC(unittest.TestCase):
             del self._server
         # We leave self.host and self.port.
 
-    def get_server(self, socket_, address):
-        """Obtain a new RemoteServiceServer to handle a new connection.
+    def handle_new_connection(self, socket_, address):
+        """Create a new RemoteServiceServer to handle a new connection.
 
-        Instantiate a RemoteServiceServer, spawn its greenlet and add
-        it to self.servers. It will listen on the given socket, that
-        represents a connection opened by a remote host at the given
-        address.
+        Instantiate a RemoteServiceServer, add it to self.servers and
+        have it listen on the given socket (which is for a connection
+        opened by a remote host from the given address). This method
+        will block until the socket gets closed.
 
         socket_ (socket): the socket to use
         address (tuple): the (ip address, port) of the remote part
-        return (RemoteServiceServer): a server
 
         """
         server = RemoteServiceServer(self.service, address)
-        server.handle(socket_)
         self.servers.append(server)
-        return server
+        server.handle(socket_)
 
     def get_client(self, coord, auto_retry=None):
         """Obtain a new RemoteServiceClient to connect to a server.


### PR DESCRIPTION
StreamServer calls the handler we provided to it for every new incoming connection, giving it the socket for that connection. That call is performed in its own greenlet. Once that handler terminates, StreamServer considers the socket as dealt with, and therefore ready for closure and elimination. Yet, in gevent up to 1.0, the socket was left untouched by StreamServer. Starting in gevent 1.1 StreamServer closes the socket once the handler returns.

Our handler used to spawn another greenlet, inside of which it was running an infinite loop that read from the socket and took care of executing the requests. Once it spawned that greenlet, the handler would return. This worked correctly in gevent 1.0 but breaks now, as the socket will be closed immediately after the reading loop starts.

This causes the client to get into a loop of connection, immediate disconnection and reattempt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/729)
<!-- Reviewable:end -->
