### PR TITLE
Use Python's Abstract Base Classes for our abstract classes

### DIFF
--- a/cms/grading/ScoreType.py
+++ b/cms/grading/ScoreType.py
@@ -37,6 +37,7 @@ from __future__ import unicode_literals
 
 import logging
 import re
+from abc import ABCMeta, abstractmethod
 
 from tornado.template import Template
 
@@ -56,6 +57,9 @@ class ScoreType(object):
     defined here.
 
     """
+
+    __metaclass__ = ABCMeta
+
     TEMPLATE = ""
 
     def __init__(self, parameters, public_testcases):
@@ -117,6 +121,7 @@ class ScoreType(object):
         else:
             return Template(self.TEMPLATE).generate(details=score_details, _=_)
 
+    @abstractmethod
     def max_scores(self):
         """Returns the maximum score that one could aim to in this
         problem. Also return the maximum score from the point of view
@@ -128,9 +133,9 @@ class ScoreType(object):
             score with only public testcases; ranking headers.
 
         """
-        logger.error("Unimplemented method max_scores.")
-        raise NotImplementedError("Please subclass this class.")
+        pass
 
+    @abstractmethod
     def compute_score(self, unused_submission_result):
         """Computes a score of a single submission.
 
@@ -145,8 +150,7 @@ class ScoreType(object):
             did not play a token, the list of strings to send to RWS.
 
         """
-        logger.error("Unimplemented method compute_score.")
-        raise NotImplementedError("Please subclass this class.")
+        pass
 
 
 class ScoreTypeAlone(ScoreType):
@@ -395,6 +399,7 @@ class ScoreTypeGroup(ScoreTypeAlone):
 
         return score, subtasks, public_score, public_subtasks, ranking_details
 
+    @abstractmethod
     def get_public_outcome(self, unused_outcome, unused_parameter):
         """Return a public outcome from an outcome.
 
@@ -410,9 +415,9 @@ class ScoreTypeGroup(ScoreTypeAlone):
         return (float): the public output.
 
         """
-        logger.error("Unimplemented method get_public_outcome.")
-        raise NotImplementedError("Please subclass this class.")
+        pass
 
+    @abstractmethod
     def reduce(self, unused_outcomes, unused_parameter):
         """Return the score of a subtask given the outcomes.
 
@@ -423,5 +428,4 @@ class ScoreTypeGroup(ScoreTypeAlone):
         return (float): the public output.
 
         """
-        logger.error("Unimplemented method reduce.")
-        raise NotImplementedError("Please subclass this class.")
+        pass

--- a/cms/grading/TaskType.py
+++ b/cms/grading/TaskType.py
@@ -36,6 +36,7 @@ from __future__ import unicode_literals
 
 import logging
 import re
+from abc import ABCMeta, abstractmethod
 
 from cms import config
 from cms.grading import JobException
@@ -104,6 +105,9 @@ class TaskType(object):
       operations; must be overloaded.
 
     """
+
+    __metaclass__ = ABCMeta
+
     # If ALLOW_PARTIAL_SUBMISSION is True, then we allow the user to
     # submit only some of the required files; moreover, we try to fill
     # the non-provided files with the one in the previous submission.
@@ -163,6 +167,7 @@ class TaskType(object):
 
     testable = True
 
+    @abstractmethod
     def get_compilation_commands(self, submission_format):
         """Return the compilation commands for all supported languages
 
@@ -180,8 +185,9 @@ class TaskType(object):
             is required (e.g. output only).
 
         """
-        raise NotImplementedError("Please subclass this class.")
+        pass
 
+    @abstractmethod
     def get_user_managers(self):
         """Return the managers that must be provided by the user when
         requesting a user test.
@@ -190,8 +196,9 @@ class TaskType(object):
                               '%l' as a "language wildcard").
 
         """
-        raise NotImplementedError("Please subclass this class.")
+        pass
 
+    @abstractmethod
     def get_auto_managers(self):
         """Return the managers that must be provided by the
         EvaluationService (picking them from the Task) when compiling
@@ -201,8 +208,9 @@ class TaskType(object):
                              '%l' as a "language wildcard").
 
         """
-        raise NotImplementedError("Please subclass this class.")
+        pass
 
+    @abstractmethod
     def compile(self, job, file_cacher):
         """Try to compile the given CompilationJob.
 
@@ -220,8 +228,9 @@ class TaskType(object):
                                   that are produced.
 
         """
-        raise NotImplementedError("Please subclass this class.")
+        pass
 
+    @abstractmethod
     def evaluate(self, job, file_cacher):
         """Try to evaluate the given EvaluationJob.
 
@@ -239,7 +248,7 @@ class TaskType(object):
                                   that are produced.
 
         """
-        raise NotImplementedError("Please subclass this class.")
+        pass
 
     def execute_job(self, job, file_cacher):
         """Call compile() or execute() depending on the job passed

--- a/cms/grading/language.py
+++ b/cms/grading/language.py
@@ -25,6 +25,7 @@ from __future__ import unicode_literals
 
 import logging
 import os
+from abc import ABCMeta, abstractmethod
 
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,10 @@ logger = logging.getLogger(__name__)
 class Language(object):
     """A supported programming language"""
 
+    __metaclass__ = ABCMeta
+
     @property
+    @abstractmethod
     def name(self):
         """Returns the name of the language.
 
