### PR TITLE
Make cmstestsuite great again

### DIFF
--- a/cmstestsuite/__init__.py
+++ b/cmstestsuite/__init__.py
@@ -8,6 +8,7 @@
 # Copyright © 2014 Luca Versari <veluca93@gmail.com>
 # Copyright © 2014 William Di Luigi <williamdiluigi@gmail.com>
 # Copyright © 2016 Peyman Jabbarzade Ganje <peyman.jabarzade@gmail.com>
+# Copyright © 2017 Luca Chiodini <luca@chiodini.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -67,8 +68,8 @@ admin_info = {}
 
 
 # Base URLs for AWS and CWS
-AWS_BASE_URL = "http://localhost:8889/"
-CWS_BASE_URL = "http://localhost:8888/"
+AWS_BASE_URL = "http://localhost:8889"
+CWS_BASE_URL = "http://localhost:8888"
 
 
 # Persistent browsers to access AWS and CWS.
@@ -194,7 +195,7 @@ def initialize_aws(rand):
 
 def admin_req(path, args=None, files=None):
     browser = get_aws_browser()
-    return browser.do_request(AWS_BASE_URL + path, args, files)
+    return browser.do_request(AWS_BASE_URL + '/' + path, args, files)
 
 
 def get_tasks():

--- a/cmstestsuite/web/AWSRequests.py
+++ b/cmstestsuite/web/AWSRequests.py
@@ -7,6 +7,7 @@
 # Copyright © 2010-2017 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2016 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2017 Luca Chiodini <luca@chiodini.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -52,7 +53,7 @@ class AWSSubmissionViewRequest(GenericRequest):
     def __init__(self, browser, submission_id, base_url=None):
         GenericRequest.__init__(self, browser, base_url)
         self.submission_id = submission_id
-        self.url = "%ssubmission/%s" % (self.base_url, submission_id)
+        self.url = "%s/submission/%s" % (self.base_url, submission_id)
 
     def describe(self):
         return "check submission %s" % self.submission_id
@@ -109,7 +110,7 @@ class AWSUserTestViewRequest(GenericRequest):
     def __init__(self, browser, user_test_id, base_url=None):
         GenericRequest.__init__(self, browser, base_url)
         self.user_test_id = user_test_id
-        self.url = "%suser_test/%s" % (self.base_url, user_test_id)
+        self.url = "%s/user_test/%s" % (self.base_url, user_test_id)
 
     def describe(self):
         return "check user_test %s" % self.user_test_id

--- a/cmstestsuite/web/CWSRequests.py
+++ b/cmstestsuite/web/CWSRequests.py
@@ -7,6 +7,7 @@
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2016 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2017 Luca Chiodini <luca@chiodini.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -80,7 +81,7 @@ class TaskRequest(GenericRequest):
     """
     def __init__(self, browser, task_id, base_url=None):
         GenericRequest.__init__(self, browser, base_url)
-        self.url = "%stasks/%s/description" % (self.base_url, task_id)
+        self.url = "%s/tasks/%s/description" % (self.base_url, task_id)
         self.task_id = task_id
 
     def describe(self):
@@ -93,8 +94,8 @@ class TaskStatementRequest(GenericRequest):
     """
     def __init__(self, browser, task_id, language_code, base_url=None):
         GenericRequest.__init__(self, browser, base_url)
-        self.url = "%stasks/%s/statements/%s" % (self.base_url,
-                                                 task_id, language_code)
+        self.url = "%s/tasks/%s/statements/%s" % (self.base_url,
+                                                  task_id, language_code)
         self.task_id = task_id
 
     def describe(self):
@@ -111,7 +112,7 @@ class SubmitRequest(GenericRequest):
     def __init__(self, browser, task, submission_format,
                  filenames, language=None, base_url=None):
         GenericRequest.__init__(self, browser, base_url)
