### PR TITLE
Refactor methods to update SQLAlchemy objects

### DIFF
--- a/cmscontrib/ImportContest.py
+++ b/cmscontrib/ImportContest.py
@@ -106,7 +106,7 @@ class ContestImporter(BaseImporter):
             if old_contest is not None:
                 if self.update_contest:
                     if contest_has_changed:
-                        self._update_object(old_contest, contest)
+                        BaseImporter._update_contest(old_contest, contest)
                     contest = old_contest
                 elif self.update_tasks:
                     contest = old_contest
@@ -140,12 +140,9 @@ class ContestImporter(BaseImporter):
                         new_task = task_loader.get_task(
                             get_statement=not self.no_statements)
                         if new_task:
-                            ignore = set(("num",))
-                            if self.no_statements:
-                                ignore.update(("primary_statements",
-                                               "statements"))
-                            self._update_object(task, new_task,
-                                                ignore=ignore)
+                            BaseImporter._update_task(
+                                task, new_task,
+                                get_statements=not self.no_statements)
                         else:
                             logger.critical("Could not reimport task \"%s\".",
                                             taskname)

--- a/cmscontrib/ImportTask.py
+++ b/cmscontrib/ImportTask.py
@@ -115,11 +115,9 @@ class TaskImporter(BaseImporter):
             if old_task is not None:
                 if self.update:
                     if task_has_changed:
