### PR TITLE
Logs in AWS are between <pre> tags

### DIFF
--- a/cms/server/admin/static/aws_style.css
+++ b/cms/server/admin/static/aws_style.css
@@ -335,7 +335,7 @@ table th {
 table td {
     font-size: 0.875em;
     padding: 0 0.5em;
-    vertical-align: middle;
+    vertical-align: top;
     width: 1px;
     white-space: nowrap;
 }

--- a/cms/server/admin/templates/overview.html
+++ b/cms/server/admin/templates/overview.html
@@ -184,7 +184,7 @@ function update_logs(response)
         strings.push('<td>' + severity + '</td>');
         strings.push('<td>' + coord + '</td>');
         strings.push('<td>' + operation + '</td>');
-        strings.push('<td>' + message + '</td></tr>');
+        strings.push('<td><pre>' + message + '</pre></td></tr>');
     }
 
     table.html(strings.join(""));

--- a/cms/server/admin/templates/overview.html
+++ b/cms/server/admin/templates/overview.html
@@ -170,8 +170,8 @@ function update_logs(response)
         return;
     }
 
-    var strings = [];
-    response['data'] = response['data'].reverse()
+    var new_table = $('<tbody>');
+    response['data'] = response['data'].reverse();
     for (i in response['data'])
     {
         var message = link_submissions(response['data'][i]['message']);
@@ -180,14 +180,15 @@ function update_logs(response)
         var severity = response['data'][i]['severity'];
         var timestamp = utils.format_time_or_date(response['data'][i]['timestamp']);
 
-        strings.push('<tr><td>' + timestamp + '</td>');
-        strings.push('<td>' + severity + '</td>');
-        strings.push('<td>' + coord + '</td>');
-        strings.push('<td>' + operation + '</td>');
-        strings.push('<td><pre>' + message + '</pre></td></tr>');
+        var row = $('<tr>');
+        row.append($('<td>').text(timestamp));
+        row.append($('<td>').text(severity));
+        row.append($('<td>').text(coord));
+        row.append($('<td>').text(operation));
+        row.append($('<td>').append($('<pre>').text(message)));
+        new_table.append(row);
     }
-
-    table.html(strings.join(""));
+    table.replaceWith(new_table);
 }
 
 function update_statuses()


### PR DESCRIPTION
Since forever the logs in `cmsAdminWebServer` are shown in simple text format. When something goes wrong a stacktrace is generated, which always has many endlines and tabulation characters. In HTML this chars are collapsed in a single space making the stacktraces very long lines.

The fix I propose is just to put the message inside a `<pre>` tag which
preserves all the spaces.

![screen](https://user-images.githubusercontent.com/6685454/34121439-5465c098-e429-11e7-9426-5fecfee49bdd.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/813)
<!-- Reviewable:end -->
