### PR TITLE
Provide a Babel-powered Translation object to replace Tornado's Locale

### DIFF
--- a/cms/grading/ScoreType.py
+++ b/cms/grading/ScoreType.py
@@ -45,7 +45,7 @@ from abc import ABCMeta, abstractmethod
 
 from tornado.template import Template
 
-from cms.locale import locale_format
+from cms.locale import locale_format, DEFAULT_TRANSLATION
 
 
 logger = logging.getLogger(__name__)
@@ -84,7 +84,7 @@ class ScoreType(object):
 
     @staticmethod
     def format_score(score, max_score, unused_score_details,
-                     score_precision, _=lambda s: s):
+                     score_precision, translation=None):
         """Produce the string of the score that is shown in CWS.
 
         In the submission table in the task page of CWS the global
@@ -99,31 +99,39 @@ class ScoreType(object):
             the ScoreType produced for the submission when scoring it.
         score_precision (int): the maximum number of digits of the
             fractional digits to show.
-        _ (function): translation function.
+        translation (Translation|None): the translation to use.
 
         return (string): the message to show.
 
         """
+        if translation is None:
+            translation = DEFAULT_TRANSLATION
+        _ = translation.gettext
         return locale_format(_, "{0:g} / {1:g}",
             round(score, score_precision), round(max_score, score_precision))
 
-    def get_html_details(self, score_details, _=lambda s: s):
+    def get_html_details(self, score_details, translation=None):
         """Return an HTML string representing the score details of a
         submission.
 
         score_details (object): the data saved by the score type
             itself in the database; can be public or private.
-        _ (function): translation function.
+        translation (Translation|None): the translation to use.
 
         return (string): an HTML string representing score_details.
 
         """
+        if translation is None:
+            translation = DEFAULT_TRANSLATION
+        _ = translation.gettext
         if score_details is None:
             logger.error("Found a null score details string. "
                          "Try invalidating scores.")
             return _("Score details temporarily unavailable.")
         else:
-            return Template(self.TEMPLATE).generate(details=score_details, _=_)
+            return Template(self.TEMPLATE).generate(details=score_details,
+                                                    translation=translation,
+                                                    _=_)
 
     @abstractmethod
     def max_scores(self):
@@ -246,7 +254,7 @@ class ScoreTypeGroup(ScoreTypeAlone):
                     <td class="idx">{{ idx }}</td>
                     <td class="outcome">{{ _(tc["outcome"]) }}</td>
                     <td class="details">
-                      {{ format_status_text(tc["text"], _) }}
+                      {{ format_status_text(tc["text"], translation=translation) }}
                     </td>
                     <td class="execution-time">
             {% if "time" in tc and tc["time"] is not None %}
@@ -257,7 +265,7 @@ class ScoreTypeGroup(ScoreTypeAlone):
                     </td>
                     <td class="memory-used">
             {% if "memory" in tc and tc["memory"] is not None %}
-                        {{ format_size(tc["memory"], _) }}
+                        {{ format_size(tc["memory"], translation=translation) }}
             {% else %}
                         {{ _("N/A") }}
             {% end %}

--- a/cms/grading/ScoreType.py
+++ b/cms/grading/ScoreType.py
@@ -84,7 +84,7 @@ class ScoreType(object):
 
     @staticmethod
     def format_score(score, max_score, unused_score_details,
-                     score_precision, translation=None):
+                     score_precision, translation=DEFAULT_TRANSLATION):
         """Produce the string of the score that is shown in CWS.
 
         In the submission table in the task page of CWS the global
@@ -99,30 +99,26 @@ class ScoreType(object):
             the ScoreType produced for the submission when scoring it.
         score_precision (int): the maximum number of digits of the
             fractional digits to show.
-        translation (Translation|None): the translation to use.
+        translation (Translation): the translation to use.
 
         return (string): the message to show.
 
         """
-        if translation is None:
-            translation = DEFAULT_TRANSLATION
         _ = translation.gettext
         return locale_format(_, "{0:g} / {1:g}",
             round(score, score_precision), round(max_score, score_precision))
 
-    def get_html_details(self, score_details, translation=None):
+    def get_html_details(self, score_details, translation=DEFAULT_TRANSLATION):
         """Return an HTML string representing the score details of a
         submission.
 
         score_details (object): the data saved by the score type
             itself in the database; can be public or private.
-        translation (Translation|None): the translation to use.
+        translation (Translation): the translation to use.
 
         return (string): an HTML string representing score_details.
 
         """
