### PR TITLE
Fixed performance issue reevaluating a dataset

### DIFF
--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -888,6 +888,10 @@ class EvaluationService(TriggeredService):
             contest_id = self.contest_id
 
         with SessionGen() as session:
+            # When invalidating a dataset we need to know the task_id, otherwise
+            # get_submissions will return all the submissions of the contest.
+            if dataset_id is not None and task_id is None:
+                task_id = Dataset.get_from_id(dataset_id, session).task_id
             # First we load all involved submissions.
             submissions = get_submissions(
                 # Give contest_id only if all others are None.
@@ -921,7 +925,11 @@ class EvaluationService(TriggeredService):
                     submission_id,
                     dataset_id} == {None}
                 else None,
-                participation_id, task_id, submission_id, dataset_id, session)
+                participation_id,
+                # Provide the task_id only if the entire task has to be
+                # reevaluated and not only a specific dataset.
+                task_id if dataset_id is None else None,
+                submission_id, dataset_id, session)
             logger.info("Submission results to invalidate %s for: %d.",
                         level, len(submission_results))
             for submission_result in submission_results:


### PR DESCRIPTION
When reevaluating a dataset all the evaluations of the contest are pulled by `get_submissions` and then most of them are discarded. This is caused because `get_submissions` knows anything about datasets and the `task_id` is not passed.

When a request of reevaluation of a dataset is made, the task_id is pulled from the db and passed to `get_evaluation` to filter only the _interesting_ submissions.

Since #662 the submissions in the db have grown to over 230k and ES freezes when a reevaluation is requested even for a dataset with few submissions.

Fixes #662

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/828)
<!-- Reviewable:end -->