-        self.url = "%stasks/%s/submit" % (self.base_url, task[1])
+        self.url = "%s/tasks/%s/submit" % (self.base_url, task[1])
         self.task = task
         self.submission_format = submission_format
         self.filenames = filenames
@@ -171,7 +172,7 @@ class SubmitUserTestRequest(GenericRequest):
     def __init__(self, browser, task, submission_format,
                  filenames, language=None, base_url=None):
         GenericRequest.__init__(self, browser, base_url)
-        self.url = "%stasks/%s/test" % (self.base_url, task[1])
+        self.url = "%s/tasks/%s/test" % (self.base_url, task[1])
         self.task = task
         self.submission_format = submission_format
         self.filenames = filenames
@@ -237,9 +238,9 @@ class TokenRequest(GenericRequest):
     """
     def __init__(self, browser, task, submission_num, base_url=None):
         GenericRequest.__init__(self, browser, base_url)
-        self.url = "%stasks/%s/submissions/%s/token" % (self.base_url,
-                                                        task[1],
-                                                        submission_num)
+        self.url = "%s/tasks/%s/submissions/%s/token" % (self.base_url,
+                                                         task[1],
+                                                         submission_num)
         self.task = task
         self.submission_num = submission_num
         self.data = {}
@@ -261,7 +262,7 @@ class SubmitRandomRequest(GenericRequest):
     def __init__(self, browser, task, base_url=None,
                  submissions_path=None):
         GenericRequest.__init__(self, browser, base_url)
-        self.url = "%stasks/%s/submit" % (self.base_url, task[1])
+        self.url = "%s/tasks/%s/submit" % (self.base_url, task[1])
         self.task = task
         self.submissions_path = submissions_path
         self.data = {}

--- a/cmstestsuite/web/__init__.py
+++ b/cmstestsuite/web/__init__.py
@@ -7,6 +7,7 @@
 # Copyright © 2010-2016 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2016 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2017 Luca Chiodini <luca@chiodini.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -46,8 +47,8 @@ class Browser(object):
         self.session = requests.Session()
 
     def read_xsrf_token(self, url):
-        response = self.session.get(url)
-        for cookie in response.cookies:
+        self.session.get(url)
+        for cookie in self.session.cookies:
             if cookie.name == "_xsrf":
                 self.xsrf_token = cookie.value
 
@@ -56,10 +57,9 @@ class Browser(object):
         login_request.execute()
 
     def do_request(self, url, data=None, file_names=None):
-        """Open an URL in a mechanize browser, optionally passing the
-        specified data and files as POST arguments.
+        """Open an URL, optionally passing the specified data and files as
+           POST arguments.
 
-        browser (mechanize.Browser): the browser to use.
         url (string): the URL to open.
         data (dict): a dictionary of parameters to pass as POST
             arguments.
@@ -253,10 +253,9 @@ class LoginRequest(GenericRequest):
         GenericRequest.__init__(self, browser, base_url)
         self.username = username
         self.password = password
-        self.url = '%slogin' % self.base_url
+        self.url = '%s/login' % self.base_url
         self.data = {'username': self.username,
-                     'password': self.password,
-                     'next': '/'}
+                     'password': self.password}
 
     def describe(self):
         return "try to login"


### PR DESCRIPTION
cmstestsuite has received only partial updates after the recent changes
to CMS and it is now in a broken state (in particular, StressTest.py).

This commit solves a bunch of issues:
- Missing utf8_decoder import in StressTest (required after 933a7ba)
- Wrong usage of LoginRequest instead of CWSLoginRequest in StressTest
- Bad code for joining actors in StressTest
  (wrong pylint suggestion in 2d3f38c)
- StressTest was using the old login method
- The "new" login method (class Browser in cmstestsuite/web/__init__.py),
  which in theory was supposed to correctly cope with XSRF cookies, did
  not work well. It was trying to retrieve the "_xsrf" cookie from a
  Request's Response, but that specific cookie belongs to the session.
  Moreover, the login method now works well with CWS in multicontest mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/754)
<!-- Reviewable:end -->