-        if translation is None:
-            translation = DEFAULT_TRANSLATION
         _ = translation.gettext
         if score_details is None:
             logger.error("Found a null score details string. "

--- a/cms/grading/__init__.py
+++ b/cms/grading/__init__.py
@@ -215,7 +215,7 @@ class JobException(Exception):
         return "JobException(\"%s\")" % (repr(self.msg))
 
 
-def format_status_text(status, translation=None):
+def format_status_text(status, translation=DEFAULT_TRANSLATION):
     """Format the given status text in the given locale.
 
     A status text is the content of SubmissionResult.compilation_text,
@@ -228,11 +228,9 @@ def format_status_text(status, translation=None):
     returned.
 
     status ([unicode]): a status, as described above.
-    translation (Translation|None): the translation to use.
+    translation (Translation): the translation to use.
 
     """
-    if translation is None:
-        translation = DEFAULT_TRANSLATION
     _ = translation.gettext
 
     try:

--- a/cms/grading/__init__.py
+++ b/cms/grading/__init__.py
@@ -42,6 +42,7 @@ from sqlalchemy.orm import joinedload
 from cms import SCORE_MODE_MAX, config
 from cms.db import Submission
 from cms.grading.Sandbox import Sandbox
+from cms.locale import DEFAULT_TRANSLATION
 
 from .language import Language, CompiledLanguage
 
@@ -214,7 +215,7 @@ class JobException(Exception):
         return "JobException(\"%s\")" % (repr(self.msg))
 
 
-def format_status_text(status, translator=None):
+def format_status_text(status, translation=None):
     """Format the given status text in the given locale.
 
     A status text is the content of SubmissionResult.compilation_text,
@@ -227,29 +228,24 @@ def format_status_text(status, translator=None):
     returned.
 
     status ([unicode]): a status, as described above.
-    translator (function|None): a function expecting a string and
-        returning that same string translated in some language, or
-        None to apply the identity.
+    translation (Translation|None): the translation to use.
 
     """
-    # Mark strings for localization.
-    N_("N/A")
-
-    if translator is None:
-        translator = lambda x: x
+    if translation is None:
+        translation = DEFAULT_TRANSLATION
+    _ = translation.gettext
 
     try:
         if not isinstance(status, list):
             raise TypeError("Invalid type: %r" % type(status))
 
-        # translator('') gives, for some reason, the first lines of
-        # the po file.
-        text = translator(status[0]) if status[0] != '' else ''
+        # The empty msgid corresponds to the headers of the pofile.
+        text = _(status[0]) if status[0] != '' else ''
         return text % tuple(status[1:])
     except:
         logger.error("Unexpected error when formatting status "
                      "text: %r", status, exc_info=True)
-        return translator("N/A")
+        return _("N/A")
 
 
 def compilation_step(sandbox, commands):

--- a/cms/grading/scoretypes/Sum.py
+++ b/cms/grading/scoretypes/Sum.py
@@ -72,7 +72,7 @@ class Sum(ScoreTypeAlone):
             {% end %}
             <td class="idx">{{ idx }}</td>
             <td class="outcome">{{ _(tc["outcome"]) }}</td>
-            <td class="details">{{ format_status_text(tc["text"], _) }}</td>
+            <td class="details">{{ format_status_text(tc["text"], translation=translation) }}</td>
             <td class="execution-time">
             {% if tc["time"] is not None %}
                 {{ locale_format(_, _("{seconds:0.3f} s"), seconds=tc["time"]) }}
@@ -82,7 +82,7 @@ class Sum(ScoreTypeAlone):
             </td>
             <td class="memory-used">
             {% if tc["memory"] is not None %}
-                {{ format_size(tc["memory"], _) }}
+                {{ format_size(tc["memory"], translation=translation) }}
             {% else %}
                 {{ _("N/A") }}
             {% end %}

--- a/cms/locale/__init__.py
+++ b/cms/locale/__init__.py
@@ -24,11 +24,11 @@ from future.builtins.disabled import *
 from future.builtins import *
 
 from .locale import \
-    filter_language_codes, get_system_translations, get_translations, \
-    wrap_translations_for_tornado, locale_format
+    get_system_translations, Translation, DEFAULT_TRANSLATION, \
+    get_translations, filter_language_codes, locale_format
 
 
 __all__ = [
-    "filter_language_codes", "get_system_translations", "get_translations",
-    "wrap_translations_for_tornado", "locale_format"
+    "get_system_translations", "Translation", "DEFAULT_TRANSLATION",
+    "get_translations", "filter_language_codes", "locale_format"
 ]

--- a/cms/locale/locale.py
+++ b/cms/locale/locale.py
@@ -86,6 +86,14 @@ def get_system_translations(lang):
 
 
 class Translation(object):
+    """A shim that bundles all sources of translations for a language
+
+    This class is a thin wrapper that collects all message catalogs and
+    other pieces of information about a locale and centralizes access
+    to them providing a more object-oriented interface.
+
+    """
+
     def __init__(self, lang_code, mofile=None):
         self.locale = babel.core.Locale.parse(lang_code)
         if mofile is not None:

--- a/cms/locale/locale.py
+++ b/cms/locale/locale.py
@@ -5,7 +5,7 @@
 # Copyright © 2010-2014 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
 # Copyright © 2010-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
-# Copyright © 2012-2015 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2012-2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
@@ -35,15 +35,16 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from future.builtins.disabled import *
 from future.builtins import *
-from six import iteritems
 import six
 
 import pkg_resources
 import gettext
-import io
 import logging
 import os
 import string
+
+import babel.core
+import babel.support
 
 from cms import config
 
@@ -84,69 +85,62 @@ def get_system_translations(lang):
     return [iso_639_locale, iso_3166_locale, shared_mime_info_locale]
 
 
+class Translation(object):
+    def __init__(self, lang_code, mofile=None):
+        self.locale = babel.core.Locale.parse(lang_code)
+        if mofile is not None:
+            self.translation = babel.support.Translations(mofile, domain="cms")
+        else:
+            self.translation = babel.support.NullTranslations()
+        for sys_translation in get_system_translations(lang_code):
+            self.translation.add_fallback(sys_translation)
+
+    @property
+    def identifier(self):
+        return babel.core.get_locale_identifier(
+            (self.locale.language, self.locale.territory,
+             self.locale.script, self.locale.variant))
+
+    @property
+    def name(self):
+        return self.locale.display_name
+
+    def gettext(self, msgid):
+        if six.PY3:
+            return self.translation.gettext(msgid)
+        else:
+            return self.translation.ugettext(msgid)
+
+    def ngettext(self, msgid1, msgid2, n):
+        if six.PY3:
+            return self.translation.ngettext(msgid1, msgid2, n)
+        else:
+            return self.translation.ungettext(msgid1, msgid2, n)
+
+
+DEFAULT_TRANSLATION = Translation("en")
+
+
 def get_translations():
     """Return the translations for all the languages we support.
 
     Search for the message catalogs that were installed and load them.
 
-    return ({string: gettext.NullTranslations}): for each language its
-        message catalog
+    return ({string: Translation}): for each language its message
+        catalog
 
     """
-    locale_dir = None
-    result = {"en": gettext.NullTranslations()}
+    result = {"en": DEFAULT_TRANSLATION}
 
-    locale_dir = pkg_resources.resource_filename("cms.locale", "")
-    for lang_code in os.listdir(locale_dir):
-        if os.path.isdir(os.path.join(locale_dir, lang_code)):
-            mo_file_path = os.path.join(locale_dir, lang_code,
-                                        "LC_MESSAGES", "cms.mo")
-            if os.path.exists(mo_file_path):
-                with io.open(mo_file_path, "rb") as mo_file:
-                    result[lang_code] = gettext.GNUTranslations(mo_file)
-
-    for lang_code, trans in iteritems(result):
-        for sys_trans in get_system_translations(lang_code):
-            trans.add_fallback(sys_trans)
+    for lang_code in sorted(pkg_resources.resource_listdir("cms.locale", "")):
+        mofile_path = os.path.join(lang_code, "LC_MESSAGES", "cms.mo")
+        if pkg_resources.resource_exists("cms.locale", mofile_path):
+            with pkg_resources.resource_stream("cms.locale", mofile_path) as f:
+                t = Translation(lang_code, f)
+                logger.info("Found translation %s", t.identifier)
+                result[t.identifier] = t
 
     return result
-
-
-def wrap_translations_for_tornado(trans):
-    """Make a message catalog compatible with Tornado.
-
-    Add the necessary methods to give a gettext.*Translations object
-    the interface of a tornado.locale.GettextLocale object.
-
-    trans (gettext.NullTranslations): a message catalog
-
-    return (object): a message catalog disguised as a
-        tornado.locale.GettextLocale
-
-    """
-    if six.PY3:
-        gettext = trans.gettext
-        ngettext = trans.ngettext
-    else:
-        gettext = trans.ugettext
-        ngettext = trans.ungettext
-
-    # Add translate method
-    def translate(message, plural_message=None, count=None):
-        if plural_message is not None:
-            assert count is not None
-            return ngettext(message, plural_message, count)
-        else:
-            return gettext(message)
-    trans.translate = translate
-
-    # Add a "dummy" pgettext method (that ignores the context)
-    # (Since v4.2)
-    def pgettext(_, message, plural_message=None, count=None):
-        return translate(message, plural_message, count)
-    trans.pgettext = pgettext
-
-    return trans
 
 
 def filter_language_codes(lang_codes, prefix_filter):

--- a/cms/server/admin/templates/fragments/submission_row.html
+++ b/cms/server/admin/templates/fragments/submission_row.html
@@ -78,7 +78,7 @@
       Scored ({{ sr.score }} / {{ max_score }})
       <div id="evaluation_{{ s.id }}" class="score_details" style="display: none;">
         {% try %}
-          {% raw score_type.get_html_details(sr.score_details, _) %}
+          {% raw score_type.get_html_details(sr.score_details) %}
         {% except %}
         [Cannot get score type - see logs]
         {% end %}

--- a/cms/server/admin/templates/submission.html
+++ b/cms/server/admin/templates/submission.html
@@ -187,9 +187,9 @@
 
   <div class="score_details" id="evaluation_{{ s.id }}">
     {% if s.tokened() %}
-      {% raw st.get_html_details(sr.score_details, _) %}
+      {% raw st.get_html_details(sr.score_details) %}
     {% else %}
-      {% raw st.get_html_details(sr.public_score_details, _) %}
+      {% raw st.get_html_details(sr.public_score_details) %}
     {% end %}
   </div>
 </div>

--- a/cms/server/contest/formatting.py
+++ b/cms/server/contest/formatting.py
@@ -57,19 +57,17 @@ Nn_("%d hour", "%d hours", 0)
 Nn_("%d day", "%d days", 0)
 
 
-def format_datetime(dt, timezone, translation=None):
+def format_datetime(dt, timezone, translation=DEFAULT_TRANSLATION):
     """Return the date and time of dt formatted as per locale.
 
     dt (datetime): a datetime object.
     timezone (tzinfo): the timezone the output should be in.
-    translation (Translation|None): the translation to use.
+    translation (Translation): the translation to use.
 
     return (str): the date and time of dt, formatted using the given
         locale.
 
     """
-    if translation is None:
-        translation = DEFAULT_TRANSLATION
     _ = translation.gettext
 
     # convert dt from UTC to local time
@@ -78,18 +76,16 @@ def format_datetime(dt, timezone, translation=None):
     return dt.strftime(_("%Y-%m-%d %H:%M:%S"))
 
 
-def format_time(dt, timezone, translation=None):
+def format_time(dt, timezone, translation=DEFAULT_TRANSLATION):
     """Return the time of dt formatted according to the given locale.
 
     dt (datetime): a datetime object.
     timezone (tzinfo): the timezone the output should be in.
-    translation (Translation|None): the translation to use.
+    translation (Translation): the translation to use.
 
     return (str): the time of dt, formatted using the given locale.
 
     """
-    if translation is None:
-        translation = DEFAULT_TRANSLATION
     _ = translation.gettext
 
     # convert dt from UTC to local time
@@ -98,21 +94,19 @@ def format_time(dt, timezone, translation=None):
     return dt.strftime(_("%H:%M:%S"))
 
 
-def format_datetime_smart(dt, timezone, translation=None):
+def format_datetime_smart(dt, timezone, translation=DEFAULT_TRANSLATION):
     """Return dt formatted as '[date] time'.
 
     Date is present in the output if it is not today.
 
     dt (datetime): a datetime object.
     timezone (tzinfo): the timezone the output should be in.
-    translation (Translation|None): the translation to use.
+    translation (Translation): the translation to use.
 
     return (str): the [date and] time of dt, formatted using the given
         locale.
 
     """
-    if translation is None:
-        translation = DEFAULT_TRANSLATION
     _ = translation.gettext
 
     # convert dt and 'now' from UTC to local time
@@ -125,7 +119,8 @@ def format_datetime_smart(dt, timezone, translation=None):
         return dt.strftime(_("%Y-%m-%d %H:%M:%S"))
 
 
-def format_amount_of_time(seconds, precision=2, translation=None):
+def format_amount_of_time(seconds, precision=2,
+                          translation=DEFAULT_TRANSLATION):
     """Return the number of seconds formatted 'X days, Y hours, ...'
 
     The time units that will be used are days, hours, minutes, seconds.
@@ -135,13 +130,11 @@ def format_amount_of_time(seconds, precision=2, translation=None):
 
     seconds (int): the length of the amount of time in seconds.
     precision (int): see above
-    translation (Translation|None): the translation to use.
+    translation (Translation): the translation to use.
 
     return (string): seconds formatted as above.
 
     """
-    if translation is None:
-        translation = DEFAULT_TRANSLATION
     _ = translation.gettext
     n_ = translation.ngettext
 
@@ -184,18 +177,16 @@ UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
 DIMS = list(1024 ** x for x in range(9))
 
 
-def format_size(n, translation=None):
+def format_size(n, translation=DEFAULT_TRANSLATION):
     """Format the given number of bytes.
 
     n (int): a size, as number of bytes.
-    translation (Translation|None): the translation to use.
+    translation (Translation): the translation to use.
 
     return (str): the size formatted using the most appropriate size
         unit, always with three significant digits.
 
     """
-    if translation is None:
-        translation = DEFAULT_TRANSLATION
     _ = translation.gettext
 
     if n == 0:
@@ -217,7 +208,7 @@ def format_size(n, translation=None):
     return locale_format(_, "{0:g} {1}", round(n, d), UNITS[unit_index])
 
 
-def format_token_rules(tokens, t_type=None, translation=None):
+def format_token_rules(tokens, t_type=None, translation=DEFAULT_TRANSLATION):
     """Return a human-readable string describing the given token rules
 
     tokens (dict): all the token rules (as seen in Task or Contest),
@@ -225,13 +216,11 @@ def format_token_rules(tokens, t_type=None, translation=None):
     t_type (string|None): the type of tokens the string should refer to
         (can be "contest" to mean contest-tokens, "task" to mean
         task-tokens, any other value to mean normal tokens).
-    translation (Translation|None): the translation to use.
+    translation (Translation): the translation to use.
 
     return (unicode): localized string describing the rules.
 
     """
-    if translation is None:
-        translation = DEFAULT_TRANSLATION
     _ = translation.gettext
     n_ = translation.ngettext
 

--- a/cms/server/contest/formatting.py
+++ b/cms/server/contest/formatting.py
@@ -32,10 +32,8 @@ from future.builtins import *
 
 from future.moves.urllib.parse import quote
 
-import tornado.locale
-
 from cmscommon.datetime import make_datetime, utc
-from cms.locale import locale_format
+from cms.locale import locale_format, DEFAULT_TRANSLATION
 
 
 # Dummy functions to mark strings for translation: N_ is a dummy for
@@ -59,20 +57,20 @@ Nn_("%d hour", "%d hours", 0)
 Nn_("%d day", "%d days", 0)
 
 
-def format_datetime(dt, timezone, locale=None):
+def format_datetime(dt, timezone, translation=None):
     """Return the date and time of dt formatted as per locale.
 
     dt (datetime): a datetime object.
     timezone (tzinfo): the timezone the output should be in.
+    translation (Translation|None): the translation to use.
 
     return (str): the date and time of dt, formatted using the given
         locale.
 
     """
-    if locale is None:
-        locale = tornado.locale.get()
-
-    _ = locale.translate
+    if translation is None:
+        translation = DEFAULT_TRANSLATION
+    _ = translation.gettext
 
     # convert dt from UTC to local time
     dt = dt.replace(tzinfo=utc).astimezone(timezone)
@@ -80,19 +78,19 @@ def format_datetime(dt, timezone, locale=None):
     return dt.strftime(_("%Y-%m-%d %H:%M:%S"))
 
 
-def format_time(dt, timezone, locale=None):
+def format_time(dt, timezone, translation=None):
     """Return the time of dt formatted according to the given locale.
 
     dt (datetime): a datetime object.
     timezone (tzinfo): the timezone the output should be in.
+    translation (Translation|None): the translation to use.
 
     return (str): the time of dt, formatted using the given locale.
 
     """
-    if locale is None:
-        locale = tornado.locale.get()
-
-    _ = locale.translate
+    if translation is None:
+        translation = DEFAULT_TRANSLATION
+    _ = translation.gettext
 
     # convert dt from UTC to local time
     dt = dt.replace(tzinfo=utc).astimezone(timezone)
@@ -100,22 +98,22 @@ def format_time(dt, timezone, locale=None):
     return dt.strftime(_("%H:%M:%S"))
 
 
-def format_datetime_smart(dt, timezone, locale=None):
+def format_datetime_smart(dt, timezone, translation=None):
     """Return dt formatted as '[date] time'.
 
     Date is present in the output if it is not today.
 
     dt (datetime): a datetime object.
     timezone (tzinfo): the timezone the output should be in.
+    translation (Translation|None): the translation to use.
 
     return (str): the [date and] time of dt, formatted using the given
         locale.
 
     """
-    if locale is None:
-        locale = tornado.locale.get()
-
-    _ = locale.translate
+    if translation is None:
+        translation = DEFAULT_TRANSLATION
+    _ = translation.gettext
 
     # convert dt and 'now' from UTC to local time
     dt = dt.replace(tzinfo=utc).astimezone(timezone)
@@ -127,7 +125,7 @@ def format_datetime_smart(dt, timezone, locale=None):
         return dt.strftime(_("%Y-%m-%d %H:%M:%S"))
 
 
-def format_amount_of_time(seconds, precision=2, locale=None):
+def format_amount_of_time(seconds, precision=2, translation=None):
     """Return the number of seconds formatted 'X days, Y hours, ...'
 
     The time units that will be used are days, hours, minutes, seconds.
@@ -137,19 +135,17 @@ def format_amount_of_time(seconds, precision=2, locale=None):
 
     seconds (int): the length of the amount of time in seconds.
     precision (int): see above
-    locale (Locale|None): the locale to be used, or None for the
-        default.
+    translation (Translation|None): the translation to use.
 
     return (string): seconds formatted as above.
 
     """
+    if translation is None:
+        translation = DEFAULT_TRANSLATION
+    _ = translation.gettext
+    n_ = translation.ngettext
+
     seconds = abs(int(seconds))
-
-    if locale is None:
-        locale = tornado.locale.get()
-
-    _ = locale.translate
-    n_ = locale.translate
 
     if seconds == 0:
         return n_("%d second", "%d seconds", 0) % 0
@@ -188,14 +184,20 @@ UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
 DIMS = list(1024 ** x for x in range(9))
 
 
-def format_size(n, _=lambda s: s):
+def format_size(n, translation=None):
     """Format the given number of bytes.
 
-    Return a size, given as a number of bytes, properly formatted
-    using the most appropriate size unit. Always use three
-    significant digits.
+    n (int): a size, as number of bytes.
+    translation (Translation|None): the translation to use.
+
+    return (str): the size formatted using the most appropriate size
+        unit, always with three significant digits.
 
     """
+    if translation is None:
+        translation = DEFAULT_TRANSLATION
+    _ = translation.gettext
+
     if n == 0:
         return '0 B'
 
@@ -215,7 +217,7 @@ def format_size(n, _=lambda s: s):
     return locale_format(_, "{0:g} {1}", round(n, d), UNITS[unit_index])
 
 
-def format_token_rules(tokens, t_type=None, locale=None):
+def format_token_rules(tokens, t_type=None, translation=None):
     """Return a human-readable string describing the given token rules
 
     tokens (dict): all the token rules (as seen in Task or Contest),
@@ -223,17 +225,15 @@ def format_token_rules(tokens, t_type=None, locale=None):
     t_type (string|None): the type of tokens the string should refer to
         (can be "contest" to mean contest-tokens, "task" to mean
         task-tokens, any other value to mean normal tokens).
-    locale (Locale|NullTranslation|None): the locale to be used (None
-        for the default).
+    translation (Translation|None): the translation to use.
 
     return (unicode): localized string describing the rules.
 
     """
-    if locale is None:
-        locale = tornado.locale.get()
-
-    _ = locale.translate
-    n_ = locale.translate
+    if translation is None:
+        translation = DEFAULT_TRANSLATION
+    _ = translation.gettext
+    n_ = translation.ngettext
 
     if t_type == "contest":
         tokens["type_s"] = _("contest-token")

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -58,9 +58,10 @@ class BaseHandler(CommonRequestHandler):
 
     def __init__(self, *args, **kwargs):
         super(BaseHandler, self).__init__(*args, **kwargs)
+        self.all_translations = None
         self.cookie_lang = None
         self.browser_lang = None
-        self.langs = None
+        self.translation = None
         self._ = None
 
     def get(self):

--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -298,7 +298,7 @@ class ContestHandler(BaseHandler):
         return participation
 
     def setup_locale(self):
-        self.all_tanslations = self.service.translations
+        self.all_translations = self.service.translations
         lang_codes = list(iterkeys(self.all_translations))
 
         if self.contest.allowed_localizations:

--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -56,8 +56,6 @@ from cms.server import compute_actual_phase, file_handler_gen, \
     create_url_builder
 from cms.locale import filter_language_codes
 from cmscommon.datetime import get_timezone, make_datetime, make_timestamp
-from cmscommon.isocodes import translate_language_code, \
-    translate_language_country_code
 
 from .base import BaseHandler
 
@@ -103,7 +101,7 @@ class ContestHandler(BaseHandler):
         super(ContestHandler, self).prepare()
         self.choose_contest()
 
-        self._ = self.locale.translate
+        self.setup_locale()
 
         if self.is_multi_contest():
             self.contest_url = \
@@ -299,9 +297,9 @@ class ContestHandler(BaseHandler):
 
         return participation
 
-    def get_user_locale(self):
-        self.langs = self.service.langs
-        lang_codes = list(iterkeys(self.langs))
+    def setup_locale(self):
+        self.all_tanslations = self.service.translations
+        lang_codes = list(iterkeys(self.all_translations))
 
         if self.contest.allowed_localizations:
             lang_codes = filter_language_codes(
@@ -326,7 +324,8 @@ class ContestHandler(BaseHandler):
             lang_code = self.browser_lang
 
         self.set_header("Content-Language", lang_code)
-        return self.langs[lang_code.replace("-", "_")]
+        self.translation = self.all_translations[lang_code.replace("-", "_")]
+        self._ = self.translation.gettext
 
     @staticmethod
     def _get_token_status(obj):
@@ -393,30 +392,24 @@ class ContestHandler(BaseHandler):
         else:
             ret["tokens_tasks"] = 1  # all finite or mixed
 
-        # TODO Now all language names are shown in the active language.
-        # It would be better to show them in the corresponding one.
         ret["lang_names"] = {}
 
         # Get language codes for allowed localizations
-        lang_codes = list(iterkeys(self.langs))
+        lang_codes = list(iterkeys(self.all_translations))
         if len(self.contest.allowed_localizations) > 0:
             lang_codes = filter_language_codes(
                 lang_codes, self.contest.allowed_localizations)
-        for lang_code, trans in iteritems(self.langs):
-            language_name = None
+        for lang_code, trans in iteritems(self.all_translations):
             # Filter lang_codes with allowed localizations
             if lang_code not in lang_codes:
                 continue
-            try:
-                language_name = translate_language_country_code(
-                    lang_code, trans)
-            except ValueError:
-                language_name = translate_language_code(
-                    lang_code, trans)
-            ret["lang_names"][lang_code.replace("_", "-")] = language_name
+            ret["lang_names"][lang_code.replace("_", "-")] = trans.name
 
         ret["cookie_lang"] = self.cookie_lang
         ret["browser_lang"] = self.browser_lang
+
+        ret["translation"] = self.translation
+        ret["_"] = self._
 
         return ret
 

--- a/cms/server/contest/handlers/task.py
+++ b/cms/server/contest/handlers/task.py
@@ -70,13 +70,14 @@ class TaskDescriptionHandler(ContestHandler):
             lang_code = statement.language
             if is_language_country_code(lang_code):
                 statement.language_name = \
-                    translate_language_country_code(lang_code, self.locale)
+                    translate_language_country_code(lang_code,
+                                                    self.translation)
             elif is_language_code(lang_code):
                 statement.language_name = \
-                    translate_language_code(lang_code, self.locale)
+                    translate_language_code(lang_code, self.translation)
             elif is_country_code(lang_code):
                 statement.language_name = \
-                    translate_country_code(lang_code, self.locale)
+                    translate_country_code(lang_code, self.translation)
             else:
                 statement.language_name = lang_code
 

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -468,7 +468,8 @@ class SubmissionStatusHandler(ContestHandler):
                     round(sr.public_score, task.score_precision)
                 data["public_score_message"] = score_type.format_score(
                     sr.public_score, score_type.max_public_score,
-                    sr.public_score_details, task.score_precision, self._)
+                    sr.public_score_details, task.score_precision,
+                    translation=self.translation)
             if submission.token is not None:
                 data["max_score"] = \
                     round(score_type.max_score, task.score_precision)
@@ -476,7 +477,8 @@ class SubmissionStatusHandler(ContestHandler):
                     round(sr.score, task.score_precision)
                 data["score_message"] = score_type.format_score(
                     sr.score, score_type.max_score,
-                    sr.score_details, task.score_precision, self._)
+                    sr.score_details, task.score_precision,
+                    translation=self.translation)
 
         self.write(data)
 
