### PR TITLE
HTML fixes

### DIFF
--- a/cms/server/admin/templates/base.html
+++ b/cms/server/admin/templates/base.html
@@ -6,21 +6,21 @@
 {% from cmscommon.datetime import make_timestamp %}
 {% from cmscommon.crypto import get_hex_random_key %}
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="shortcut icon" href="{{ url("static", "favicon.ico") }}" />
     <link rel="stylesheet" type="text/css" href="{{ url("static", "reset.css") }}">
     <link rel="stylesheet" type="text/css" href="{{ url("static", "aws_style.css") }}">
-    <script type="text/javascript" src="{{ url("static", "web_rpc.js") }}"></script>
-    <script type="text/javascript" src="{{ url("static", "aws_utils.js") }}"></script>
-    <script type="text/javascript" src="{{ url("static", "jq", "jquery-1.7.1.min.js") }}"></script>
-    <script type="text/javascript" src="{{ url("static", "jq", "jquery.jqplot.min.js") }}"></script>
-    <script type="text/javascript" src="{{ url("static", "jq", "jqplot.dateAxisRenderer.min.js") }}"></script>
-    <script type="text/javascript" src="{{ url("static", "jq", "jqplot.enhancedLegendRenderer.min.js") }}"></script>
-    <script type="text/javascript" src="{{ url("static", "sh", "shCore.js") }}"></script>
-    <script type="text/javascript" src="{{ url("static", "sh", "shBrushCpp.js") }}"></script>
-    <script type="text/javascript" src="{{ url("static", "sh", "shBrushDelphi.js") }}"></script>
+    <script src="{{ url("static", "web_rpc.js") }}"></script>
+    <script src="{{ url("static", "aws_utils.js") }}"></script>
+    <script src="{{ url("static", "jq", "jquery-1.7.1.min.js") }}"></script>
+    <script src="{{ url("static", "jq", "jquery.jqplot.min.js") }}"></script>
+    <script src="{{ url("static", "jq", "jqplot.dateAxisRenderer.min.js") }}"></script>
+    <script src="{{ url("static", "jq", "jqplot.enhancedLegendRenderer.min.js") }}"></script>
+    <script src="{{ url("static", "sh", "shCore.js") }}"></script>
+    <script src="{{ url("static", "sh", "shBrushCpp.js") }}"></script>
+    <script src="{{ url("static", "sh", "shBrushDelphi.js") }}"></script>
     <link rel="stylesheet" type="text/css" href="{{ url("static", "jq", "jquery.jqplot.min.css") }}"/>
     <link rel="stylesheet" type="text/css" href="{{ url("static", "sh", "shCore.css") }}"/>
     <link rel="stylesheet" type="text/css" href="{{ url("static", "sh", "shThemeDefault.css") }}"/>
@@ -31,7 +31,7 @@
     <title>Admin: {{ contest.description }}</title>
     {% end %}
 
-    <script type="text/javascript">
+    <script>
 <!--
 function init()
 {

--- a/cms/server/admin/templates/error.html
+++ b/cms/server/admin/templates/error.html
@@ -9,5 +9,4 @@
 An error occured while the server was handling your request.
 </p>
 
-</div>
 {% end %}

--- a/cms/server/admin/templates/login.html
+++ b/cms/server/admin/templates/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="shortcut icon" href="{{ url("static", "favicon.ico") }}" />

--- a/cms/server/contest/templates/base.html
+++ b/cms/server/contest/templates/base.html
@@ -10,9 +10,9 @@
         <link rel="stylesheet" href="{{ url("static", "css", "bootstrap.css") }}">
         <link rel="stylesheet" href="{{ url("static", "cws_style.css") }}">
 
-        <script type="text/javascript" src="{{ url("static", "jq", "jquery-1.7.1.min.js") }}"></script>
-        <script type="text/javascript" src="{{ url("static", "js", "bootstrap.js") }}"></script>
-        <script type="text/javascript" src="{{ url("static", "cws_utils.js") }}"></script>
+        <script src="{{ url("static", "jq", "jquery-1.7.1.min.js") }}"></script>
+        <script src="{{ url("static", "js", "bootstrap.js") }}"></script>
+        <script src="{{ url("static", "cws_utils.js") }}"></script>
 
         {% block js %}{% end %}
     </head>

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -16,7 +16,7 @@
 {% from cmscommon.datetime import make_timestamp, utc %}
 {% from cmscommon.isocodes import translate_language_country_code %}
 
-    <script type="text/javascript">
+    <script>
 var LANGUAGES = {
 {% for lang in contest.languages %}
     '{{ lang }}': {
@@ -102,15 +102,15 @@ $(document).ready(function () {
                     {% end %}
                     <fieldset>
                         <div class="control-group">
-                            <label class="control-label" for="input01">{{ _("Username") }}</label>
+                            <label class="control-label" for="username">{{ _("Username") }}</label>
                             <div class="controls">
-                                <input type="text" class="input-xlarge" name="username">
+                                <input type="text" class="input-xlarge" name="username" id="username">
                             </div>
                         </div>
                         <div class="control-group">
-                            <label class="control-label" for="input01">{{ _("Password") }}</label>
+                            <label class="control-label" for="password">{{ _("Password") }}</label>
                             <div class="controls">
-                                <input type="password" class="input-xlarge" name="password">
+                                <input type="password" class="input-xlarge" name="password" id="password">
                             </div>
                         </div>
                         <div class="control-group">

--- a/cms/server/contest/templates/error.html
+++ b/cms/server/contest/templates/error.html
@@ -1,6 +1,8 @@
 {% extends base.html %}
+{% block title %}
+  {{ _("Error %d") % status_code }}
+{% end %}
 {% block body %}
-
 <div class="span9">
 
 <div class="page-header">

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -123,7 +123,7 @@ $(document).ready(function () {
 {% for lang in contest.languages %}
                             <option value="{{ lang }}">{{ lang }}</option>
 {% end %}
-                        <select>
+                        </select>
                     </div>
                 </div>
 {% end %}

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -121,7 +121,7 @@ $(document).ready(function () {
 {% for lang in contest.languages %}
                             <option value="{{ lang }}">{{ lang }}</option>
 {% end %}
-                        <select>
+                        </select>
                     </div>
                 </div>
                 <div class="control-group">


### PR DESCRIPTION
These changes fix more HTML validation errors with https://validator.w3.org/.

`<html lang="en">` is added for AWS because AWS does not send the `Content-Language` HTTP header.

Note that `cms/server/contest/templates/contest.html` was already fixed a year ago in 08ea65064e34c6fc88ca583ec0253b3d00625782, but now changes need to be reapplied. This is because of a merge error from #594. @wil93 should probably check other files that were moved in that issue for similar problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/819)
<!-- Reviewable:end -->
