### PR TITLE
ES & AWS start up (very) slowly when SYN packets are dropped

### DIFF
--- a/cms/server/admin/server.py
+++ b/cms/server/admin/server.py
@@ -33,6 +33,7 @@ from __future__ import unicode_literals
 import base64
 import logging
 import pkg_resources
+import gevent
 
 from sqlalchemy import func, not_
 
@@ -94,8 +95,8 @@ class AdminWebServer(WebService):
 
         self.resource_services = []
         for i in range(get_service_shards("ResourceService")):
-            self.resource_services.append(self.connect_to(
-                ServiceCoord("ResourceService", i)))
+            gevent.spawn(lambda self, i: self.resource_services.append(
+                self.connect_to(ServiceCoord("ResourceService", i))), self, i)
         self.logservice = self.connect_to(ServiceCoord("LogService", 0))
 
     def is_rpc_authorized(self, service, shard, method):

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -94,7 +94,8 @@ class EvaluationExecutor(Executor):
 
         for i in xrange(get_service_shards("Worker")):
             worker = ServiceCoord("Worker", i)
-            self.pool.add_worker(worker)
+            gevent.spawn(lambda s, worker: s.pool.add_worker(worker),
+                    self, worker)
 
     def __contains__(self, item):
         """Return whether the item is in execution.


### PR DESCRIPTION
## Scenario
During the OIS (IOI-like competition in teams in Italy) the contest is hosted on Google Cloud Engine which has a peculiar policy with unreachable hosts. If a packet is sent to an unreachable host it will be dropped. This causes all the TCP connection to fail by timeout if the host is down.

## Setup
`cms.conf` is configured to "allow" connection from a _big_ number of workers (where _big_ is like 20). In fact we may want to scale up the number of running workers during the contest without restarting all the services.

## Problem
During the boot of some services (e.g. ES and AWS) there is a loop that tries to connect to all the services listed in the config file. ES tries to connect to the workers and AWS to the RS. The problem occurs in this loop:

https://github.com/cms-dev/cms/blob/1635eddb115c0105b3d0ed323c35c3c6b11c6183/cms/service/EvaluationService.py#L95-L97

`self.pool.add_worker` is blocking, and in this scenario the service boots up (as said by `cmsLogService`) but it cannot process any request until the loop finishes. This loop could be very very long since the TCP handshake timeout on linux is pretty high, times the number of host means an infeasible startup time.

In AWS the incriminated loop is this:

https://github.com/cms-dev/cms/blob/1635eddb115c0105b3d0ed323c35c3c6b11c6183/cms/server/admin/server.py#L96-L98

## This solution
Instead of making that blocking call in the main "thread" we can spawn _N_ greenlets that take care of the connections. We (at the OIS) have used this approach for the last 2 rounds without any problems. There is only one side effect that I've seen: the eventlets are spawned, they get blocked at the `connect` call which is done before adding the worker to the list in the pool. That means the worker is not listed in AWS until the `connect` call returns, successfully or not. In this scenario this means that when a worker connects it is almost instantly registered, when it's down it will be listed (as down) after the timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/814)
<!-- Reviewable:end -->