@@ -516,13 +518,13 @@ class SubmissionDetailsHandler(ContestHandler):
                 details = sr.public_score_details
 
             if sr.scored():
-                details = score_type.get_html_details(details, self._)
+                details = score_type.get_html_details(
+                    details, translation=self.translation)
             else:
                 details = None
 
-        self.render("submission_details.html",
-                    sr=sr,
-                    details=details)
+        self.render("submission_details.html", sr=sr, details=details,
+                    **self.r_params)
 
 
 class SubmissionFileHandler(FileHandler):

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -490,7 +490,8 @@ class UserTestStatusHandler(ContestHandler):
             else:
                 data["time"] = None
             if ur.execution_memory is not None:
-                data["memory"] = format_size(ur.execution_memory, self._)
+                data["memory"] = format_size(ur.execution_memory,
+                                             translation=self.translation)
             else:
                 data["memory"] = None
             data["output"] = ur.output is not None
@@ -527,7 +528,8 @@ class UserTestDetailsHandler(ContestHandler):
 
         tr = user_test.get_result(task.active_dataset)
 
-        self.render("user_test_details.html", task=task, tr=tr)
+        self.render("user_test_details.html", task=task, tr=tr,
+                    **self.r_params)
 
 
 class UserTestIOHandler(FileHandler):

