### PR TITLE
Add multicontest autorestart support to ResourceService

### DIFF
--- a/cms/service/ResourceService.py
+++ b/cms/service/ResourceService.py
@@ -176,7 +176,7 @@ class ResourceService(Service):
     upon request.
 
     """
-    def __init__(self, shard, contest_id=None):
+    def __init__(self, shard, contest_id=None, autorestart=False):
         """If contest_id is not None, we assume the user wants the
         autorestart feature.
 
@@ -184,6 +184,7 @@ class ResourceService(Service):
         Service.__init__(self, shard)
 
         self.contest_id = contest_id
+        self.autorestart = autorestart or (contest_id is not None)
 
         # _local_store is a dictionary indexed by time in int(epoch)
         self._local_store = []
@@ -195,7 +196,7 @@ class ResourceService(Service):
         self._local_services = self._find_local_services()
         # Dict service with bool to mark if we will restart them.
         self._will_restart = dict((service,
-                                   None if self.contest_id is None else True)
+                                   None if not self.autorestart else True)
                                   for service in self._local_services)
         # Found process associate to the ServiceCoord.
         self._procs = dict((service, None)
@@ -207,7 +208,7 @@ class ResourceService(Service):
         self._store_resources(store=False)
 
         self.add_timeout(self._store_resources, None, 5.0)
-        if self.contest_id is not None:
+        if self.autorestart:
             self._launched_processes = set([])
             self.add_timeout(self._restart_services, None, 5.0,
                              immediately=True)
@@ -260,10 +261,12 @@ class ResourceService(Service):
                         ".",
                         "scripts",
                         "cms%s" % service.name)
