### PR TITLE
Improve retrieval of information from shared-mime-info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ addons:
       - fp-units-rtl
       - postgresql-client
       - python2.7
-      - shared-mime-info
       - stl-manual
       - cgroup-lite
       - libcap-dev

--- a/cms/conf.py
+++ b/cms/conf.py
@@ -137,6 +137,12 @@ class Config(object):
         self.max_submission_length = 100000
         self.max_input_length = 5000000
         self.stl_path = "/usr/share/doc/stl-manual/html/"
+        # Prefix of 'shared-mime-info'[1] installation. It can be found
+        # out using `pkg-config --variable=prefix shared-mime-info`, but
+        # it's almost universally the same (i.e. '/usr') so it's hardly
+        # necessary to change it.
+        # [1] http://freedesktop.org/wiki/Software/shared-mime-info
+        self.shared_mime_info_prefix = "/usr"
 
         # AdminWebServer.
         self.admin_listen_address = ""

--- a/cms/conf.py
+++ b/cms/conf.py
@@ -137,12 +137,6 @@ class Config(object):
         self.max_submission_length = 100000
         self.max_input_length = 5000000
         self.stl_path = "/usr/share/doc/stl-manual/html/"
-        # Prefix of 'shared-mime-info'[1] installation. It can be found
-        # out using `pkg-config --variable=prefix shared-mime-info`, but
-        # it's almost universally the same (i.e. '/usr') so it's hardly
-        # necessary to change it.
-        # [1] http://freedesktop.org/wiki/Software/shared-mime-info
-        self.shared_mime_info_prefix = "/usr"
 
         # AdminWebServer.
         self.admin_listen_address = ""

--- a/cms/locale/__init__.py
+++ b/cms/locale/__init__.py
@@ -24,11 +24,10 @@ from future.builtins.disabled import *
 from future.builtins import *
 
 from .locale import \
-    get_system_translations, Translation, DEFAULT_TRANSLATION, \
-    get_translations, filter_language_codes
+    Translation, DEFAULT_TRANSLATION, get_translations, filter_language_codes
 
 
 __all__ = [
-    "get_system_translations", "Translation", "DEFAULT_TRANSLATION",
-    "get_translations", "filter_language_codes"
+    "Translation", "DEFAULT_TRANSLATION", "get_translations",
+    "filter_language_codes"
 ]

--- a/cms/locale/locale.py
+++ b/cms/locale/locale.py
@@ -33,17 +33,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-
-import copy
-
-import math
 from future.builtins.disabled import *
 from future.builtins import *
 import six
 
-import pkg_resources
+import copy
 import logging
+import math
 import os
+import pkg_resources
 
 import babel.core
 import babel.dates
@@ -75,7 +73,8 @@ class Translation(object):
         else:
             self.translation = babel.support.NullTranslations()
         self.mimetype_translation = babel.support.Translations.load(
-            domain="shared-mime-info", locales=[self.locale])
+            os.path.join(config.shared_mime_info_prefix, "share", "locale"),
+            [self.locale], "shared-mime-info")
 
     @property
     def identifier(self):

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -190,8 +190,8 @@
                         <span class="name">{{ filename }}</span>
                         <span class="size">{{ translation.format_size(file_size) }}</span>
                     </span>
-            {% if type_icon is not None %}
-                    <span class="type">{{ _(type_name) }}</span>
+            {% if type_name is not None %}
+                    <span class="type">{{ translation.translate_mimetype(type_name) }}</span>
             {% end %}
                 </a>
             </li>

--- a/cmscommon/mimetypes.py
+++ b/cmscommon/mimetypes.py
@@ -21,16 +21,16 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+
+import errno
 from future.builtins.disabled import *
 from future.builtins import *
 
 import io
 import os.path