--- a/cms/server/contest/server.py
+++ b/cms/server/contest/server.py
@@ -44,7 +44,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from future.builtins.disabled import *
 from future.builtins import *
-from six import iteritems
 
 import logging
 import pkg_resources
@@ -53,7 +52,7 @@ from cmscommon.binary import hex_to_bin, bin_to_b64
 from cms import ConfigError, ServiceCoord, config
 from cms.io import WebService
 from cms.db.filecacher import FileCacher
-from cms.locale import get_translations, wrap_translations_for_tornado
+from cms.locale import get_translations
 
 from .handlers import HANDLERS
 from .handlers.base import BaseHandler
@@ -115,8 +114,7 @@ class ContestWebServer(WebService):
         self.notifications = {}
 
         # Retrieve the available translations.
-        self.langs = {lang_code: wrap_translations_for_tornado(trans)
-                      for lang_code, trans in iteritems(get_translations())}
+        self.translations = get_translations()
 
         self.file_cacher = FileCacher(self)
         self.evaluation_service = self.connect_to(

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -18,7 +18,7 @@
         {% else %}
         <h4 class="subject empty">{{ _("(no subject)") }}</h4>
         {% end %}
-        <span class="timestamp">{{ format_datetime_smart(msg.timestamp, timezone, locale=locale) }}</span>
+        <span class="timestamp">{{ format_datetime_smart(msg.timestamp, timezone, translation=translation) }}</span>
         {% if len(msg.text) > 0 %}
         <div class="body">{{ msg.text }}</div>
         {% end %}
@@ -73,7 +73,7 @@
         {% else %}
         <h4 class="subject empty">{{ _("(no subject)") }}</h4>
         {% end %}
-        <span class="timestamp">{{ format_datetime_smart(msg.question_timestamp, timezone, locale=locale) }}</span>
+        <span class="timestamp">{{ format_datetime_smart(msg.question_timestamp, timezone, translation=translation) }}</span>
         {% if len(msg.text) > 0 %}
         <div class="body">{{ msg.text }}</div>
         {% end %}
@@ -85,7 +85,7 @@
             {% else %}
         <h4 class="subject empty">{{ _("(no subject)") }}</h4>
             {% end %}
-        <span class="timestamp">{{ format_datetime_smart(msg.reply_timestamp, timezone, locale=locale) }}</span>
+        <span class="timestamp">{{ format_datetime_smart(msg.reply_timestamp, timezone, translation=translation) }}</span>
             {% if len(msg.reply_text) > 0 %}
         <div class="body">{{ msg.reply_text }}</div>
             {% end %}
@@ -112,7 +112,7 @@
         {% else %}
         <h4 class="subject empty">{{ _("(no subject)") }}</h4>
         {% end %}
-        <span class="timestamp">{{ format_datetime_smart(msg.timestamp, timezone, locale=locale) }}</span>
+        <span class="timestamp">{{ format_datetime_smart(msg.timestamp, timezone, translation=translation) }}</span>
         {% if len(msg.text) > 0 %}
         <div class="body">{{ msg.text }}</div>
         {% end %}

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -23,17 +23,17 @@
         {{ _("The contest hasn't started yet.") }}
         </p>
         <p>
-        {{ _("The contest will start at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start + current_user.delay_time, timezone, locale=locale), "stop_time": format_datetime_smart(contest.stop + current_user.delay_time + current_user.extra_time, timezone, locale=locale)} }}
+        {{ _("The contest will start at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start + current_user.delay_time, timezone, translation=translation), "stop_time": format_datetime_smart(contest.stop + current_user.delay_time + current_user.extra_time, timezone, translation=translation)} }}
 {% elif phase == 0 %}
         {{ _("The contest is currently running.") }}
         </p>
         <p>
-        {{ _("The contest started at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start + current_user.delay_time, timezone, locale=locale), "stop_time": format_datetime_smart(contest.stop + current_user.delay_time + current_user.extra_time, timezone, locale=locale)} }}
+        {{ _("The contest started at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start + current_user.delay_time, timezone, translation=translation), "stop_time": format_datetime_smart(contest.stop + current_user.delay_time + current_user.extra_time, timezone, translation=translation)} }}
 {% elif phase >= +1 %}
         {{ _("The contest has already ended.") }}
         </p>
         <p>
-        {{ _("The contest started at %(start_time)s and ended at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start + current_user.delay_time, timezone, locale=locale), "stop_time": format_datetime_smart(contest.stop + current_user.delay_time + current_user.extra_time, timezone, locale=locale)} }}
+        {{ _("The contest started at %(start_time)s and ended at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.start + current_user.delay_time, timezone, translation=translation), "stop_time": format_datetime_smart(contest.stop + current_user.delay_time + current_user.extra_time, timezone, translation=translation)} }}
 {% end %}
         </p>
 {% if contest.analysis_enabled %}
@@ -42,17 +42,17 @@
         {{ _("The analysis mode hasn't started yet.") }}
         </p>
         <p>
-        {{ _("The analysis mode will start at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.analysis_start, timezone, locale=locale), "stop_time": format_datetime_smart(contest.analysis_stop, timezone, locale=locale)} }}
+        {{ _("The analysis mode will start at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.analysis_start, timezone, translation=translation), "stop_time": format_datetime_smart(contest.analysis_stop, timezone, translation=translation)} }}
   {% elif phase == +2 %}
         {{ _("The analysis mode is currently running.") }}
         </p>
         <p>
-        {{ _("The analysis mode started at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.analysis_start, timezone, locale=locale), "stop_time": format_datetime_smart(contest.analysis_stop, timezone, locale=locale)} }}
+        {{ _("The analysis mode started at %(start_time)s and will end at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.analysis_start, timezone, translation=translation), "stop_time": format_datetime_smart(contest.analysis_stop, timezone, translation=translation)} }}
   {% elif phase == +3 %}
         {{ _("The analysis mode has already ended.") }}
         </p>
         <p>
-        {{ _("The analysis mode started at %(start_time)s and ended at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.analysis_start, timezone, locale=locale), "stop_time": format_datetime_smart(contest.analysis_stop, timezone, locale=locale)} }}
+        {{ _("The analysis mode started at %(start_time)s and ended at %(stop_time)s.") % {"start_time": format_datetime_smart(contest.analysis_start, timezone, translation=translation), "stop_time": format_datetime_smart(contest.analysis_stop, timezone, translation=translation)} }}
   {% end %}
         </p>
 
@@ -84,7 +84,7 @@
         <p>
         {{ _("You have a set of tokens shared among all tasks.") }}
         {% set tokens = {k[6:]: v for k, v in iteritems(contest.__dict__) if k.startswith("token_")} %}
-        {{ format_token_rules(tokens, locale=locale) }}
+        {{ format_token_rules(tokens, translation=translation) }}
         </p>
 
         <p>
@@ -95,7 +95,7 @@
         <p>
         {% raw _("You have two types of tokens: a set of <em>contest-tokens</em> shared among all tasks and a distinct set of <em>task-tokens</em> for each task.") %}
         {% set tokens = {k[6:]: v for k, v in iteritems(contest.__dict__) if k.startswith("token_")} %}
-        {{ format_token_rules(tokens, t_type="contest", locale=locale) }}
+        {{ format_token_rules(tokens, t_type="contest", translation=translation) }}
         {{ _("You can find the rules for the %(type_pl)s on each task's description page.") % {"type_pl": _("task-tokens")} }}
         </p>
 
@@ -124,7 +124,7 @@
         <div class="well per_user_time">
             <p>
         {% comment TODO would be very nice to write something like "just for 3 consecutive hours"... %}
-        {{ _("Every user is allowed to compete (i.e. submit solutions) for a uninterrupted time frame of %(per_user_time)s.") % {"per_user_time": format_amount_of_time(contest.per_user_time.total_seconds(), precision=-1, locale=locale)} }}
+        {{ _("Every user is allowed to compete (i.e. submit solutions) for a uninterrupted time frame of %(per_user_time)s.") % {"per_user_time": format_amount_of_time(contest.per_user_time.total_seconds(), precision=-1, translation=translation)} }}
             </p>
 
             <p>
@@ -135,16 +135,16 @@
         {{ _("By clicking on the button below you can start your time frame.") }}
         {{ _("Once you start, you can submit solutions until the end of the time frame or until the end of the contest, whatever comes first.") }}
     {% elif actual_phase == 0 %}
-        {{ _("You started your time frame at %(start_time)s.") % {"start_time": format_datetime_smart(current_user.starting_time, timezone, locale=locale)} }}
+        {{ _("You started your time frame at %(start_time)s.") % {"start_time": format_datetime_smart(current_user.starting_time, timezone, translation=translation)} }}
         {{ _("You can submit solutions until the end of the time frame or until the end of the contest, whatever comes first.") }}
     {% elif actual_phase == +1 %}
-        {{ _("You started your time frame at %(start_time)s and you already finished it.") % {"start_time": format_datetime_smart(current_user.starting_time, timezone, locale=locale)} }}
+        {{ _("You started your time frame at %(start_time)s and you already finished it.") % {"start_time": format_datetime_smart(current_user.starting_time, timezone, translation=translation)} }}
         {{ _("There's nothing you can do now.") }}
     {% elif actual_phase == +2 %}
         {% if current_user.starting_time is None %}
             {{ _("You never started your time frame. Now it's too late.") }}
         {% else %}
-            {{ _("You started your time frame at %(start_time)s and you already finished it.") % {"start_time": format_datetime_smart(current_user.starting_time, timezone, locale=locale)} }}
+            {{ _("You started your time frame at %(start_time)s and you already finished it.") % {"start_time": format_datetime_smart(current_user.starting_time, timezone, translation=translation)} }}
         {% end %}
         {{ _("There's nothing you can do now.") }}
     {% end %}

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -79,12 +79,12 @@
     {% for p_idx, p in enumerate(sorted(printjobs, key=lambda p: p.timestamp, reverse=True)) %}
         <tr>
         {% if show_date %}
-            <td class="datetime">{{ format_datetime(p.timestamp, timezone, locale=locale) }}</td>
+            <td class="datetime">{{ format_datetime(p.timestamp, timezone, translation=translation) }}</td>
         {% else %}
-            <td class="time">{{ format_time(p.timestamp, timezone, locale=locale) }}</td>
+            <td class="time">{{ format_time(p.timestamp, timezone, translation=translation) }}</td>
         {% end %}
             <td class="filename">{{ p.filename }}</td>
-            <td class="status">{{ format_status_text(p.status) if p.done else _("Preparing...") }}</td>
+            <td class="status">{{ format_status_text(p.status, translation=translation) if p.done else _("Preparing...") }}</td>
         </tr>
     {% end %}
 {% end %}

--- a/cms/server/contest/templates/submission_details.html
+++ b/cms/server/contest/templates/submission_details.html
@@ -16,7 +16,7 @@
     <tbody>
         <tr>
             <th>{{ _("Compilation outcome:") }}</th>
-            <td>{{ format_status_text(sr.compilation_text, _) }}</td>
+            <td>{{ format_status_text(sr.compilation_text, translation=translation) }}</td>
         </tr>
         <tr>
             <th>{{ _("Compilation time:") }}</th>
@@ -33,7 +33,7 @@
 {% if sr.compilation_memory is None %}
     {{ _("N/A") }}
 {% else %}
-    {{ format_size(sr.compilation_memory, _) }}
+    {{ format_size(sr.compilation_memory, translation=translation) }}
 {% end %}
             </td>
         </tr>

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -1,7 +1,7 @@
 {% if show_date %}
-    {% set col1 = "<td class=\"datetime\">%s</td>" % format_datetime(s.timestamp, timezone, locale=locale) %}
+    {% set col1 = "<td class=\"datetime\">%s</td>" % format_datetime(s.timestamp, timezone, translation=translation) %}
 {% else %}
-    {% set col1 = "<td class=\"time\">%s</td>" % format_time(s.timestamp, timezone, locale=locale) %}
+    {% set col1 = "<td class=\"time\">%s</td>" % format_time(s.timestamp, timezone, translation=translation) %}
 {% end %}
 {% if sr is None or not sr.compiled() %}
 <tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.COMPILING }}">
@@ -62,14 +62,14 @@
 
     {% if score_type.max_public_score > 0 %}
     <td class="public_score {{ get_score_class(sr.public_score, score_type.max_public_score) }}">
-        {{ score_type.format_score(sr.public_score, score_type.max_public_score, sr.public_score_details, task.score_precision, _) }}
+        {{ score_type.format_score(sr.public_score, score_type.max_public_score, sr.public_score_details, task.score_precision, translation=translation) }}
     </td>
     {% end %}
 
     {% if score_type.max_public_score != score_type.max_score %}
         {% if s.token is not None or actual_phase == 3 %}
     <td class="total_score {{ get_score_class(sr.score, score_type.max_score) }}">
-        {{ score_type.format_score(sr.score, score_type.max_score, sr.score_details, task.score_precision, _) }}
+        {{ score_type.format_score(sr.score, score_type.max_score, sr.score_details, task.score_precision, translation=translation) }}
     </td>
         {% else %}
     <td class="total_score undefined">

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -146,7 +146,7 @@
     {% elif tokens_contest == 2 %}
         <p>
         {% set tokens = {k[6:]: v for k, v in iteritems(task.__dict__) if k.startswith("token_")} %}
-        {{ format_token_rules(tokens, locale=locale) }}
+        {{ format_token_rules(tokens, translation=translation) }}
         </p>
     {% elif tokens_tasks == 2 %}
         <p>
@@ -155,7 +155,7 @@
     {% else %}
         <p>
         {% set tokens = {k[6:]: v for k, v in iteritems(task.__dict__) if k.startswith("token_")} %}
-        {{ format_token_rules(tokens, t_type="task", locale=locale) }}
+        {{ format_token_rules(tokens, t_type="task", translation=translation) }}
         </p>
 
         <p>
@@ -195,7 +195,7 @@
             {% end %}
                     <span class="first_line">
                         <span class="name">{{ filename }}</span>
-                        <span class="size">{{ format_size(file_size, _) }}</span>
+                        <span class="size">{{ format_size(file_size, translation=translation) }}</span>
                     </span>
             {% if type_icon is not None %}
                     <span class="type">{{ _(type_name) }}</span>

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -176,11 +176,11 @@ $(document).ready(function () {
             {{ _("Right now, you have %(tokens)s tokens available on this task.") % { "tokens": tokens_info[0]} }}
         {% end %}
         {% if need_to_wait %}
-            {% set t = format_datetime_smart(tokens_info[2], timezone, locale=locale) %}
+            {% set t = format_datetime_smart(tokens_info[2], timezone, translation=translation) %}
             {% raw _("But you have to wait until %(expiration_time)s to use them.") % {"expiration_time": t} %}
         {% end %}
         {% if tokens_info[1] is not None %}
-            {% set t = format_datetime_smart(tokens_info[1], timezone, locale=locale) %}
+            {% set t = format_datetime_smart(tokens_info[1], timezone, translation=translation) %}
             {{ _("You will receive a new token at %(gen_time)s.") % {"gen_time": t} }}
         {% else %}
             {{ _("In the current situation, no more tokens will be generated.") }}
@@ -188,10 +188,10 @@ $(document).ready(function () {
     {% else %}
         {{ _("Right now, you do not have tokens available for this task.") }}
         {% if actual_phase == 0 and tokens_info[1] is not None %}
-            {% set t = format_datetime_smart(tokens_info[1], timezone, locale=locale) %}
+            {% set t = format_datetime_smart(tokens_info[1], timezone, translation=translation) %}
             {{ _("You will receive a new token at %(gen_time)s.") % {"gen_time": t} }}
             {% if tokens_info[2] is not None and tokens_info[2] > tokens_info[1] %}
-                {% set t = format_datetime_smart(tokens_info[2], timezone, locale=locale) %}
+                {% set t = format_datetime_smart(tokens_info[2], timezone, translation=translation) %}
                 {{ _("But you will have to wait until %(expiration_time)s to use it.") % {"expiration_time": t} }}
             {% end %}
         {% else %}

--- a/cms/server/contest/templates/user_test_details.html
+++ b/cms/server/contest/templates/user_test_details.html
@@ -6,7 +6,7 @@
 
 {% if tr is not None and tr.evaluated() %}
 <h3>{{ _("Evaluation outcome") }}</h3>{% comment TODO: trim long outputs and add facility to see raw %}
-<pre>{{ format_status_text(tr.evaluation_text, _) }}</pre>
+<pre>{{ format_status_text(tr.evaluation_text, translation=translation) }}</pre>
 {% end %}
 
 {% if tr is not None and tr.compiled() %}
@@ -15,7 +15,7 @@
     <tbody>
         <tr>
             <th>{{ _("Compilation outcome:") }}</th>
-            <td>{{ format_status_text(tr.compilation_text, _) }}</td>
+            <td>{{ format_status_text(tr.compilation_text, translation=translation) }}</td>
         </tr>
         <tr>
             <th>{{ _("Compilation time:") }}</th>
@@ -32,7 +32,7 @@
 {% if tr.compilation_memory is None %}
     {{ _("N/A") }}
 {% else %}
-    {{ format_size(tr.compilation_memory, _) }}
+    {{ format_size(tr.compilation_memory, translation=translation) }}
 {% end %}
             </td>
         </tr>

--- a/cms/server/contest/templates/user_test_row.html
+++ b/cms/server/contest/templates/user_test_row.html
@@ -1,9 +1,9 @@
 {% from cms.server.contest.formatting import format_size %}
 {% from cms.locale import locale_format %}
 {% if show_date %}
-    {% set col1 = "<td class=\"datetime\">%s</td>" % format_datetime(t.timestamp, timezone, locale=locale) %}
+    {% set col1 = "<td class=\"datetime\">%s</td>" % format_datetime(t.timestamp, timezone, translation=translation) %}
 {% else %}
-    {% set col1 = "<td class=\"time\">%s</td>" % format_time(t.timestamp, timezone, locale=locale) %}
+    {% set col1 = "<td class=\"time\">%s</td>" % format_time(t.timestamp, timezone, translation=translation) %}
 {% end %}
 {% if tr is None or not tr.compiled() %}
 <tr data-user-test="{{ t_idx }}" data-status="1">
@@ -47,7 +47,7 @@
     </td>
 {% else %}
     <td class="memory">
-        {{ format_size(tr.execution_memory, _) }}
+        {{ format_size(tr.execution_memory, translation=translation) }}
     </td>
 {% end %}
     <td class="input">

--- a/cmscommon/isocodes.py
+++ b/cmscommon/isocodes.py
@@ -82,22 +82,22 @@ def is_language_code(code):
     return code in _language_codes
 
 
-def translate_language_code(code, locale):
+def translate_language_code(code, translation):
     if code not in _language_codes:
         raise ValueError("Language code not recognized.")
 
-    return locale.translate(_language_codes[code]).split(';')[0]
+    return translation.gettext(_language_codes[code]).split(';')[0]
 
 
 def is_country_code(code):
     return code in _country_codes
 
 
-def translate_country_code(code, locale):
+def translate_country_code(code, translation):
     if code not in _country_codes:
         raise ValueError("Country code not recognized.")
 
-    return locale.translate(_country_codes[code]).split(';')[0]
+    return translation.gettext(_country_codes[code]).split(';')[0]
 
 
 def is_language_country_code(code):
@@ -109,12 +109,12 @@ def is_language_country_code(code):
     return True
 
 
-def translate_language_country_code(code, locale):
+def translate_language_country_code(code, translation):
     tokens = code.split('_')
     if len(tokens) != 2 or \
             tokens[0] not in _language_codes or \
             tokens[1] not in _country_codes:
         raise ValueError("Language and country code not recognized.")
 
-    return "%s (%s)" % (translate_language_code(tokens[0], locale),
-                        translate_country_code(tokens[1], locale))
+    return "%s (%s)" % (translate_language_code(tokens[0], translation),
+                        translate_country_code(tokens[1], translation))

--- a/cmstestsuite/unit_tests/grading/__init__.py
+++ b/cmstestsuite/unit_tests/grading/__init__.py
@@ -36,7 +36,8 @@ from cms.grading import Sandbox, WHITES, \
 
 
 class DummyTranslation(object):
-    def gettext(self, s):
+    @staticmethod
+    def gettext(s):
         if len(s) == 0:
             return "the headers of the po file"
         return s.replace("A", "E")

--- a/cmstestsuite/unit_tests/grading/__init__.py
+++ b/cmstestsuite/unit_tests/grading/__init__.py
@@ -35,13 +35,17 @@ from cms.grading import Sandbox, WHITES, \
     format_status_text, merge_evaluation_results, white_diff
 
 
-class TestFormatStatusText(unittest.TestCase):
-
-    @staticmethod
-    def _tr(s):
+class DummyTranslation(object):
+    def gettext(self, s):
         if len(s) == 0:
             return "the headers of the po file"
         return s.replace("A", "E")
+
+
+class TestFormatStatusText(unittest.TestCase):
+
+    def setUp(self):
+        self._tr = DummyTranslation()
 
     def test_success_no_placeholders(self):
         self.assertEqual(format_status_text([]), "N/A")


### PR DESCRIPTION
Fix the chaos of some formatting functions expecting an overloaded
translate function (i.e., one that works both as gettext and as
ngettext) and others expecting a Tornado Locale object. Provide our own
Translation object that uses Babel behind the scenes. It is quite bare
(for now).

This also means stopping using Tornado's "magic" where accessing the
locale attribute on the handler automatically calls the get_user_locale
method (and, as a fallback, the built-in get_browser_locale method).
Instead we explicitly call a setup_locale method that does basically
the same things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/837)
<!-- Reviewable:end -->