@@ -44,7 +48,7 @@ class Language(object):
         return (str): the name
 
         """
-        raise NotImplementedError("Please subclass this class.")
+        pass
 
     @property
     def source_extensions(self):
@@ -101,6 +105,7 @@ class Language(object):
         return self.object_extensions[0] \
             if len(self.object_extensions) > 0 else None
 
+    @abstractmethod
     def get_compilation_commands(self,
                                  source_filenames, executable_filename,
                                  for_evaluation=True):
@@ -124,8 +129,9 @@ class Language(object):
             strings to be passed to subprocess.
 
         """
-        raise NotImplementedError("Please subclass this class.")
+        pass
 
+    @abstractmethod
     def get_evaluation_commands(
             self, executable_filename, main=None, args=None):
         """Return the evaluation commands.
@@ -140,7 +146,7 @@ class Language(object):
             strings to be passed to subprocess.
 
         """
-        raise NotImplementedError("Please subclass this class.")
+        pass
 
 
 class CompiledLanguage(Language):

--- a/cmscontrib/loaders/base_loader.py
+++ b/cmscontrib/loaders/base_loader.py
@@ -22,6 +22,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from abc import ABCMeta, abstractmethod
+
 
 class BaseLoader(object):
     """Base class for deriving loaders.
@@ -32,6 +34,8 @@ class BaseLoader(object):
       * The class method detect() can be called at any time.
 
     """
+
+    __metaclass__ = ABCMeta
 
     # Short name of this loader, meant to be a unique identifier.
     short_name = None
@@ -52,6 +56,7 @@ class BaseLoader(object):
         self.file_cacher = file_cacher
 
     @staticmethod
+    @abstractmethod
     def detect(path):
         """Detect whether this loader is able to interpret a path.
 
@@ -64,10 +69,11 @@ class BaseLoader(object):
                        given path.
 
         """
-        raise NotImplementedError("Please extend Loader")
+        pass
 
+    @abstractmethod
     def get_task_loader(self, taskname):
-        raise NotImplementedError("Please extend Loader")
+        pass
 
 
 class TaskLoader(BaseLoader):
@@ -86,6 +92,7 @@ class TaskLoader(BaseLoader):
     def __init__(self, path, file_cacher):
         super(TaskLoader, self).__init__(path, file_cacher)
 
+    @abstractmethod
     def get_task(self, get_statement):
         """Produce a Task object.
 
@@ -94,8 +101,9 @@ class TaskLoader(BaseLoader):
         return (Task): the Task object.
 
         """
-        raise NotImplementedError("Please extend TaskLoader")
+        pass
 
+    @abstractmethod
     def task_has_changed(self):
         """Detect if the task has been changed since its last import.
 
@@ -113,7 +121,7 @@ class TaskLoader(BaseLoader):
         return (bool): True if the task was changed, False otherwise.
 
         """
-        raise NotImplementedError("Please extend TaskLoader")
+        pass
 
 
 class UserLoader(BaseLoader):
@@ -132,14 +140,16 @@ class UserLoader(BaseLoader):
     def __init__(self, path, file_cacher):
         super(UserLoader, self).__init__(path, file_cacher)
 
+    @abstractmethod
     def get_user(self):
         """Produce a User object.
 
         return (User): the User object.
 
         """
-        raise NotImplementedError("Please extend UserLoader")
+        pass
 
+    @abstractmethod
     def user_has_changed(self):
         """Detect if the user has been changed since its last import.
 
@@ -157,7 +167,7 @@ class UserLoader(BaseLoader):
         return (bool): True if the user was changed, False otherwise.
 
         """
-        raise NotImplementedError("Please extend UserLoader")
+        pass
 
 
 class TeamLoader(BaseLoader):
@@ -176,14 +186,16 @@ class TeamLoader(BaseLoader):
     def __init__(self, path, file_cacher):
         super(TeamLoader, self).__init__(path, file_cacher)
 
+    @abstractmethod
     def get_team(self):
         """Produce a Team object.
 
         return (Team): the Team object.
 
         """
-        raise NotImplementedError("Please extend TeamLoader")
+        pass
 
+    @abstractmethod
     def team_has_changed(self):
         """Detect if the team has been changed since its last import.
 
@@ -201,7 +213,7 @@ class TeamLoader(BaseLoader):
         return (bool): True if the team was changed, False otherwise.
 
         """
-        raise NotImplementedError("Please extend TeamLoader")
+        pass
 
 
 class ContestLoader(BaseLoader):
@@ -220,6 +232,7 @@ class ContestLoader(BaseLoader):
     def __init__(self, path, file_cacher):
         super(ContestLoader, self).__init__(path, file_cacher)
 
+    @abstractmethod
     def get_contest(self):
         """Produce a Contest object.
 
@@ -235,8 +248,9 @@ class ContestLoader(BaseLoader):
                         above.
 
         """
-        raise NotImplementedError("Please extend ContestLoader")
+        pass
 
+    @abstractmethod
     def contest_has_changed(self):
         """Detect if the contest has been changed since its last import.
 
@@ -254,4 +268,4 @@ class ContestLoader(BaseLoader):
         return (bool): True if the contset was changed, False otherwise.
 
         """
-        raise NotImplementedError("Please extend ContestLoader")
+        pass


### PR DESCRIPTION
Rather than raising NotImplemented in abstract methods decorate them
with @abstractmethod. Abstract classes, which are those that have at
least one @abstractmethod, cannot be instantiated. This is more robust.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/823)
<!-- Reviewable:end -->
