### PR TITLE
Use Babel instead of using pytz (directly)

### DIFF
--- a/cmscommon/datetime.py
+++ b/cmscommon/datetime.py
@@ -24,20 +24,20 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from future.builtins.disabled import *
 from future.builtins import *
-from six import iteritems
 
 import os
-import sys
 import time
-from datetime import tzinfo, timedelta, datetime
-from pytz import timezone, all_timezones
+import sys
+from datetime import datetime
+
+import babel.dates
 
 
 __all__ = [
     "make_datetime", "make_timestamp",
     "get_timezone", "get_system_timezone",
 
-    "utc",
+    "utc", "local",
 
     "monotonic_time",
     ]
@@ -76,6 +76,10 @@ def make_timestamp(_datetime=None):
         return (_datetime - EPOCH).total_seconds()
 
 
+utc = babel.dates.UTC
+local = babel.dates.LOCALTZ
+
+
 def get_timezone(user, contest):
     """Return the timezone for the given user and contest
 
@@ -85,10 +89,16 @@ def get_timezone(user, contest):
     return (tzinfo): the timezone information for the user.
 
     """
-    if user.timezone is not None and user.timezone in all_timezones:
-        return timezone(user.timezone)
-    if contest.timezone is not None and contest.timezone in all_timezones:
-        return timezone(contest.timezone)
+    if user.timezone is not None:
+        try:
+            return babel.dates.get_timezone(user.timezone)
+        except LookupError:
+            pass
+    if contest.timezone is not None:
+        try:
+            return babel.dates.get_timezone(contest.timezone)
+        except LookupError:
+            pass
     return local
 
 
@@ -102,89 +112,9 @@ def get_system_timezone():
         strings in the form Europe/Rome, or None if nothing is found.
 
     """
-    if time.daylight:
-        local_offset = time.altzone
-        localtz = time.tzname[1]
-    else:
-        local_offset = time.timezone
-        localtz = time.tzname[0]
-
-    local_offset = timedelta(seconds=-local_offset)
-
-    for name in all_timezones:
-        tz = timezone(name)
-        if not hasattr(tz, '_tzinfos'):
-            continue
-        for (utcoffset, daylight, tzname), _ in iteritems(tz._tzinfos):
-            if utcoffset == local_offset and tzname == localtz:
-                return name
-
-    return None
-
-
-# The following code provides some sample timezone implementations
-# (i.e. tzinfo subclasses). It has been copied (almost) verbatim
-# from the official datetime module documentation:
-# http://docs.python.org/library/datetime.html#tzinfo-objects
-
-ZERO = timedelta(0)
-HOUR = timedelta(hours=1)
-
-
-# A UTC class.
-
-class UTC(tzinfo):
-    """UTC"""
-
-    def utcoffset(self, dt):
-        return ZERO
-
-    def tzname(self, dt):
-        return "UTC"
-
-    def dst(self, dt):
-        return ZERO
-
-utc = UTC()
-
-
-# A class capturing the platform's idea of local time.
-
-STDOFFSET = timedelta(seconds=-time.timezone)
-if time.daylight:
-    DSTOFFSET = timedelta(seconds=-time.altzone)
-else:
-    DSTOFFSET = STDOFFSET
-
-DSTDIFF = DSTOFFSET - STDOFFSET
-
-
-class LocalTimezone(tzinfo):
-
-    def utcoffset(self, dt):
-        if self._isdst(dt):
-            return DSTOFFSET
-        else:
-            return STDOFFSET
-
-    def dst(self, dt):
-        if self._isdst(dt):
-            return DSTDIFF
-        else:
-            return ZERO
-
-    def tzname(self, dt):
-        return time.tzname[self._isdst(dt)]
-
-    def _isdst(self, dt):
-        tt = (dt.year, dt.month, dt.day,
-              dt.hour, dt.minute, dt.second,
-              dt.weekday(), 0, 0)
-        stamp = time.mktime(tt)
-        tt = time.localtime(stamp)
-        return tt.tm_isdst > 0
-
-local = LocalTimezone()
+    if hasattr(local, 'zone'):
+        return local.zone
+    return local.tzname(make_datetime())
 
 
 if sys.version_info >= (3, 3):
@@ -204,6 +134,7 @@ if sys.version_info >= (3, 3):
         return (float): the value of the clock, in seconds.
 
         """