-                        ignore = set(("num",))
-                        if self.no_statement:
-                            ignore.update(("primary_statements",
-                                           "statements"))
-                        self._update_object(old_task, task, ignore)
+                        BaseImporter._update_task(
+                            old_task, task,
+                            get_statements=not self.no_statement)
                     task = old_task
                 else:
                     logger.critical("Task \"%s\" already exists in database.",

--- a/cmscontrib/__init__.py
+++ b/cmscontrib/__init__.py
@@ -34,12 +34,13 @@ from future.builtins.disabled import *
 from future.builtins import *
 from six import iterkeys
 
+import functools
 import hashlib
 import io
 import os
 
 from cmscommon.binary import bin_to_hex
-from cms.db import Base, Contest, Participation, Submission, Task
+from cms.db import Contest, Dataset, Task
 
 
 def sha1sum(path):
@@ -74,151 +75,238 @@ def touch(path):
         os.utime(path, None)
 
 
-def _is_rel(prp, attr):
-    # The target of the relationship is in prp.mapper.class_
-    return prp.parent.class_ == attr.class_ and prp.key == attr.key
-
-
 class BaseImporter(object):
+    # TODO: move these methods to be some module's functions.
 
-    def _update_columns(self, old_object, new_object, ignore=None):
-        ignore = ignore if ignore is not None else set()
+    @staticmethod
+    def _update_columns(old_object, new_object, spec=None):
+        """Update the scalar columns of the object
+
+        Update all non-relationship columns of old_object with the values in
+        new_object, unless spec[attribute] is False.
+
+        """
+        assert type(old_object) == type(new_object)
+        spec = spec if spec is not None else {}
+
         for prp in old_object._col_props:
-            if prp.key in ignore:
+            if spec.get(prp.class_attribute, True) is False:
                 continue
             if hasattr(new_object, prp.key):
                 setattr(old_object, prp.key, getattr(new_object, prp.key))
 
-    def _update_object(self, old_object, new_object, ignore=None):
-        # This method copies the scalar column properties from the new
-        # object into the old one, and then tries to do the same for
-        # relationships too. The data model isn't a tree: for example
-        # there are two distinct paths from Contest to Submission, one
-        # through User and one through Task. Yet, at the moment, if we
-        # ignore Submissions and UserTest (and thus their results, too)
-        # we get a tree-like structure and Task.active_dataset and
-        # Submission.token are the only scalar relationships that don't
-        # refer to the parent. Therefore, if we catch these as special
-        # cases, we can use a simple DFS to explore the whole data
-        # graph, recursing only on "vector" relationships.
-        # TODO Find a better way to handle all of this.
+    @staticmethod
+    def _update_object(old_object, new_object, spec=None, parent=None):
+        """Update old_object with the values in new_object
 
-        ignore = ignore if ignore is not None else set()
-        self._update_columns(old_object, new_object, ignore)
+        Update all columns with this strategy:
+        - for non-relationship columns, use _update_columns (in particular, all
+          columns are updated by default, unless spec[attribute] is false);
+        - for relationship columns:
+          - if the name is equal to parent, then it is ignored;
+          - otherwise, it needs to be defined in spec; if spec is False, the
+            column is ignored; if it is True, it is updated with the default
+            strategy (see _update_list and _update_dict); otherwise if spec is
+            a function, that function is used to update.
+
+        old_object (Base): object to update.
+        new_object (Base): object whose values will be used.
+        spec (
+            {sqlalchemy.orm.attributes.InstrumentedAttribute: boolean|function}
+            |None): a dictionary mapping attributes to a boolean (if not
+            updating or using the default strategy) or to an updating function,
+            with signature fn(old_value, new_value, parent=None).
+        parent (string|None): the name of the relationship in the parent
+            object, which is ignored.
+
+        """
+        assert type(old_object) == type(new_object)
+        spec = spec if spec is not None else {}
+
+        # Update all scalar columns by default, unless spec says otherwise.
+        BaseImporter._update_columns(old_object, new_object, spec)
 
         for prp in old_object._rel_props:
-            if prp.key in ignore:
+            # Don't update the parent relationship.
+            if prp.backref is not None and parent is not None \
+                    and prp.backref[0] == parent:
+                continue
+
+            # To avoid bugs when new relationships are introduced, we force the
+            # caller to describe how to update all other relationships.
+            assert prp.class_attribute in spec, (
+                "Programming error: update specification not complete, "
+                "missing relationship for %s.%s"
+                % (prp.parent.class_, prp.class_attribute))
+
+            # Spec is false, it means we should not update this relationship.
+            if spec[prp.class_attribute] is False:
                 continue
 
             old_value = getattr(old_object, prp.key)
             new_value = getattr(new_object, prp.key)
-
-            # Special case #1: Contest.announcements, User.questions,
-            #                  User.messages
-            if _is_rel(prp, Contest.announcements):
-                # A loader should not provide new Announcements,
-                # Questions or Messages, since they are data generated
-                # by the users during the contest: don't update them.
-                # TODO Warn the admin if these attributes are non-empty
-                # collections.
-                pass
-
-            # Special case #2: Task.datasets
-            elif _is_rel(prp, Task.datasets):
-                old_datasets = dict((d.description, d) for d in old_value)
-                new_datasets = dict((d.description, d) for d in new_value)
-
-                for key in iterkeys(new_datasets):
-                    if key not in old_datasets:
-                        # create
-                        temp = new_datasets[key]
-                        new_value.remove(temp)
-                        old_value.append(temp)
-                    else:
-                        # update
-                        self._update_object(old_datasets[key],
-                                            new_datasets[key])
-
-            # Special case #3: Task.active_dataset
-            elif _is_rel(prp, Task.active_dataset):
-                # We don't want to update the existing active dataset.
-                pass
-
-            # Special case #4: User.submissions, Task.submissions,
-            #                 User.user_tests, Task.user_tests
-            elif (_is_rel(prp, Task.submissions) or
-                  _is_rel(prp, Participation.submissions) or
-                  _is_rel(prp, Task.user_tests) or
-                  _is_rel(prp, Participation.user_tests)):
-                # A loader should not provide new Submissions or
-                # UserTests, since they are data generated by the users
-                # during the contest: don't update them.
-                # TODO Warn the admin if these attributes are non-empty
-                # collections.
-                pass
-
-            # Special case #5: Submission.token
-            elif _is_rel(prp, Submission.token):
-                # We should never reach this point! We should never try
-                # to update Submissions! We could even assert False...
-                pass
-
-            # General case #1: a dict
-            elif isinstance(old_value, dict):
-                for key in set(iterkeys(old_value)) | set(iterkeys(new_value)):
-                    if key in new_value:
-                        if key not in old_value:
-                            # create
-                            # FIXME This hack is needed because of some
-                            # funny behavior of SQLAlchemy-instrumented
-                            # collections when copying values, that
-                            # resulted in new objects being added to
-                            # the session. We need to investigate it.
-                            temp = new_value[key]
-                            del new_value[key]
-                            old_value[key] = temp
-                        else:
-                            # update
-                            self._update_object(old_value[key], new_value[key])
-                    else:
-                        # delete
-                        del old_value[key]
-
-            # General case #2: a list
-            elif isinstance(old_value, list):
-                old_len = len(old_value)
-                new_len = len(new_value)
-                for i in range(min(old_len, new_len)):
-                    self._update_object(old_value[i], new_value[i])
-                if old_len > new_len:
-                    del old_value[new_len:]
-                elif new_len > old_len:
-                    for i in range(old_len, new_len):
-                        # FIXME This hack is needed because of some
-                        # funny behavior of SQLAlchemy-instrumented
-                        # collections when copying values, that
-                        # resulted in new objects being added to the
-                        # session. We need to investigate it.
-                        temp = new_value[i]
-                        del new_value[i]
-                        old_value.append(temp)
-
-            # General case #3: a parent object
-            elif isinstance(old_value, Base):
-                # No need to climb back up the recursion tree...
-                pass
-
-            # General case #4: None
-            elif old_value is None:
-                # That should only happen in case of a scalar
-                # relationship (i.e. a many-to-one or a one-to-one)
-                # that is nullable. "Parent" relationships aren't
-                # nullable, so the only possible cases are the active
-                # datasets and the tokens, but we should have already
-                # caught them. We could even assert False...
-                pass
-
+            if spec[prp.class_attribute] is True:
+                # Spec is true, it means we update the relationship with the
+                # default update method (for lists or dicts). Note that the
+                # values cannot have other relationships than the parent's,
+                # otherwise _update_object will complain it doesn't have the
+                # spec for them.
+                update_fn = functools.partial(
+                    BaseImporter._update_object, parent=prp.key)
+                if isinstance(old_value, dict):
+                    BaseImporter._update_dict(old_value, new_value, update_fn)
+                elif isinstance(old_value, list):
+                    BaseImporter._update_list(old_value, new_value, update_fn)
+                else:
+                    raise AssertionError(
+                        "Programming error: unknown type of relationship for "
+                        "%s.%s." % (prp.parent.class_, prp.class_attribute))
             else:
-                raise RuntimeError(
-                    "Unknown type of relationship for %s.%s." %
-                    (prp.parent.class_.__name__, prp.key))
+                # Spec is not true, then it must be an update function, which
+                # we duly apply.
+                spec[prp.class_attribute](old_value, new_value, parent=prp.key)
+
+    @staticmethod
+    def _update_list(old_list, new_list, update_value_fn=None):
+        """Update a SQLAlchemy relationship with type list
+
+        Make old_list look like new_list, by:
+        - up to the minimum length, calling update_value_fn on each element, to
+          overwrite the values;
+        - deleting additional entries in old_list, if they exist;
+        - moving additional entries in new_list, if they exist.
+
+        """
+        if update_value_fn is None:
+            update_value_fn = BaseImporter._update_object
+
+        old_len = len(old_list)
+        new_len = len(new_list)
+
+        # Update common elements.
+        for old_value, new_value in zip(old_list, new_list):
+            update_value_fn(old_value, new_value)
+
+        # Delete additional elements of old_list.
+        del old_list[new_len:]
+
+        # Move additional elements from new_list to old_list.
+        for _ in range(old_len, new_len):
+            # For some funny behavior of SQLAlchemy-instrumented
+            # collections when copying values, that resulted in new objects
+            # being added to the session.
+            temp = new_list[old_len]
+            del new_list[old_len]
+            old_list.append(temp)
+
+    @staticmethod
+    def _update_dict(old_dict, new_dict, update_value_fn=None):
+        """Update a SQLAlchemy relationship with type dict
+
+        Make old_dict look like new_dict, by:
+        - calling update_value_fn to overwrite the values of old_dict with a
+          corresponding value in new_dict;
+        - deleting all entries in old_dict whose key is not in new_dict;
+        - moving all entries in new_dict whose key is not in old_dict.
+
+        """
+        if update_value_fn is None:
+            update_value_fn = BaseImporter._update_object
+        for key in set(iterkeys(old_dict)) | set(iterkeys(new_dict)):
+            if key in new_dict:
+                if key not in old_dict:
+                    # Move the object from new_dict to old_dict. For some funny
+                    # behavior of SQLAlchemy-instrumented collections when
+                    # copying values, that resulted in new objects being added
+                    # to the session.
+                    temp = new_dict[key]
+                    del new_dict[key]
+                    old_dict[key] = temp
+                else:
+                    # Update the old value with the new value.
+                    update_value_fn(old_dict[key], new_dict[key])
+            else:
+                # Delete the old value if no new value for that key.
+                del old_dict[key]
+
+    @staticmethod
+    def _update_list_with_key(old_list, new_list, key,
+                              preserve_old=False, update_value_fn=None):
+        """Update a SQLAlchemy list-relationship, using key for identity
+
+        Make old_list look like new_list, in a similar way to _update_dict, as
+        if the list was a dictionary with key computed using the key function.
+
+        If preserve_old is true, elements in old_list with a key not present in
+        new_list will be preserved.
+
+        """
+        if update_value_fn is None:
+            update_value_fn = BaseImporter._update_object
+
+        old_dict = dict((key(v), v) for v in old_list)
+        new_dict = dict((key(v), v) for v in new_list)
+
+        for k in set(iterkeys(old_dict)) | set(iterkeys(new_dict)):
+            if k in new_dict:
+                if k not in old_dict:
+                    # Add new value to the old dictionary.
+                    temp = new_dict[k]
+                    new_list.remove(temp)
+                    old_list.append(temp)
+                else:
+                    # Update the value in old_dict with the new value.
+                    update_value_fn(old_dict[k], new_dict[k])
+            elif not preserve_old:
+                # Remove the old value not anymore present.
+                old_list.remove(old_dict[k])
+
+    @staticmethod
+    def _update_dataset(old_dataset, new_dataset, parent=None):
+        """Update old_dataset with information from new_dataset"""
+        BaseImporter._update_object(old_dataset, new_dataset, {
+            # Since we know it, hardcode to ignore the parent relationship.
+            Dataset.task: False,
+            # Relationships to update (all others).
+            Dataset.managers: True,
+            Dataset.testcases: True,
+        }, parent=parent)
+
+    @staticmethod
+    def _update_task(old_task, new_task, parent=None, get_statements=True):
+        """Update old_task with information from new_task"""
+        def update_datasets_fn(o, n, parent=None):
+            BaseImporter._update_list_with_key(
+                o, n, key=lambda d: d.description, preserve_old=True,
+                update_value_fn=functools.partial(
+                    BaseImporter._update_dataset, parent=parent))
+
+        BaseImporter._update_object(old_task, new_task, {
+            # Since we know it, hardcode to ignore the parent relationship.
+            Task.contest: False,
+            # Relationships not to update because not provided by the loader.
+            Task.active_dataset: False,
+            Task.submissions: False,
+            Task.user_tests: False,
+            # Relationships to update.
+            Task.statements: get_statements,
+            Task.submission_format: True,
+            Task.datasets: update_datasets_fn,
+            Task.attachments: True,
+            # Scalar columns exceptions.
+            Task.num: False,
+            Task.primary_statements: get_statements,
+        }, parent=parent)
+
+    @staticmethod
+    def _update_contest(old_contest, new_contest, parent=None):
+        """Update old_contest with information from new_contest"""
+        BaseImporter._update_object(old_contest, new_contest, {
+            # Announcements are not provided by the loader, we should keep
+            # those we have.
+            Contest.announcements: False,
+            # Tasks and participations are top level objects for the loader, so
+            # must be handled differently.
+            Contest.tasks: False,
+            Contest.participations: False,
+        }, parent=parent)


### PR DESCRIPTION
This was done to remove bugs and make them more resilient to changes
in the schema.

Bugs:
- when importing contests, participations were always deleted and
  rebuilt, losing thus the objects associated to them (submissions,
  questions, ...) (fixes #775);
- when importing new data for list relationship with longer length,
  the importer crashed.

The new method is more resilient because forces the caller to specify
what to do with each relationship, instead of using some default
update logic which might be wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/835)
<!-- Reviewable:end -->
