### PR TITLE
Show max used time and memory in AWS submissions

### DIFF
--- a/cms/db/submission.py
+++ b/cms/db/submission.py
@@ -424,6 +424,20 @@ class SubmissionResult(Base):
             .filter(Evaluation.testcase == testcase)\
             .first()
 
+    def get_used_resources(self):
+        """Return the maximum time and memory used by this SR.
+
+        return (float|None, int|None): max used time and memory,
+            or None if data is incomplete or unavailable.
+
+        """
+        t, m = None, None
+        if self.evaluated() and self.evaluations:
+            for ev in self.evaluations:
+                t = max(t, ev.execution_time)
+                m = max(m, ev.execution_memory)
+        return (t, m)
+
     def compiled(self):
         """Return whether the submission result has been compiled.
 

--- a/cms/server/admin/templates/submission.html
+++ b/cms/server/admin/templates/submission.html
@@ -137,6 +137,15 @@
         <td>Failures during evaluation</td>
         <td>{{ sr.evaluation_tries }}</td>
       </tr>
+        {% set t, m = sr.get_used_resources() %}
+      <tr>
+        <td>Execution time</td>
+        <td>{% if t is not None %}{{ t }} s{% else %}N/A{% end %}</td>
+      </tr>
+      <tr>
+        <td>Memory used</td>
+        <td>{% if m is not None %}{{ m // (1024 ** 2) }} MiB{% else %}N/A{% end %}</td>
+      </tr>
       {% end %}
       <tr>
         <td>Reevaluate</td>


### PR DESCRIPTION
This change adds maximum used time and memory to the submission details page in AWS.

Both `SubmissionResult.evaluations` and `SubmissionResult.score_details` could be used to calculate these values. Here `evaluations` is used for simpler code, however, it incurs a database query. This is not a problem now since the `templates/submission.html` queries `sr.evaluations` later anyway.

Closes #720.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/796)
<!-- Reviewable:end -->