+        # Raw means it's immune even to NTP time adjustments.
         return time.clock_gettime(time.CLOCK_MONOTONIC_RAW)
 
 # Taken from http://bugs.python.org/file19461/monotonic.py and
@@ -214,7 +145,7 @@ else:
         pointer
     from ctypes.util import find_library
 
-    # Raw means it's immune even to NTP time adjustements.
+    # Raw means it's immune even to NTP time adjustments.
     CLOCK_MONOTONIC_RAW = 4
 
     class timespec(Structure):

--- a/cmscommon/datetime.py
+++ b/cmscommon/datetime.py
@@ -103,13 +103,11 @@ def get_timezone(user, contest):
 
 
 def get_system_timezone():
-    """Return the timezone of the system.
+    """Return the name of the system timezone.
 
-    See http://stackoverflow.com/questions/7669938/
-        get-the-olson-tz-name-for-the-local-timezone
-
-    return (unicode|None): one among the possible timezone description
-        strings in the form Europe/Rome, or None if nothing is found.
+    return (unicode): the "best" description of the timezone of the
+        local system clock that we were able to find, in a format like
+        "Europe/Rome", "CET", etc.
 
     """
     if hasattr(local, 'zone'):

--- a/cmstestsuite/unit_tests/locale/locale.py
+++ b/cmstestsuite/unit_tests/locale/locale.py
@@ -31,13 +31,13 @@ from future.builtins import *
 import unittest
 from datetime import datetime, timedelta
 
-import pytz
+import babel.dates
 
 from cms.locale import Translation, DEFAULT_TRANSLATION
 
 
-UTC = pytz.utc
-ROME = pytz.timezone("Europe/Rome")
+UTC = babel.dates.UTC
+ROME = babel.dates.get_timezone("Europe/Rome")
 
 ENGLISH = DEFAULT_TRANSLATION
 FRENCH = Translation("fr")

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -206,9 +206,9 @@ To install CMS and its Python dependencies on Ubuntu, you can issue:
 
     sudo apt-get install python3-setuptools python3-tornado python3-psycopg2 \
          python3-sqlalchemy python3-psutil python3-netifaces python3-crypto \
-         python3-tz python3-six python3-bs4 python3-coverage python3-mock \
-         python3-requests python3-werkzeug python3-gevent python3-bcrypt \
-         python3-chardet patool python3-ipaddress python3-babel
+         python3-six python3-bs4 python3-coverage python3-mock python3-requests \
+         python3-werkzeug python3-gevent python3-bcrypt python3-chardet patool \
+         python3-ipaddress python3-babel
 
     # Optional.
     # sudo apt-get install python3-yaml python3-sphinx python3-cups python3-pypdf2
@@ -228,9 +228,9 @@ To install CMS python dependencies on Arch Linux (again: assuming you did not us
 
     sudo pacman -S --needed python-setuptools python-tornado python-psycopg2 \
          python-sqlalchemy python-psutil python-netifaces python-crypto \
-         python-pytz python-six python-beautifulsoup4 python-coverage \
-         python-mock python-requests python-werkzeug python-gevent \
-         python-bcrypt python-chardet python-ipaddress python-babel
+         python-six python-beautifulsoup4 python-coverage python-mock \
+         python-requests python-werkzeug python-gevent python-bcrypt \
+         python-chardet python-ipaddress python-babel
 
     # Install the following from AUR.
     # https://aur.archlinux.org/packages/patool/

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ psycopg2>=2.7,<2.8  # http://initd.org/psycopg/articles/tag/release/
 sqlalchemy>=1.1,<1.2  # http://docs.sqlalchemy.org/en/latest/changelog/index.html
 netifaces>=0.10,<0.11  # https://bitbucket.org/al45tair/netifaces/src/
 pycrypto>=2.6,<2.7  # https://github.com/dlitz/pycrypto/blob/master/ChangeLog
-pytz  # https://pypi.python.org/pypi/pytz
 psutil>=5.4,<5.5  # https://github.com/giampaolo/psutil/blob/master/HISTORY.rst
 six>=1.11,<1.12  # https://github.com/benjaminp/six/blob/master/CHANGES
 requests>=2.18,<2.19  # https://pypi.python.org/pypi/requests


### PR DESCRIPTION
Babel wraps and enhances pytz: we can use its tools instead of some of
our own machinery and remove our (explicit) dependency on pytz.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/842)
<!-- Reviewable:end -->
