### PR TITLE
Do not close SQL session if it does not exist

### DIFF
--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -103,7 +103,7 @@ class BaseHandler(CommonRequestHandler):
         that. So far I'm leaving it to minimize changes.
 
         """
-        if hasattr(self, "sql_session"):
+        if hasattr(self, "sql_session") and self.sql_session:
             try:
                 self.sql_session.close()
             except Exception as error:


### PR DESCRIPTION
In the `CommonRequestHandler` class (`cms/server/util.py`) an SQL session set to `None` during initialization and later created during `prepare()`. On the other hand, Tornado checks CSRF cookies just before calling `prepare()`, see `check_xsrf_cookie()` in https://github.com/tornadoweb/tornado/blob/master/tornado/web.py.

If an error occurs during the CSRF check, then the `BaseHandler.finish()` function in `
cms/server/contest/handlers/base.py` will try to close an SQL session that does not exist. This can be fixed with an additional check.

Fixes #811.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/820)
<!-- Reviewable:end -->
