### PR TITLE
Fix cmsMake errors when running 'cmsMake -c' from a path with spaces in it

### DIFF
--- a/cmstaskenv/cmsMake.py
+++ b/cmstaskenv/cmsMake.py
@@ -579,9 +579,9 @@ def clean(base_dir, generated_list):
         pass
 
     # Delete compiled and/or backup files
-    os.system("find %s -name '*.o' -delete" % (base_dir))
-    os.system("find %s -name '*.pyc' -delete" % (base_dir))
-    os.system("find %s -name '*~' -delete" % (base_dir))
+    os.system("find \"%s\" -name '*.o' -delete" % (base_dir))
+    os.system("find \"%s\" -name '*.pyc' -delete" % (base_dir))
+    os.system("find \"%s\" -name '*~' -delete" % (base_dir))
 
 
 def build_execution_tree(actions):


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/752)
<!-- Reviewable:end -->
