### PR TITLE
[ExportSubmission] Support output-only task & task name in format

### DIFF
--- a/cmscontrib/ExportSubmissions.py
+++ b/cmscontrib/ExportSubmissions.py
@@ -61,6 +61,7 @@ TEMPLATE = {
 }
 TEMPLATE[".cpp"] = TEMPLATE[".c"]
 TEMPLATE[".java"] = TEMPLATE[".c"]
+TEMPLATE[".txt"] = TEMPLATE[".c"]
 
 
 def filter_top_scoring(results, unique):
@@ -193,10 +194,12 @@ def main():
             name = f_filename
             if name.endswith(".%l"):
                 name = name[:-3]  # remove last 3 chars
-            ext = languagemanager.get_language(s_language).source_extension
+            ext = languagemanager.get_language(s_language).source_extension \
+                  if s_language else '.txt'
 
             filename = args.filename.format(id=s_id, name=name, ext=ext,
-                                            time=s_timestamp, user=u_name)
+                                            time=s_timestamp, user=u_name,
+                                            task=t_name)
             filename = os.path.join(args.output_dir, filename)
             if os.path.exists(filename):
                 logger.warning("Skipping file '%s' because it already exists",


### PR DESCRIPTION
1) `s_language` for an output-only task is None. ---> Fixed extension for an output-only task as `.txt`.
2) Make template of `.txt` same as `.cpp`.
3) Add task name to file format variable named `task`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/789)
<!-- Reviewable:end -->