-                process = subprocess.Popen([command,
-                                            "%d" % service.shard,
-                                            "-c",
-                                            "%d" % self.contest_id],
+                args = [command, "%d" % service.shard]
+                if self.contest_id is not None:
+                    args += ["-c", str(self.contest_id)]
+                else:
+                    args += ["-c", "ALL"]
+                process = subprocess.Popen(args,
                                            stdout=DEVNULL,
                                            stderr=subprocess.STDOUT
                                            )
@@ -453,8 +456,7 @@ class ResourceService(Service):
         return (bool/None): current status of will_restart.
 
         """
-        # If the contest_id is not set, we cannot autorestart.
-        if self.contest_id is None:
+        if not self.autorestart:
             return None
 
         # Decode name,shard
@@ -463,6 +465,11 @@ class ResourceService(Service):
         except ValueError:
             logger.error("Unable to decode service string.")
         name = service[:idx]
+
+        # ProxyService requires contest_id
+        if self.contest_id is None and name == "ProxyService":
+            return None
+
         try:
             shard = int(service[idx + 1:])
         except ValueError:

--- a/scripts/cmsContestWebServer
+++ b/scripts/cmsContestWebServer
@@ -27,11 +27,10 @@ from __future__ import unicode_literals
 import gevent.monkey
 gevent.monkey.patch_all()
 
-import argparse
 import logging
 import sys
 
-from cms import ConfigError, contest_id_from_args, get_safe_shard, utf8_decoder
+from cms import ConfigError, default_argument_parser
 from cms.db import ask_for_contest, test_db_connection
 from cms.server.contest import ContestWebServer
 
@@ -43,36 +42,10 @@ def main():
     """Parse arguments and launch service.
 
     """
-    parser = argparse.ArgumentParser(
-        description="Contestants' web server for CMS.")
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument("-c", "--contest-id", action="store", type=utf8_decoder,
-                       help="id of the contest to automatically load, "
-                       "or ALL to serve all contests")
-    parser.add_argument("shard", action="store", type=int, nargs="?")
-    args = parser.parse_args()
-
-    try:
-        args.shard = get_safe_shard("ContestWebServer", args.shard)
-    except ValueError:
-        raise ConfigError("Couldn't autodetect shard number and "
-                          "no shard specified for service %s, "
-                          "quitting." % ("ContestWebServer", ))
-
     test_db_connection()
-
-    if args.contest_id == "ALL":
-        success = ContestWebServer(args.shard).run()
-    else:
-        try:
-            if args.contest_id is not None:
-                args.contest_id = int(args.contest_id)
-        except ValueError:
-            logger.critical("Unable to parse contest id `%s'", args.contest_id)
-            return 1
-        success = ContestWebServer(
-            args.shard,
-            contest_id_from_args(args.contest_id, ask_for_contest)).run()
+    success = default_argument_parser("Contestants' web server for CMS.",
+                                      ContestWebServer,
+                                      ask_contest=ask_for_contest).run()
 
     return 0 if success is True else 1
 

--- a/scripts/cmsResourceService
+++ b/scripts/cmsResourceService
@@ -47,7 +47,12 @@ def main():
         description="Resource monitor and service starter for CMS.")
     parser.add_argument("-a", "--autorestart", action="store", type=int,
                         nargs="?", const=-1, metavar="CONTEST_ID",
+                        dest="contest_id",
                         help="restart automatically services on its machine")
+    parser.add_argument("-r", dest="autorestart", action="store_true",
+                        default=False,
+                        help="automatically restart services, same as '-a' "
+                             "but in multi-contest mode")
     parser.add_argument("shard", action="store", type=int, nargs="?")
     args = parser.parse_args()
 
@@ -60,17 +65,16 @@ def main():
 
     test_db_connection()
 
-    if args.autorestart is not None:
-        if args.autorestart == -1:
-            success = ResourceService(
-                args.shard, contest_id=ask_for_contest()).run()
+    contest_id = None
+    if args.contest_id is not None:
+        if args.contest_id == -1:
+            contest_id = ask_for_contest()
         else:
-            success = ResourceService(
-                args.shard,
-                contest_id=contest_id_from_args(
-                    args.autorestart, ask_for_contest)).run()
-    else:
-        success = ResourceService(args.shard).run()
+            contest_id = contest_id_from_args(args.autorestart, ask_for_contest)
+    success = ResourceService(args.shard,
+                              contest_id=contest_id,
+                              autorestart=args.autorestart).run()
+
     return 0 if success is True else 1
 
 

--- a/scripts/cmsResourceService
+++ b/scripts/cmsResourceService
@@ -31,12 +31,14 @@ import argparse
 import logging
 import sys
 
-from cms import ConfigError, contest_id_from_args, get_safe_shard
+from cms import ConfigError, contest_id_from_args, get_safe_shard, utf8_decoder
 from cms.db import ask_for_contest, test_db_connection
 from cms.service.ResourceService import ResourceService
 
 
 logger = logging.getLogger(__name__)
+
+RESTART_DISABLED = "RESTART_DISABLED"
 
 
 def main():
@@ -45,14 +47,10 @@ def main():
     """
     parser = argparse.ArgumentParser(
         description="Resource monitor and service starter for CMS.")
-    parser.add_argument("-a", "--autorestart", action="store", type=int,
-                        nargs="?", const=-1, metavar="CONTEST_ID",
-                        dest="contest_id",
+    parser.add_argument("-a", "--autorestart", action="store", nargs="?",
+                        type=utf8_decoder, const=None, metavar="CONTEST_ID",
+                        dest="contest_id", default=RESTART_DISABLED,
                         help="restart automatically services on its machine")
-    parser.add_argument("-r", dest="autorestart", action="store_true",
-                        default=False,
-                        help="automatically restart services, same as '-a' "
-                             "but in multi-contest mode")
     parser.add_argument("shard", action="store", type=int, nargs="?")
     args = parser.parse_args()
 
@@ -65,15 +63,13 @@ def main():
 
     test_db_connection()
 
+    autorestart = args.contest_id != RESTART_DISABLED
     contest_id = None
-    if args.contest_id is not None:
-        if args.contest_id == -1:
-            contest_id = ask_for_contest()
-        else:
-            contest_id = contest_id_from_args(args.autorestart, ask_for_contest)
+    if autorestart:
+        contest_id = contest_id_from_args(args.contest_id, ask_for_contest)
     success = ResourceService(args.shard,
                               contest_id=contest_id,
-                              autorestart=args.autorestart).run()
+                              autorestart=autorestart).run()
 
     return 0 if success is True else 1
 


### PR DESCRIPTION
ProxyService still requires contest_id, nothing changed there. Code could be slightly cleaner if it wasn't necessary to maintain backwards compatibility with previous CLI, but I think it is no worse than current master and makes testing cms in multi-contest mode easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/794)
<!-- Reviewable:end -->
