### PR TITLE
Fix detection of psycopg2 version

### DIFF
--- a/cms/db/types.py
+++ b/cms/db/types.py
@@ -39,10 +39,10 @@ from sqlalchemy.types import TypeDecorator, Unicode
 # before that we do it ourselves. See:
 # https://github.com/psycopg/psycopg2/commit/643ba70bad0f19a68c06ec95de2691c28e060e48
 
-if tuple(int(x) for x in psycopg2.__version__.split('.')[:2]) >= (2, 7):
+try:
     psycopg2.extras.register_ipaddress()
 
-else:
+except AttributeError:
     from psycopg2.extensions import new_type, new_array_type, register_type, \
         register_adapter, QuotedString
 


### PR DESCRIPTION
Apparently some systems have a version of the form "X.Y (foo)".

Fixes #750.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/751)
<!-- Reviewable:end -->
