### PR TITLE
Fixed corrupted users imported after eaee3a8

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -25,7 +25,7 @@ Artem Iglikov (aka artikz) <artem.iglikov@gmail.com>
 Damien Leroy <damien.leroy@be-oi.be>
 Tubérculo Martínez <nlehmann@dcc.uchile.cl>
 Evgeny Martynov <evgeny@epochfail.com>
-Edoardo Morassutto <gianluigi988@gmail.com>
+Edoardo Morassutto <edoardo.morassutto@gmail.com>
 Kento Nikaido (aka snukent) <snukent@gmail.com>
 William Pettersson <william.pettersson@gmail.com>
 Ludwig Schmidt <ludwigschmidt2@gmail.com>

--- a/cmscontrib/loaders/italy_yaml.py
+++ b/cmscontrib/loaders/italy_yaml.py
@@ -40,6 +40,7 @@ from cms import SCORE_MODE_MAX, SCORE_MODE_MAX_TOKENED_LAST
 from cms.db import Contest, User, Task, Statement, Attachment, \
     Team, SubmissionFormatElement, Dataset, Manager, Testcase
 from cms.grading.languagemanager import LANGUAGES, HEADER_EXTS
+from cmscommon.crypto import build_password
 from cmscommon.datetime import make_datetime
 from cmscontrib import touch
 
@@ -211,7 +212,7 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
         tasks = load(conf, None, ["tasks", "problemi"])
         participations = load(conf, None, ["users", "utenti"])
         for p in participations:
-            p["password"] = "plaintext:" + p["password"]
+            p["password"] = build_password(p["password"])
 
         # Import was successful
         os.remove(os.path.join(self.path, ".import_error_contest"))
@@ -248,7 +249,7 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
             return None
 
         load(conf, args, "username")
-        load(conf, args, "password", conv=lambda p: "plaintext:" + p)
+        load(conf, args, "password", conv=build_password)
 
         load(conf, args, ["first_name", "nome"])
         load(conf, args, ["last_name", "cognome"])

--- a/cmscontrib/loaders/italy_yaml.py
+++ b/cmscontrib/loaders/italy_yaml.py
@@ -9,6 +9,7 @@
 # Copyright © 2014-2016 William Di Luigi <williamdiluigi@gmail.com>
 # Copyright © 2015 Luca Chiodini <luca@chiodini.org>
 # Copyright © 2016 Andrea Cracco <guilucand@gmail.com>
+# Copyright © 2018 Edoardo Morassutto <edoardo.morassutto@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -209,6 +210,8 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
 
         tasks = load(conf, None, ["tasks", "problemi"])
         participations = load(conf, None, ["users", "utenti"])
+        for p in participations:
+            p["password"] = "plaintext:" + p["password"]
 
         # Import was successful
         os.remove(os.path.join(self.path, ".import_error_contest"))
@@ -245,7 +248,7 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
             return None
 
         load(conf, args, "username")
-        load(conf, args, "password")
+        load(conf, args, "password", conv=lambda p: "plaintext:" + p)
 
         load(conf, args, ["first_name", "nome"])
         load(conf, args, ["last_name", "cognome"])

--- a/cmscontrib/loaders/polygon.py
+++ b/cmscontrib/loaders/polygon.py
@@ -37,6 +37,7 @@ import xml.etree.ElementTree as ET
 from cms import config
 from cms.db import Contest, User, Task, Statement, \
     SubmissionFormatElement, Dataset, Manager, Testcase
+from cmscommon.crypto import build_password
 from cmscontrib import touch
 
 from .base_loader import ContestLoader, TaskLoader, UserLoader
@@ -322,7 +323,7 @@ class PolygonUserLoader(UserLoader):
             logger.info("Loading parameters for user %s.", username)
             args = {}
             args['username'] = userdata[0]
-            args['password'] = "plaintext:" + userdata[1]
+            args['password'] = build_password(userdata[1])
             args['first_name'] = userdata[2]
             args['last_name'] = userdata[3]
             args['hidden'] = (len(userdata) > 4 and userdata[4] == '1')
@@ -447,7 +448,7 @@ class PolygonContestLoader(ContestLoader):
                     user = user.split(';')
                     participations.append({
                         "username": user[0].strip(),
-                        "password": "plaintext:" + user[1].strip(),
+                        "password": build_password(user[1].strip()),
                         "hidden": user[4].strip()
                         # "ip" is not passed
                     })

--- a/cmscontrib/loaders/polygon.py
+++ b/cmscontrib/loaders/polygon.py
@@ -4,6 +4,7 @@
 # Programming contest management system
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014-2017 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2018 Edoardo Morassutto <edoardo.morassutto@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -321,7 +322,7 @@ class PolygonUserLoader(UserLoader):
             logger.info("Loading parameters for user %s.", username)
             args = {}
             args['username'] = userdata[0]
-            args['password'] = userdata[1]
+            args['password'] = "plaintext:" + userdata[1]
             args['first_name'] = userdata[2]
             args['last_name'] = userdata[3]
             args['hidden'] = (len(userdata) > 4 and userdata[4] == '1')
@@ -446,7 +447,7 @@ class PolygonContestLoader(ContestLoader):
                     user = user.split(';')
                     participations.append({
                         "username": user[0].strip(),
-                        "password": user[1].strip(),
+                        "password": "plaintext:" + user[1].strip(),
                         "hidden": user[4].strip()
                         # "ip" is not passed
                     })


### PR DESCRIPTION
The new format of stored passwords (after eaee3a8) requires that in the DB the password is a 2 part string separated by ':'. Before this patch when an old contest (like [cms-dev/con_test](https://github.com/cms-dev/con_test/blob/caa33415d4858a3df11d3b228964c0053ef3b3da/contest.yaml#L15)) is imported the passwords in the db were corrupted (the "method" is not specified) and cmsContestWebServer will fire 500 errors on login.

I fixed the loaders prepending "plaintext:" to the passwords of the users and participations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/817)
<!-- Reviewable:end -->
