### PR TITLE
Use Babel tools to handle message catalogs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ addons:
       - fp-units-math
       - fp-units-rtl
       - postgresql-client
-      - gettext
       - python2.7
       - iso-codes
       - shared-mime-info

--- a/babel_mapping.cfg
+++ b/babel_mapping.cfg
@@ -1,0 +1,8 @@
+# Tell Babel which files to inspect to extract messages, and which extractor to use.
+[python: grading/*.py]
+[python: grading/*/*.py]
+[python: server/*.py]
+[python: server/contest/*.py]
+[python: server/contest/handlers/*.py]
+# There is no extractor for Tornado templates... :(
+#[tornado: server/contest/templates/*.html]

--- a/cms/server/contest/formatting.py
+++ b/cms/server/contest/formatting.py
@@ -39,7 +39,11 @@ from cms.locale import locale_format
 
 
 # Dummy function to mark strings for translation
-def N_(*unused_args, **unused_kwargs):
+def N_(msgid):
+    pass
+
+
+def Nn_(msgid1, msgid2, c):
     pass
 
 
@@ -48,10 +52,10 @@ N_("loading...")
 N_("unknown")
 
 # Other messages used in this file.
-N_("%d second", "%d seconds", 0)
-N_("%d minute", "%d minutes", 0)
-N_("%d hour", "%d hours", 0)
-N_("%d day", "%d days", 0)
+Nn_("%d second", "%d seconds", 0)
+Nn_("%d minute", "%d minutes", 0)
+Nn_("%d hour", "%d hours", 0)
+Nn_("%d day", "%d days", 0)
 
 
 def format_datetime(dt, timezone, locale=None):
@@ -144,9 +148,10 @@ def format_amount_of_time(seconds, precision=2, locale=None):
         locale = tornado.locale.get()
 
     _ = locale.translate
+    n_ = locale.translate
 
     if seconds == 0:
-        return _("%d second", "%d seconds", 0) % 0
+        return n_("%d second", "%d seconds", 0) % 0
 
     units = [(("%d day", "%d days"), 60 * 60 * 24),
              (("%d hour", "%d hours"), 60 * 60),
@@ -227,6 +232,7 @@ def format_token_rules(tokens, t_type=None, locale=None):
         locale = tornado.locale.get()
 
     _ = locale.translate
+    n_ = locale.translate
 
     if t_type == "contest":
         tokens["type_s"] = _("contest-token")
@@ -258,51 +264,51 @@ def format_token_rules(tokens, t_type=None, locale=None):
         if tokens['gen_initial'] == 0:
             result += _("You start with no %(type_pl)s.") % tokens
         else:
-            result += _("You start with one %(type_s)s.",
-                        "You start with %(gen_initial)d %(type_pl)s.",
-                        tokens['gen_initial'] == 1) % tokens
+            result += n_("You start with one %(type_s)s.",
+                         "You start with %(gen_initial)d %(type_pl)s.",
+                         tokens['gen_initial'] == 1) % tokens
 
         result += " "
 
         if tokens['gen_number'] > 0:
-            result += _("Every minute ",
-                        "Every %(gen_interval)g minutes ",
-                        tokens['gen_interval']) % tokens
+            result += n_("Every minute ",
+                         "Every %(gen_interval)g minutes ",
+                         tokens['gen_interval']) % tokens
             if tokens['gen_max'] is not None:
-                result += _("you get another %(type_s)s, ",
-                            "you get %(gen_number)d other %(type_pl)s, ",
-                            tokens['gen_number']) % tokens
-                result += _("up to a maximum of one %(type_s)s.",
-                            "up to a maximum of %(gen_max)d %(type_pl)s.",
-                            tokens['gen_max']) % tokens
+                result += n_("you get another %(type_s)s, ",
+                             "you get %(gen_number)d other %(type_pl)s, ",
+                             tokens['gen_number']) % tokens
+                result += n_("up to a maximum of one %(type_s)s.",
+                             "up to a maximum of %(gen_max)d %(type_pl)s.",
+                             tokens['gen_max']) % tokens
             else:
-                result += _("you get another %(type_s)s.",
-                            "you get %(gen_number)d other %(type_pl)s.",
-                            tokens['gen_number']) % tokens
+                result += n_("you get another %(type_s)s.",
+                             "you get %(gen_number)d other %(type_pl)s.",
+                             tokens['gen_number']) % tokens
         else:
             result += _("You don't get other %(type_pl)s.") % tokens
 
         result += " "
 
         if tokens['min_interval'] > 0 and tokens['max_number'] is not None:
-            result += _("You can use a %(type_s)s every second ",
-                        "You can use a %(type_s)s every %(min_interval)g "
-                        "seconds ",
-                        tokens['min_interval']) % tokens
-            result += _("and no more than one %(type_s)s in total.",
-                        "and no more than %(max_number)d %(type_pl)s in "
-                        "total.",
-                        tokens['max_number']) % tokens
+            result += n_("You can use a %(type_s)s every second ",
+                         "You can use a %(type_s)s every %(min_interval)g "
+                         "seconds ",
+                         tokens['min_interval']) % tokens
+            result += n_("and no more than one %(type_s)s in total.",
+                         "and no more than %(max_number)d %(type_pl)s in "
+                         "total.",
+                         tokens['max_number']) % tokens
         elif tokens['min_interval'] > 0:
-            result += _("You can use a %(type_s)s every second.",
-                        "You can use a %(type_s)s every %(min_interval)g "
-                        "seconds.",
-                        tokens['min_interval']) % tokens
+            result += n_("You can use a %(type_s)s every second.",
+                         "You can use a %(type_s)s every %(min_interval)g "
+                         "seconds.",
+                         tokens['min_interval']) % tokens
         elif tokens['max_number'] is not None:
-            result += _("You can use no more than one %(type_s)s in total.",
-                        "You can use no more than %(max_number)d %(type_pl)s "
-                        "in total.",
-                        tokens['max_number']) % tokens
+            result += n_("You can use no more than one %(type_s)s in total.",
+                         "You can use no more than %(max_number)d %(type_pl)s "
+                         "in total.",
+                         tokens['max_number']) % tokens
         else:
             result += \
                 _("You have no limitations on how you use them.") % tokens

--- a/cms/server/contest/formatting.py
+++ b/cms/server/contest/formatting.py
@@ -38,7 +38,8 @@ from cmscommon.datetime import make_datetime, utc
 from cms.locale import locale_format
 
 
-# Dummy function to mark strings for translation
+# Dummy functions to mark strings for translation: N_ is a dummy for
+# gettext/_ and Nn_ is a dummy for ngettext/n_ (for plural forms).
 def N_(msgid):
     pass
 

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -16,8 +16,6 @@ These are our requirements (in particular we highlight those that are not usuall
 
 * `GNU compiler collection <https://gcc.gnu.org/>`_ (in particular the C compiler ``gcc``);
 
-* `gettext <http://www.gnu.org/software/gettext/>`_ >= 0.18;
-
 * `Python <http://www.python.org/>`_ 2.7 or 3.6;
 
 * `libcg <http://libcg.sourceforge.net/>`_;
@@ -62,7 +60,7 @@ On Ubuntu 16.04, one will need to run the following script to satisfy all depend
     # Feel free to change OpenJDK packages with your preferred JDK.
     sudo apt-get install build-essential openjdk-8-jre openjdk-8-jdk \
         fp-compiler fp-units-base fp-units-fcl fp-units-misc fp-units-math fp-units-rtl \
-        postgresql postgresql-client gettext python3.6 \
+        postgresql postgresql-client python3.6 \
         iso-codes shared-mime-info stl-manual cgroup-lite libcap-dev
 
     # Only if you are going to use pip/virtualenv to install python dependencies
@@ -212,7 +210,7 @@ To install CMS and its Python dependencies on Ubuntu, you can issue:
          python3-sqlalchemy python3-psutil python3-netifaces python3-crypto \
          python3-tz python3-six python3-bs4 python3-coverage python3-mock \
          python3-requests python3-werkzeug python3-gevent python3-bcrypt \
-         python3-chardet patool python3-ipaddress
+         python3-chardet patool python3-ipaddress python3-babel
 
     # Optional.
     # sudo apt-get install python3-yaml python3-sphinx python3-cups python3-pypdf2
@@ -234,7 +232,7 @@ To install CMS python dependencies on Arch Linux (again: assuming you did not us
          python-sqlalchemy python-psutil python-netifaces python-crypto \
          python-pytz python-six python-beautifulsoup4 python-coverage \
          python-mock python-requests python-werkzeug python-gevent \
-         python-bcrypt python-chardet python-ipaddress
+         python-bcrypt python-chardet python-ipaddress python-babel
 
     # Install the following from AUR.
     # https://aur.archlinux.org/packages/patool/

--- a/docs/Localization.rst
+++ b/docs/Localization.rst
@@ -12,7 +12,7 @@ When you change a string in a template or in a web server, you have to generate 
 
     ./setup.py extract_messages
 
-When you have a new translation, or an update of an old translation, you need to update the ``cms.mo`` files (the compiled versions of the ``cms.po`` files). You can run ``python setup.py compile_catalog`` to update all translations (or add the ``-l <code>`` argument to update only the one for a given locale). The usual ``python setup.py install`` will do this automatically. Note that, to have the new strings, you need to restart the web server.
+When you have a new translation, or an update of an old translation, you need to update the ``cms.mo`` files (the compiled versions of the ``cms.po`` files). You can run ``python setup.py compile_catalog`` to update the ``cms.mo`` files for all translations (or add the ``-l <code>`` argument to update only the one for a given locale). The usual ``python setup.py install`` will do this automatically. Note that, to have the new strings, you need to restart the web server.
 
 
 For translators

--- a/docs/Localization.rst
+++ b/docs/Localization.rst
@@ -10,39 +10,24 @@ When you change a string in a template or in a web server, you have to generate 
 
 .. sourcecode:: bash
 
-    xgettext -o cms/locale/cms.pot --language=Python --no-location \
-      --add-comments=translators --keyword=_:1,2 --keyword=N_ \
-      --keyword=N_:1,2 --width=79 cms/locale/*.py cms/grading/*.py \
-      cms/grading/*/*.py cms/server/*.py cms/server/contest/*.py \
-      cms/server/contest/handlers/*.py cms/server/contest/templates/*.html
+    ./setup.py extract_messages
 
-When you have a new translation, or an update of an old translation, you need to update the ``cms.mo`` files (the compiled versions of the ``cms.po`` files). You can run ``./prerequisites.py build_l10n`` to update all translations, and the usual ``python setup.py install`` to install them.
-
-Alternatively, run the following inside the root of the repository.
-
-.. sourcecode:: bash
-
-    msgfmt cms/locale/<code>/LC_MESSAGES/cms.po -o cms/locale/<code>/LC_MESSAGES/cms.mo
-
-And then copy the compiled ``.mo`` files to the appropriate folder. You may have to manually create the directory tree. Note that, to have the new strings, you need to restart the web server.
+When you have a new translation, or an update of an old translation, you need to update the ``cms.mo`` files (the compiled versions of the ``cms.po`` files). You can run ``python setup.py compile_catalog`` to update all translations (or add the ``-l <code>`` argument to update only the one for a given locale). The usual ``python setup.py install`` will do this automatically. Note that, to have the new strings, you need to restart the web server.
 
 
 For translators
 ===============
 
-To begin translating to a new language, run this command, from :gh_tree:`cms/locale/`.
+To begin translating to a new language, run this command from the root of the repository.
 
 .. sourcecode:: bash
 
-    mkdir -p <two_letter_code_of_language>/LC_MESSAGES
-    msginit --width=79 -l <two_letter_code_of_language>/LC_MESSAGES/cms
+    ./setup.py init_catalog -l <code>
 
-Right after that, open the newly created :file:`cms.po` and fill the information in the header. To translate a string, simply fill the corresponding msgstr with the translations. You can also use specialized translation softwares such as poEdit and others.
+Right after that, open the newly created :file:`cms/locale/<code>/LC_MESSAGES/cms.po` and fill the information in the header. To translate a string, simply fill the corresponding msgstr with the translations. You can also use specialized translation softwares such as poEdit and others.
 
-When the developers update the ``cms.pot`` file, you do not need to start from scratch. Instead, you can create a new ``cms.po`` file that merges the old translated string with the new, to-be-translated ones. The command is the following, run inside :gh_tree:`cms/locale/`.
+When the developers update the ``cms.pot`` file, you do not need to start from scratch. Instead, you can create a new ``cms.po`` file that merges the old translated string with the new, to-be-translated ones. The command is the following, run inside the root of the repository.
 
 .. sourcecode:: bash
 
-    msgmerge --width=79 <code>/LC_MESSAGES/cms.po cms.pot > <code>/LC_MESSAGES/cms.new.po
-
-You can now inspect the newly created :file:`cms.new.po` and, if you are satisfied, move it to :file:`cms.po` and finish the translation.
+    ./setup.py update_catalog -l <code>

--- a/prerequisites.py
+++ b/prerequisites.py
@@ -41,7 +41,6 @@ import argparse
 import grp
 import os
 import pwd
-import re
 import shutil
 import subprocess
 import sys
@@ -199,25 +198,6 @@ def get_real_user():
     return name
 
 
-def build_l10n():
-    """This function compiles localization files.
-
-    """
-    assert_not_root()
-
-    print("===== Compiling localization files")
-    for locale in glob(os.path.join("cms", "locale", "*")):
-        if os.path.isdir(locale) \
-                and not os.path.basename(locale).startswith("_"):
-            country_code = os.path.basename(locale)
-            print("  %s" % country_code)
-            path = os.path.join(
-                "cms", "locale", country_code, "LC_MESSAGES")
-            locale = os.path.join(locale, "LC_MESSAGES", "cms.po")
-            subprocess.call(
-                ["msgfmt", locale, "-o", os.path.join(path, "cms.mo")])
-
-
 def build_isolate():
     """This function compiles the isolate sandbox.
 
@@ -269,7 +249,6 @@ def build():
     - build_isolate
 
     """
-    build_l10n()
     build_isolate()
 
 
@@ -304,7 +283,6 @@ def install():
     """This function prepares all that's needed to run CMS:
     - creation of cmsuser user
     - compilation and installation of isolate
-    - compilation and installation of localization files
     - installation of configuration files
     and so on.
 
@@ -405,7 +383,6 @@ def uninstall():
     function:
     - deletion of the cmsuser user
     - deletion of isolate
-    - deletion of localization files
     - deletion of configuration files
     and so on.
 
@@ -419,14 +396,6 @@ def uninstall():
     if ask("Type Y if you really want to remove configuration files: "):
         for conf_file_name in ["cms.conf", "cms.ranking.conf"]:
             try_delete(os.path.join(USR_ROOT, "etc", conf_file_name))
-
-    print("===== Deleting localization files")
-    for locale in glob(os.path.join("po", "*.po")):
-        country_code = re.search(r"/([^/]*)\.po", locale).groups()[0]
-        print("  %s" % country_code)
-        dest_path = os.path.join(USR_ROOT, "share", "locale",
-                                 country_code, "LC_MESSAGES")
-        try_delete(os.path.join(dest_path, "cms.mo"))
 
     print("===== Deleting empty directories")
     dirs = [os.path.join(VAR_ROOT, "log"),

--- a/prerequisites.py
+++ b/prerequisites.py
@@ -245,7 +245,6 @@ def install_isolate():
 
 def build():
     """This function builds all the prerequisites by calling:
-    - build_l10n
     - build_isolate
 
     """
@@ -456,9 +455,6 @@ if __name__ == '__main__':
 
     subparsers = parser.add_subparsers(metavar="command",
                                        help="Subcommand to run")
-    subparsers.add_parser("build_l10n",
-                          help="Build localization files") \
-        .set_defaults(func=build_l10n)
     subparsers.add_parser("build_isolate",
                           help="Build \"isolate\" sandbox") \
         .set_defaults(func=build_isolate)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ bcrypt>=3.1,<3.2  # https://github.com/pyca/bcrypt/
 chardet>=3.0,<3.1  # https://pypi.python.org/pypi/chardet
 ipaddress>=1.0,<1.1  # https://pypi.python.org/pypi/ipaddress
 future>=0.15,<0.16  # https://pypi.python.org/pypi/future
+babel>=2.4,<2.5  # http://babel.pocoo.org/en/latest/changelog.html
 
 # Only for some importers:
 pyyaml>=3.12,<3.13  # http://pyyaml.org/wiki/PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,27 @@
+# This file provides default options for setup.py commands.
+
+[extract_messages]
+mapping-file: babel_mapping.cfg
+keywords: n_:1,2 Nn_:1,2
+output-file: cms/locale/cms.pot
+no-location: 1
+width: 79
+project: Contest Management System
+copyright-holder: CMS development group
+msgid-bugs-address: contestms-dev@freelists.org
+
+[init_catalog]
+domain: cms
+input-file: cms/locale/cms.pot
+output-dir: cms/locale
+width: 79
+
+[update_catalog]
+domain: cms
+input-file: cms/locale/cms.pot
+output-dir: cms/locale
+width: 79
+
+[compile_catalog]
+domain: cms
+directory: cms/locale

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ def find_version():
 class build_py_and_l10n(build_py):
     def run(self):
         self.run_command("compile_catalog")
-        super(build_py, self).run()
+        super(build_py_and_l10n, self).run()
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ import re
 import os
 
 from setuptools import setup, find_packages
+from setuptools.command.build_py import build_py
 
 
 PACKAGE_DATA = {
@@ -97,6 +98,15 @@ def find_version():
     raise RuntimeError("Unable to find version string.")
 
 
+# We piggyback the translation catalogs compilation onto build_py since
+# the po and mofiles will be part of the package data for cms.locale,
+# which is collected at this stage.
+class build_py_and_l10n(build_py):
+    def run(self):
+        self.run_command("compile_catalog")
+        super(build_py, self).run()
+
+
 setup(
     name="cms",
     version=find_version(),
@@ -108,6 +118,7 @@ setup(
                 "for IOI-like programming competitions",
     packages=find_packages(),
     package_data=PACKAGE_DATA,
+    cmdclass = {"build_py": build_py_and_l10n},
     scripts=["scripts/cmsLogService",
              "scripts/cmsScoringService",
              "scripts/cmsEvaluationService",

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,8 @@ def find_version():
 class build_py_and_l10n(build_py):
     def run(self):
         self.run_command("compile_catalog")
-        super(build_py_and_l10n, self).run()
+        # Can't use super here as in Py2 it isn't a new-style class.
+        build_py.run(self)
 
 
 setup(


### PR DESCRIPTION
Stop using the gettext command line utilities (xgettext, msginit,
msgmerge, msgfmt) both in the documentation and in prerequisites.py and
replace them with the setuptools commands provided by the Babel package.
Thanks to two configuration files (setup.cfg and babel_mapping.cfg)
these commands can be called with no arguments, making them simpler to
use and harder to get wrong.

Moreover, resolve the "hybrid" situation we had regarding mofiles (i.e.,
compiled pofiles): they were installed as part of the package data of
cms.locale yet they were built and uninstalled by prerequisites.py. Now
they are entirely handled by setuptools, with all the package-related
stuff.

The Babel extractor doesn't support a localization function with
multiple signatures, that is, supporting both singular (_(msgid)) and
plural (_(msgid1, msgid2, count)) forms, as was the case with Tornado's
translate function. Hence we alias it to two names: gettext/_ for
singular and ngettext/n_ for plural. Same for the dummy versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/836)
<!-- Reviewable:end -->