-import fnmatch
-import mimetypes
-from xml import sax
-from xml.sax.handler import ContentHandler
-from xml.dom import XML_NAMESPACE as _XML_NS
+
+import xdg.BaseDirectory
+import xdg.Mime
 
 
 __all__ = [
@@ -39,108 +39,34 @@ __all__ = [
     ]
 
 
-_XDG_NS = "http://www.freedesktop.org/standards/shared-mime-info"
-
-# We need the config to access the shared_mime_info_prefix value. It
-# would be better not to depend on cms (i.e. be standalone). The best
-# solution would be to get the prefix at installation-time (using
-# pkgconfig), like many C libraries/applications do, and store it
-# somehow. Yet, I don't know what's the best way to do this in Python...
-from cms import config
+_icons = dict()
 
 
-# FIXME the following code doesn't take comments into account.
-# FIXME the specification requires to look in XDG_DATA_HOME and
-# XDG_DATA_DIRS instead of the installation dir of shared-mime-info...
-# TODO use python-xdg (or similar libraries) instead of doing the
-# parsing ourselves. they also provide ways to find the MIME type.
-
-_aliases = dict(tuple(l.strip().split()) for l in
-                io.open(os.path.join(config.shared_mime_info_prefix,
-                                     "share", "mime", "aliases"),
-                        "rt", encoding="utf-8").readlines())
-
-_icons = dict(tuple(l.strip().split(':')) for l in
-              io.open(os.path.join(config.shared_mime_info_prefix,
-                                   "share", "mime", "generic-icons"),
-                      "rt", encoding="utf-8").readlines())
-
-_types = list(l.strip() for l in
-              io.open(os.path.join(config.shared_mime_info_prefix,
-                                   "share", "mime", "types"),
-                      "rt", encoding="utf-8").readlines())
-
-_comments = dict()
+for dir in reversed([xdg.BaseDirectory.xdg_data_home]
+                    + xdg.BaseDirectory.xdg_data_dirs):
+    try:
+        with io.open(os.path.join(dir, "mime", "generic-icons"), "rt") as f:
+            _icons.update(tuple(l.strip().split(':')) for l in f.readlines())
+    except IOError as err:
+        if err.errno != errno.ENOENT:
+            raise
 
 
-class _get_comment(ContentHandler):
-    def __init__(self):
-        self.inside = False
-        self.result = None
-
-    def startElementNS(self, name, qname, attrs):
-        if name == (_XDG_NS, "comment") and \
-                ((_XML_NS, "lang") not in attrs or
-                 attrs[(_XML_NS, "lang")] in ["en", "en_US"]):
-            self.inside = True
-            self.result = ''
-
-    def endElementNS(self, name, qname):
-        self.inside = False
-
-    def characters(self, content):
-        if self.inside:
-            self.result += content
+def get_icon_for_type(typename):
+    mimetype = xdg.Mime.lookup(typename).canonical()
+    typename = "%s/%s" % (mimetype.media, mimetype.subtype)
+    if typename in _icons:
+        return _icons[typename]
+    return mimetype.media + "-x-generic"
 
 
-def get_icon_for_type(name):
-    if name in _aliases:
-        name = _aliases[name]
-    if name not in _types:
+def get_name_for_type(typename):
+    mimetype = xdg.Mime.lookup(typename).canonical()
+    return mimetype.get_comment()
+
+
+def get_type_for_file_name(filename):
+    mimetype = xdg.Mime.get_type_by_name(filename).canonical()
+    if mimetype is None:
         return None
-
-    if name in _icons:
-        return _icons[name]
-    return name[:name.index('/')] + "-x-generic"
-
-
-def get_name_for_type(name):
-    if name in _aliases:
-        name = _aliases[name]
-    if name not in _types:
-        return None
-
-    if name not in _comments:
-        try:
-            media, subtype = name.split('/')
-            path = os.path.join(config.shared_mime_info_prefix,
-                                'share', 'mime', media, "%s.xml" % subtype)
-
-            handler = _get_comment()
-            parser = sax.make_parser()
-            parser.setContentHandler(handler)
-            parser.setFeature(sax.handler.feature_namespaces, 1)
-            parser.parse(path)
-
-            _comments[name] = handler.result
-        except:
-            pass
-
-    if name in _comments:
-        return _comments[name]
-
-
-def get_type_for_file_name(name):
-    # Provide support for some commonly used types and fallback on
-    # Python's mimetypes module. In the future we could be using a
-    # proper library here (i.e. an interface to shared-mime-info).
-    for glob, mime in [('*.tar.gz', 'application/x-compressed-tar'),
-                       ('*.tar.bz2', 'application/x-bzip-compressed-tar'),
-                       ('*.c', 'text/x-csrc'),
-                       ('*.h', 'text/x-chdr'),
-                       ('*.cpp', 'text/x-c++src'),
-                       ('*.hpp', 'text/x-c++hdr'),
-                       ('*.pas', 'text/x-pascal')]:
-        if fnmatch.fnmatchcase(name, glob):
-            return mime
-    return mimetypes.guess_type(name)[0]
+    return "%s/%s" % (mimetype.media, mimetype.subtype)

--- a/cmscommon/mimetypes.py
+++ b/cmscommon/mimetypes.py
@@ -39,20 +39,31 @@ __all__ = [
     ]
 
 
-_icons = dict()
+def _retrieve_icons():
+    res = dict()
+    for d in reversed([xdg.BaseDirectory.xdg_data_home]
+                      + xdg.BaseDirectory.xdg_data_dirs):
+        try:
+            with io.open(os.path.join(d, "mime", "generic-icons"), "rt") as f:
+                res.update(tuple(l.strip().split(':')) for l in f.readlines())
+        except IOError as err:
+            if err.errno != errno.ENOENT:
+                raise
+    return res
 
 
-for d in reversed([xdg.BaseDirectory.xdg_data_home]
-                  + xdg.BaseDirectory.xdg_data_dirs):
-    try:
-        with io.open(os.path.join(d, "mime", "generic-icons"), "rt") as f:
-            _icons.update(tuple(l.strip().split(':')) for l in f.readlines())
-    except IOError as err:
-        if err.errno != errno.ENOENT:
-            raise
+_icons = _retrieve_icons()
 
 
 def get_icon_for_type(typename):
+    """Get a generic icon name for the given MIME type.
+
+    typename (str): a MIME type, e.g., "application/pdf".
+
+    return (str): the generic icon that best depicts the given MIME
+        type, e.g., "x-office-document".
+
+    """
     mimetype = xdg.Mime.lookup(typename).canonical()
     typename = "%s/%s" % (mimetype.media, mimetype.subtype)
     if typename in _icons:
@@ -61,11 +72,28 @@ def get_icon_for_type(typename):
 
 
 def get_name_for_type(typename):
+    """Get the natural language description of the MIME type.
+
+    typename (str): a MIME type, e.g., "application/pdf".
+
+    return (str): the human-readable description (also called comment)
+        of the given MIME type, e.g., "PDF document".
+
+    """
     mimetype = xdg.Mime.lookup(typename).canonical()
     return mimetype.get_comment()
 
 
 def get_type_for_file_name(filename):
+    """Guess the MIME type of a file given its name.
+
+    filename (str): the name of a file (just the base name, without the
+        directory name), e.g., "statement.pdf".
+
+    return (str): a guess of what MIME type that file might have, e.g.,
+        "application/pdf".
+
+    """
     mimetype = xdg.Mime.get_type_by_name(filename).canonical()
     if mimetype is None:
         return None

--- a/cmscommon/mimetypes.py
+++ b/cmscommon/mimetypes.py
@@ -90,8 +90,8 @@ def get_type_for_file_name(filename):
     filename (str): the name of a file (just the base name, without the
         directory name), e.g., "statement.pdf".
 
-    return (str): a guess of what MIME type that file might have, e.g.,
-        "application/pdf".
+    return (str|None): a guess of what MIME type that file might have,
+        e.g., "application/pdf".
 
     """
     mimetype = xdg.Mime.get_type_by_name(filename).canonical()

--- a/cmscommon/mimetypes.py
+++ b/cmscommon/mimetypes.py
@@ -42,10 +42,10 @@ __all__ = [
 _icons = dict()
 
 
-for dir in reversed([xdg.BaseDirectory.xdg_data_home]
-                    + xdg.BaseDirectory.xdg_data_dirs):
+for d in reversed([xdg.BaseDirectory.xdg_data_home]
+                  + xdg.BaseDirectory.xdg_data_dirs):
     try:
-        with io.open(os.path.join(dir, "mime", "generic-icons"), "rt") as f:
+        with io.open(os.path.join(d, "mime", "generic-icons"), "rt") as f:
             _icons.update(tuple(l.strip().split(':')) for l in f.readlines())
     except IOError as err:
         if err.errno != errno.ENOENT:

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -20,8 +20,6 @@ These are our requirements (in particular we highlight those that are not usuall
 
 * `libcg <http://libcg.sourceforge.net/>`_;
 
-* `shared-mime-info <http://freedesktop.org/wiki/Software/shared-mime-info>`_;
-
 * `TeX Live <https://www.tug.org/texlive/>`_ (only for printing);
 
 * `a2ps <https://www.gnu.org/software/a2ps/>`_ (only for printing).
@@ -58,8 +56,7 @@ On Ubuntu 16.04, one will need to run the following script to satisfy all depend
     # Feel free to change OpenJDK packages with your preferred JDK.
     sudo apt-get install build-essential openjdk-8-jre openjdk-8-jdk \
         fp-compiler fp-units-base fp-units-fcl fp-units-misc fp-units-math fp-units-rtl \
-        postgresql postgresql-client python3.6 \
-        shared-mime-info stl-manual cgroup-lite libcap-dev
+        postgresql postgresql-client python3.6 stl-manual cgroup-lite libcap-dev
 
     # Only if you are going to use pip/virtualenv to install python dependencies
     sudo apt-get install python3.6-dev libpq-dev libcups2-dev libyaml-dev \
@@ -77,8 +74,7 @@ On Arch Linux, unofficial AUR packages can be found: `cms <http://aur.archlinux.
 .. sourcecode:: bash
 
     sudo pacman -S base-devel jre8-openjdk jdk8-openjdk fpc \
-         postgresql postgresql-client python \
-         shared-mime-info libcap
+         postgresql postgresql-client python libcap
 
     # Install the following from AUR.
     # https://aur.archlinux.org/packages/libcgroup/
@@ -208,7 +204,7 @@ To install CMS and its Python dependencies on Ubuntu, you can issue:
          python3-sqlalchemy python3-psutil python3-netifaces python3-crypto \
          python3-six python3-bs4 python3-coverage python3-mock python3-requests \
          python3-werkzeug python3-gevent python3-bcrypt python3-chardet patool \
-         python3-ipaddress python3-babel
+         python3-ipaddress python3-babel python3-xdg
 
     # Optional.
     # sudo apt-get install python3-yaml python3-sphinx python3-cups python3-pypdf2
@@ -230,7 +226,7 @@ To install CMS python dependencies on Arch Linux (again: assuming you did not us
          python-sqlalchemy python-psutil python-netifaces python-crypto \
          python-six python-beautifulsoup4 python-coverage python-mock \
          python-requests python-werkzeug python-gevent python-bcrypt \
-         python-chardet python-ipaddress python-babel
+         python-chardet python-ipaddress python-babel python-xdg
 
     # Install the following from AUR.
     # https://aur.archlinux.org/packages/patool/

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ chardet>=3.0,<3.1  # https://pypi.python.org/pypi/chardet
 ipaddress>=1.0,<1.1  # https://pypi.python.org/pypi/ipaddress
 future>=0.15,<0.16  # https://pypi.python.org/pypi/future
 babel>=2.4,<2.5  # http://babel.pocoo.org/en/latest/changelog.html
+pyxdg>=0.25,<0.26  # https://freedesktop.org/wiki/Software/pyxdg/
 
 # Only for some importers:
 pyyaml>=3.12,<3.13  # http://pyyaml.org/wiki/PyYAML


### PR DESCRIPTION
We use shared-mime-info to get two types of information:
* The translations of the descriptions of MIME types (e.g., "PDF
  document" becomes "Documento PDF" in Italian). We used to specify the
  exact location of the .mo files containing them, but the domain name
  appears to be enough (I believe this was the case even before we
  started using Babel, it's just that we didn't know it).
* The list of all MIME types, possible aliases, their natural language
  descriptions and their icon names. We were manually parsing all the
  relevant system files, of which we needed to know the exact locations.
  The xdg library can do most of these tasks for us. It doesn't provide
  information about the generic icon names (yet?), which means we have
  to keep retrieving it by hand, but even there it can help us figure
  out where the files are located.

This, in fact, removes our direct dependency on shared-mime-info, as we
have good fallbacks in place. And, anyways, it comes preinstalled by
default on all modern platforms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/843)
<!-- Reviewable:end -->
