### PR TITLE
Force checker results to be ASCII

### DIFF
--- a/cmstaskenv/Test.py
+++ b/cmstaskenv/Test.py
@@ -40,6 +40,7 @@ from cms.grading.tasktypes import get_task_type
 from cms.service.esoperations import ESOperation
 from cmscommon.terminal import move_cursor, add_color_to_string, \
     colors, directions
+from unidecode import unidecode
 
 
 # TODO - Use a context object instead of global variables
@@ -260,7 +261,7 @@ def test_testcases(base_dir, solution, language, assume=None):
                     "%5.2lf" % p,
                     colors.RED if abs(p - 1) > 0.01 else colors.BLACK
                 ),
-                "--- %s [Time:" % c.ljust(clen),
+                "--- %s [Time:" % unidecode(c).ljust(clen),
                 add_color_to_string(
                     ("%5.3f" % w[0]) if w[0] is not None else "N/A",
                     colors.BLUE if w[0] is not None and w[0] >= 0.95 * d[3][0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ patool>=1.10,<1.11  # https://github.com/wummel/patool/blob/master/doc/changelog
 bcrypt>=2.0,<2.1  # https://github.com/pyca/bcrypt/
 chardet>=2.3,<2.4  # https://pypi.python.org/pypi/chardet
 ipaddress>=1.0,<1.1  # https://pypi.python.org/pypi/ipaddress
+unidecode>=0.04,<0.05  # https://pypi.python.org/pypi/Unidecode
 
 # Only for some importers:
 pyyaml>=3.11,<3.12  # http://pyyaml.org/wiki/PyYAML


### PR DESCRIPTION
Sometimes an italian message can screw with a remote ssh terminal
because of accents and stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/782)
<!-- Reviewable:end -->
