### PR TITLE
Start porting the CWS templates from Tornado to Jinja2

### DIFF
--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -146,6 +146,8 @@ class BaseHandler(CommonRequestHandler):
         ret["translation"] = self.translation
         ret["_"] = self._
 
+        ret["xsrf_form_html"] = self.xsrf_form_html()
+
         return ret
 
     def write_error(self, status_code, **kwargs):

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -86,6 +86,11 @@ class BaseHandler(CommonRequestHandler):
         self.render("contest_list.html", contest_list=contest_list,
                     **self.r_params)
 
+    def render(self, template_name, **params):
+        t = self.service.jinja2_environment.get_template(template_name)
+        for chunk in t.generate(**params):
+            self.write(chunk)
+
     def prepare(self):
         """This method is executed at the beginning of each request.
 

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -49,6 +49,7 @@ from werkzeug.http import parse_accept_header
 from cms.db import Contest
 from cms.locale import DEFAULT_TRANSLATION, choose_language_code
 from cms.server import CommonRequestHandler
+from cmscommon.datetime import utc as utc_tzinfo
 
 
 logger = logging.getLogger(__name__)
@@ -134,6 +135,7 @@ class BaseHandler(CommonRequestHandler):
         """
         ret = {}
         ret["now"] = self.timestamp
+        ret["utc"] = utc_tzinfo
         ret["url"] = self.url
 
         ret["available_translations"] = self.available_translations

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -45,6 +45,7 @@ import tornado.web
 
 from cms import config
 from cms.db import Participation, PrintJob, User
+from cms.grading import COMPILATION_MESSAGES, EVALUATION_MESSAGES
 from cms.server import actual_phase_required, filter_ascii, multi_contest
 from cmscommon.datetime import make_datetime, make_timestamp
 from cmscommon.crypto import validate_password
@@ -375,4 +376,7 @@ class DocumentationHandler(ContestHandler):
     @tornado.web.authenticated
     @multi_contest
     def get(self):
-        self.render("documentation.html", **self.r_params)
+        self.render("documentation.html",
+                    COMPILATION_MESSAGES=COMPILATION_MESSAGES,
+                    EVALUATION_MESSAGES=EVALUATION_MESSAGES,
+                    **self.r_params)

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -411,6 +411,7 @@ class TaskSubmissionsHandler(ContestHandler):
                     submissions_left=submissions_left,
                     submissions_download_allowed=
                         self.contest.submissions_download_allowed,
+                    SubmissionResult=SubmissionResult,
                     **self.r_params)
 
 

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -48,7 +48,8 @@ import tornado.web
 from sqlalchemy import func
 
 from cms import config
-from cms.db import Task, UserTest, UserTestFile, UserTestManager
+from cms.db import Task, UserTest, UserTestFile, UserTestManager, \
+    UserTestResult
 from cms.grading.languagemanager import get_language
 from cms.grading.tasktypes import get_task_type
 from cms.server import actual_phase_required, multi_contest
@@ -119,6 +120,7 @@ class UserTestInterfaceHandler(ContestHandler):
 
         self.render("test_interface.html", default_task=default_task,
                     user_tests=user_tests, user_tests_left=user_tests_left,
+                    UserTestResult=UserTestResult,
                     **self.r_params)
 
 

--- a/cms/server/contest/jinja2_toolbox.py
+++ b/cms/server/contest/jinja2_toolbox.py
@@ -34,8 +34,8 @@ from six import iteritems
 
 from jinja2 import PackageLoader
 
-import cms.grading.languagemanager
 from cmscommon.datetime import utc
+from cms.grading.languagemanager import get_language
 from cms.server.jinja2_toolbox import GLOBAL_ENVIRONMENT
 
 
@@ -50,7 +50,7 @@ def astimezone(dt, tz):
 
 def instrument_cms_toolbox(env):
     env.filters["extract_token_params"] = extract_token_params
-    env.filters["get_language"] = cms.grading.languagemanager.get_language
+    env.filters["get_language"] = get_language
     env.filters["astimezone"] = astimezone
 
 

--- a/cms/server/contest/jinja2_toolbox.py
+++ b/cms/server/contest/jinja2_toolbox.py
@@ -47,8 +47,13 @@ def instrument_cms_toolbox(env):
 
 
 CWS_ENVIRONMENT = GLOBAL_ENVIRONMENT.overlay(
+    # Allow the use of {% trans %} tags to localize strings.
     extensions=['jinja2.ext.i18n'],
+    # Load templates from CWS's package (use package rather than file
+    # system as that works even in case of a compressed distribution).
     loader=PackageLoader('cms.server.contest', 'templates'))
+# This compresses all leading/trailing whitespace and line breaks of
+# internationalized messages when translating and extracting them.
 CWS_ENVIRONMENT.policies['ext.i18n.trimmed'] = True
 
 

--- a/cms/server/contest/jinja2_toolbox.py
+++ b/cms/server/contest/jinja2_toolbox.py
@@ -30,13 +30,34 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from future.builtins.disabled import *
 from future.builtins import *
+from six import iteritems
 
 from jinja2 import PackageLoader
 
+import cms.grading.languagemanager
+from cmscommon.datetime import utc
 from cms.server.jinja2_toolbox import GLOBAL_ENVIRONMENT
+
+
+def extract_token_params(o):
+    return {k[6:]: v
+            for k, v in iteritems(o.__dict__) if k.startswith("token_")}
+
+
+def astimezone(dt, tz):
+    return dt.replace(tzinfo=utc).astimezone(tz).replace(tzinfo=None)
+
+
+def instrument_cms_toolbox(env):
+    env.filters["extract_token_params"] = extract_token_params
+    env.filters["get_language"] = cms.grading.languagemanager.get_language
+    env.filters["astimezone"] = astimezone
 
 
 CWS_ENVIRONMENT = GLOBAL_ENVIRONMENT.overlay(
     extensions=['jinja2.ext.i18n'],
     loader=PackageLoader('cms.server.contest', 'templates'))
 CWS_ENVIRONMENT.policies['ext.i18n.trimmed'] = True
+
+
+instrument_cms_toolbox(CWS_ENVIRONMENT)

--- a/cms/server/contest/jinja2_toolbox.py
+++ b/cms/server/contest/jinja2_toolbox.py
@@ -34,8 +34,6 @@ from six import iteritems
 
 from jinja2 import PackageLoader
 
-from cmscommon.datetime import utc
-from cms.grading.languagemanager import get_language
 from cms.server.jinja2_toolbox import GLOBAL_ENVIRONMENT
 
 
@@ -44,14 +42,8 @@ def extract_token_params(o):
             for k, v in iteritems(o.__dict__) if k.startswith("token_")}
 
 
-def astimezone(dt, tz):
-    return dt.replace(tzinfo=utc).astimezone(tz).replace(tzinfo=None)
-
-
 def instrument_cms_toolbox(env):
     env.filters["extract_token_params"] = extract_token_params
-    env.filters["get_language"] = get_language
-    env.filters["astimezone"] = astimezone
 
 
 CWS_ENVIRONMENT = GLOBAL_ENVIRONMENT.overlay(

--- a/cms/server/contest/jinja2_toolbox.py
+++ b/cms/server/contest/jinja2_toolbox.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Provide a Jinja2 environment tailored to CWS.
+
+Extend the global generic Jinja2 environment to inject tools that are
+useful specifically to the use that CWS makes of it.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *
+from future.builtins import *
+
+from jinja2 import PackageLoader
+
+from cms.server.jinja2_toolbox import GLOBAL_ENVIRONMENT
+
+
+CWS_ENVIRONMENT = GLOBAL_ENVIRONMENT.overlay(
+    extensions=['jinja2.ext.i18n'],
+    loader=PackageLoader('cms.server.contest', 'templates'))
+CWS_ENVIRONMENT.policies['ext.i18n.trimmed'] = True

--- a/cms/server/contest/server.py
+++ b/cms/server/contest/server.py
@@ -46,8 +46,8 @@ from future.builtins.disabled import *
 from future.builtins import *
 
 import logging
-import pkg_resources
 
+from cms.server.contest.jinja2_toolbox import CWS_ENVIRONMENT
 from cmscommon.binary import hex_to_bin, bin_to_b64
 from cms import ConfigError, ServiceCoord, config
 from cms.io import WebService
@@ -68,8 +68,6 @@ class ContestWebServer(WebService):
     """
     def __init__(self, shard, contest_id=None):
         parameters = {
-            "template_path": pkg_resources.resource_filename(
-                "cms.server.contest", "templates"),
             "static_files": [("cms.server", "static"),
                              ("cms.server.contest", "static")],
             "cookie_secret": hex_to_bin(config.secret_key),
@@ -105,6 +103,8 @@ class ContestWebServer(WebService):
             parameters,
             shard=shard,
             listen_address=listen_address)
+
+        self.jinja2_environment = CWS_ENVIRONMENT
 
         # This is a dictionary (indexed by username) of pending
         # notification. Things like "Yay, your submission went

--- a/cms/server/contest/templates/base.html
+++ b/cms/server/contest/templates/base.html
@@ -1,4 +1,3 @@
-{% from six import iterkeys, itervalues, iteritems %}
 <!DOCTYPE html>
 <html>
     <head>

--- a/cms/server/contest/templates/base.html
+++ b/cms/server/contest/templates/base.html
@@ -5,7 +5,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-        <title>{% block title %}{% end %}</title>
+        <title>{% block title %}{% endblock title %}</title>
 
         <link rel="shortcut icon" href="{{ url("static", "favicon.ico") }}" />
         <link rel="stylesheet" href="{{ url("static", "css", "bootstrap.css") }}">
@@ -15,9 +15,9 @@
         <script src="{{ url("static", "js", "bootstrap.js") }}"></script>
         <script src="{{ url("static", "cws_utils.js") }}"></script>
 
-        {% block js %}{% end %}
+        {% block js %}{% endblock js %}
     </head>
     <body>
-        {% block body %}{% end %}
+        {% block body %}{% endblock body %}
     </body>
 </html>

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -2,7 +2,6 @@
 {% block core %}
 <div class="span9">
 
-{% from cms import config %}
 
 <div class="page-header">
     <h1>{{ _("Communication") }}</h1>

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -10,7 +10,7 @@
 {% if len (contest.announcements) > 0 %}
 <h2>{{ _("Announcements") }}</h2>
 <div class="announcement_list">
-    {% for msg in reversed(contest.announcements) %}
+    {% for msg in contest.announcements|reverse %}
     <div class="announcement">
         {% if len(msg.subject) > 0 %}
         <h4 class="subject">{{ msg.subject }}</h4>
@@ -65,7 +65,7 @@
 
 {% if len (current_user.questions) > 0 %}
 <div class="question_list">
-    {% for msg in reversed(current_user.questions) %}
+    {% for msg in current_user.questions|reverse %}
     <div class="question">
         {% if len(msg.subject) > 0 %}
         <h4 class="subject">{{ msg.subject }}</h4>
@@ -104,7 +104,7 @@
 {% if len (current_user.messages) > 0 %}
 <h2>{{ _("Messages") }}</h2>
 <div class="message_list">
-    {% for msg in reversed(current_user.messages) %}
+    {% for msg in current_user.messages|reverse %}
     <div class="message">
         {% if len(msg.subject) > 0 %}
         <h4 class="subject">{{ msg.subject }}</h4>

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -7,18 +7,18 @@
     <h1>{{ _("Communication") }}</h1>
 </div>
 
-{% if len (contest.announcements) > 0 %}
+{% if contest.announcements|length > 0 %}
 <h2>{{ _("Announcements") }}</h2>
 <div class="announcement_list">
     {% for msg in contest.announcements|reverse %}
     <div class="announcement">
-        {% if len(msg.subject) > 0 %}
+        {% if msg.subject|length > 0 %}
         <h4 class="subject">{{ msg.subject }}</h4>
         {% else %}
         <h4 class="subject empty">{{ _("(no subject)") }}</h4>
         {% endif %}
         <span class="timestamp">{{ translation.format_datetime_smart(msg.timestamp, now, timezone) }}</span>
-        {% if len(msg.text) > 0 %}
+        {% if msg.text|length > 0 %}
         <div class="body">{{ msg.text }}</div>
         {% endif %}
     </div>
@@ -63,29 +63,29 @@
 </div>
 
 
-{% if len (current_user.questions) > 0 %}
+{% if current_user.questions|length > 0 %}
 <div class="question_list">
     {% for msg in current_user.questions|reverse %}
     <div class="question">
-        {% if len(msg.subject) > 0 %}
+        {% if msg.subject|length > 0 %}
         <h4 class="subject">{{ msg.subject }}</h4>
         {% else %}
         <h4 class="subject empty">{{ _("(no subject)") }}</h4>
         {% endif %}
         <span class="timestamp">{{ translation.format_datetime_smart(msg.question_timestamp, now, timezone) }}</span>
-        {% if len(msg.text) > 0 %}
+        {% if msg.text|length > 0 %}
         <div class="body">{{ msg.text }}</div>
         {% endif %}
     </div>
         {% if msg.reply_timestamp is not None %}
     <div class="answer">
-            {% if len(msg.reply_subject) > 0 %}
+            {% if msg.reply_subject|length > 0 %}
         <h4 class="subject">{{ msg.reply_subject }}</h4>
             {% else %}
         <h4 class="subject empty">{{ _("(no subject)") }}</h4>
             {% endif %}
         <span class="timestamp">{{ translation.format_datetime_smart(msg.reply_timestamp, now, timezone) }}</span>
-            {% if len(msg.reply_text) > 0 %}
+            {% if msg.reply_text|length > 0 %}
         <div class="body">{{ msg.reply_text }}</div>
             {% endif %}
     </div>
@@ -101,18 +101,18 @@
 {% endif %}
 
 
-{% if len (current_user.messages) > 0 %}
+{% if current_user.messages|length > 0 %}
 <h2>{{ _("Messages") }}</h2>
 <div class="message_list">
     {% for msg in current_user.messages|reverse %}
     <div class="message">
-        {% if len(msg.subject) > 0 %}
+        {% if msg.subject|length > 0 %}
         <h4 class="subject">{{ msg.subject }}</h4>
         {% else %}
         <h4 class="subject empty">{{ _("(no subject)") }}</h4>
         {% endif %}
         <span class="timestamp">{{ translation.format_datetime_smart(msg.timestamp, now, timezone) }}</span>
-        {% if len(msg.text) > 0 %}
+        {% if msg.text|length > 0 %}
         <div class="body">{{ msg.text }}</div>
         {% endif %}
     </div>

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -33,7 +33,7 @@
 <h2>{{ _("Questions") }}</h2>
 <div class="well question_submit">
     <form class="form-horizontal" action="{{ contest_url("question") }}" method="POST">
-        {% module xsrf_form_html() %}
+        {{ xsrf_form_html|safe }}
         <fieldset>
             <div class="control-group">
                 <label class="control-label" for="input_subject">{{ _("Subject") }}</label>

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -1,4 +1,4 @@
-{% extends contest.html %}
+{% extends "contest.html" %}
 {% block core %}
 <div class="span9">
 

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -17,15 +17,15 @@
         <h4 class="subject">{{ msg.subject }}</h4>
         {% else %}
         <h4 class="subject empty">{{ _("(no subject)") }}</h4>
-        {% end %}
+        {% endif %}
         <span class="timestamp">{{ translation.format_datetime_smart(msg.timestamp, now, timezone) }}</span>
         {% if len(msg.text) > 0 %}
         <div class="body">{{ msg.text }}</div>
-        {% end %}
+        {% endif %}
     </div>
-    {% end %}
+    {% endfor %}
 </div>
-{% end %}
+{% endif %}
 
 
 
@@ -43,7 +43,7 @@
                     <datalist id="task_names_list">
                         {% for task in contest.tasks %}
                         <option value="{{ task.name }}">
-                        {% end %}
+                        {% endfor %}
                     </datalist>
                 </div>
             </div>
@@ -72,11 +72,11 @@
         <h4 class="subject">{{ msg.subject }}</h4>
         {% else %}
         <h4 class="subject empty">{{ _("(no subject)") }}</h4>
-        {% end %}
+        {% endif %}
         <span class="timestamp">{{ translation.format_datetime_smart(msg.question_timestamp, now, timezone) }}</span>
         {% if len(msg.text) > 0 %}
         <div class="body">{{ msg.text }}</div>
-        {% end %}
+        {% endif %}
     </div>
         {% if msg.reply_timestamp is not None %}
     <div class="answer">
@@ -84,22 +84,22 @@
         <h4 class="subject">{{ msg.reply_subject }}</h4>
             {% else %}
         <h4 class="subject empty">{{ _("(no subject)") }}</h4>
-            {% end %}
+            {% endif %}
         <span class="timestamp">{{ translation.format_datetime_smart(msg.reply_timestamp, now, timezone) }}</span>
             {% if len(msg.reply_text) > 0 %}
         <div class="body">{{ msg.reply_text }}</div>
-            {% end %}
+            {% endif %}
     </div>
         {% else %}
     <div class="no_answer">
         {{ _("no answer yet") }}
     </div>
-        {% end %}
-    {% end %}
+        {% endif %}
+    {% endfor %}
 </div>
-{% end %}
+{% endif %}
 
-{% end %}
+{% endif %}
 
 
 {% if len (current_user.messages) > 0 %}
@@ -111,16 +111,16 @@
         <h4 class="subject">{{ msg.subject }}</h4>
         {% else %}
         <h4 class="subject empty">{{ _("(no subject)") }}</h4>
-        {% end %}
+        {% endif %}
         <span class="timestamp">{{ translation.format_datetime_smart(msg.timestamp, now, timezone) }}</span>
         {% if len(msg.text) > 0 %}
         <div class="body">{{ msg.text }}</div>
-        {% end %}
+        {% endif %}
     </div>
-    {% end %}
+    {% endfor %}
 </div>
-{% end %}
+{% endif %}
 
 
 </div>
-{% end %}
+{% endblock core %}

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -77,7 +77,7 @@
         <div class="body">{{ msg.text }}</div>
         {% endif %}
     </div>
-        {% if msg.reply_timestamp is not None %}
+        {% if msg.reply_timestamp is not none %}
     <div class="answer">
             {% if msg.reply_subject|length > 0 %}
         <h4 class="subject">{{ msg.reply_subject }}</h4>

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -33,7 +33,7 @@ var utils = new CMS.CWSUtils("{{ url() }}", "{{ contest_url() }}", "{{ contest.n
 // FIXME use Date objects
 var utils = new CMS.CWSUtils("{{ url() }}", "{{ contest_url() }}", "{{ contest.name }}",
                              {{ make_timestamp(now) }},
-                             {% comment What we do is: if timezone is +HH:MM we return the UNIX timestamp + 3600*HH + 60*MM. %}
+                             {# What we do is: if timezone is +HH:MM we return the UNIX timestamp + 3600*HH + 60*MM. #}
                              {{ make_timestamp(now.replace(tzinfo=utc).astimezone(timezone).replace(tzinfo=None)) }},
                              {{ make_timestamp(current_phase_begin) }},
                              {{ make_timestamp(current_phase_end) }},
@@ -193,7 +193,7 @@ $(document).ready(function () {
                             <li{% if request.path == '/documentation' %} class="active"{% endif %}>
                                 <a href="{{ contest_url("documentation") }}">{{ _("Documentation") }}</a>
                             </li>
-    {% if actual_phase == 0 or current_user.unrestricted %}{% comment FIXME maybe >= 0? %}
+    {% if actual_phase == 0 or current_user.unrestricted %}{# FIXME maybe >= 0? #}
         {% if testing_enabled %}
                             <li{% if request.path == '/testing' %} class="active"{% endif %}>
                                 <a href="{{ contest_url("testing") }}">{{ _("Testing") }}</a>

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -63,7 +63,7 @@ $(document).ready(function () {
 {% endif %}
 {% if current_user is not none %}
                     <form action="{{ contest_url("logout") }}" method="POST" class="navbar-form pull-right">
-                        {% module xsrf_form_html() %}
+                        {{ xsrf_form_html|safe }}
                         <button type="submit" class="btn btn-warning">{{ _('Logout') }}</button>
                     </form>
                     <p class="navbar-text pull-right">
@@ -87,7 +87,7 @@ $(document).ready(function () {
                 <h1>{{ _("Welcome") }}</h1>
                 <p>{{ _("Please log in") }}</p>
                 <form class="form-horizontal" action="{{ contest_url("login") }}" method="POST">
-                    {% module xsrf_form_html() %}
+                    {{ xsrf_form_html|safe }}
                     {% set next_page = handler.get_argument("next", none) %}
                     {% if next_page is not none %}
                     <input type="hidden" name="next" value="{{ next_page }}">

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -6,14 +6,6 @@
 
 {% block js %}
 
-{% import re %}
-{% import time %}
-{% import json %}
-{% from cms.server.contest.formatting import get_score_class, encode_for_url %}
-{% from cms.grading import COMPILATION_MESSAGES, EVALUATION_MESSAGES %}
-{% from cms.grading.languagemanager import get_language %}
-{% from cms.db import SubmissionResult %}
-{% from cmscommon.datetime import make_timestamp, utc %}
 
     <script>
 var LANGUAGES = {

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -24,11 +24,11 @@ var utils = new CMS.CWSUtils("{{ url() }}", "{{ contest_url() }}", "{{ contest.n
 {% else %}
 // FIXME use Date objects
 var utils = new CMS.CWSUtils("{{ url() }}", "{{ contest_url() }}", "{{ contest.name }}",
-                             {{ make_timestamp(now) }},
+                             {{ now|make_timestamp }},
                              {# What we do is: if timezone is +HH:MM we return the UNIX timestamp + 3600*HH + 60*MM. #}
-                             {{ make_timestamp(now.replace(tzinfo=utc).astimezone(timezone).replace(tzinfo=none)) }},
-                             {{ make_timestamp(current_phase_begin) }},
-                             {{ make_timestamp(current_phase_end) }},
+                             {{ now.replace(tzinfo=utc).astimezone(timezone).replace(tzinfo=none)|make_timestamp }},
+                             {{ current_phase_begin|make_timestamp }},
+                             {{ current_phase_end|make_timestamp }},
                              {{ actual_phase }});
 $(document).ready(function () {
     utils.update_time({{ "true" if contest.per_user_time is not none else "false" }});

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -51,7 +51,7 @@ $(document).ready(function () {
             <div class="navbar-inner">
                 <div class="container">
                     <a class="brand" href="{{ contest_url() }}">{{ contest.description }}</a>
-{% if len(available_translations) > 1 %}
+{% if available_translations|length > 1 %}
                     <p class="navbar-text pull-right">
                         <select id="lang" class="form-control btn btn-info" onchange="utils.switch_lang()">
                             <option value=""{% if cookie_translation is None %} selected{% endif %}>{{ _("Automatic (%s)") % automatic_translation.name }}</option>

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -1,4 +1,4 @@
-{% extends base.html %}
+{% extends "base.html" %}
 
 {% block title %}
     {{ contest.description }}

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -11,7 +11,7 @@
 var LANGUAGES = {
 {% for lang in contest.languages %}
     '{{ lang }}': {
-{% for extension in (lang|get_language).source_extensions %}
+{% for extension in (lang|to_language).source_extensions %}
         '{{ extension }}': true,
 {% endfor %}
     },

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -11,7 +11,7 @@
 var LANGUAGES = {
 {% for lang in contest.languages %}
     '{{ lang }}': {
-{% for extension in get_language(lang).source_extensions %}
+{% for extension in (lang|get_language).source_extensions %}
         '{{ extension }}': true,
 {% endfor %}
     },

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -18,7 +18,7 @@ var LANGUAGES = {
 {% endfor %}
 };
 
-{% if current_user is None %}
+{% if current_user is none %}
 var utils = new CMS.CWSUtils("{{ url() }}", "{{ contest_url() }}", "{{ contest.name }}",
                              0, 0, 0, 0, 0);
 {% else %}
@@ -26,14 +26,14 @@ var utils = new CMS.CWSUtils("{{ url() }}", "{{ contest_url() }}", "{{ contest.n
 var utils = new CMS.CWSUtils("{{ url() }}", "{{ contest_url() }}", "{{ contest.name }}",
                              {{ make_timestamp(now) }},
                              {# What we do is: if timezone is +HH:MM we return the UNIX timestamp + 3600*HH + 60*MM. #}
-                             {{ make_timestamp(now.replace(tzinfo=utc).astimezone(timezone).replace(tzinfo=None)) }},
+                             {{ make_timestamp(now.replace(tzinfo=utc).astimezone(timezone).replace(tzinfo=none)) }},
                              {{ make_timestamp(current_phase_begin) }},
                              {{ make_timestamp(current_phase_end) }},
                              {{ actual_phase }});
 $(document).ready(function () {
-    utils.update_time({{ "true" if contest.per_user_time is not None else "false" }});
+    utils.update_time({{ "true" if contest.per_user_time is not none else "false" }});
     setInterval(function() {
-        utils.update_time({{ "true" if contest.per_user_time is not None else "false" }});
+        utils.update_time({{ "true" if contest.per_user_time is not none else "false" }});
     }, 1000);
     utils.update_unread_count(0{% if request.path == '/communication' %}, 0{% end %});
     utils.update_notifications(true);
@@ -54,14 +54,14 @@ $(document).ready(function () {
 {% if available_translations|length > 1 %}
                     <p class="navbar-text pull-right">
                         <select id="lang" class="form-control btn btn-info" onchange="utils.switch_lang()">
-                            <option value=""{% if cookie_translation is None %} selected{% endif %}>{{ _("Automatic (%s)") % automatic_translation.name }}</option>
+                            <option value=""{% if cookie_translation is none %} selected{% endif %}>{{ _("Automatic (%s)") % automatic_translation.name }}</option>
                         {% for lang_code, t in iteritems(available_translations)|sort %}
                             <option value="{{ lang_code }}"{% if t == cookie_translation %} selected{% endif %}>{{ t.name }}</option>
                         {% endfor %}
                         </select>
                     </p>
 {% endif %}
-{% if current_user is not None %}
+{% if current_user is not none %}
                     <form action="{{ contest_url("logout") }}" method="POST" class="navbar-form pull-right">
                         {% module xsrf_form_html() %}
                         <button type="submit" class="btn btn-warning">{{ _('Logout') }}</button>
@@ -73,7 +73,7 @@ $(document).ready(function () {
                 </div>
             </div>
         </div>
-{% if current_user is None %}
+{% if current_user is none %}
     {% if handler.get_argument("login_error", "") != "" %}
         <div id="notifications" class="notifications">
             <div class="alert alert-block alert-error notification">
@@ -88,8 +88,8 @@ $(document).ready(function () {
                 <p>{{ _("Please log in") }}</p>
                 <form class="form-horizontal" action="{{ contest_url("login") }}" method="POST">
                     {% module xsrf_form_html() %}
-                    {% set next_page = handler.get_argument("next", None) %}
-                    {% if next_page is not None %}
+                    {% set next_page = handler.get_argument("next", none) %}
+                    {% if next_page is not none %}
                     <input type="hidden" name="next" value="{{ next_page }}">
                     {% endif %}
                     <fieldset>

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -55,7 +55,7 @@ $(document).ready(function () {
                     <p class="navbar-text pull-right">
                         <select id="lang" class="form-control btn btn-info" onchange="utils.switch_lang()">
                             <option value=""{% if cookie_translation is None %} selected{% endif %}>{{ _("Automatic (%s)") % automatic_translation.name }}</option>
-                        {% for lang_code, t in sorted(iteritems(available_translations), key=lambda x: x[1].name) %}
+                        {% for lang_code, t in iteritems(available_translations)|sort %}
                             <option value="{{ lang_code }}"{% if t == cookie_translation %} selected{% endif %}>{{ t.name }}</option>
                         {% endfor %}
                         </select>

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -2,7 +2,7 @@
 
 {% block title %}
     {{ contest.description }}
-{% end %}
+{% endblock title %}
 
 {% block js %}
 
@@ -21,9 +21,9 @@ var LANGUAGES = {
     '{{ lang }}': {
 {% for extension in get_language(lang).source_extensions %}
         '{{ extension }}': true,
-{% end %}
+{% endfor %}
     },
-{% end %}
+{% endfor %}
 };
 
 {% if current_user is None %}
@@ -48,11 +48,11 @@ $(document).ready(function () {
     setInterval(function() { utils.update_notifications(); }, 30000);
     $('#main').css('top', $('#navigation_bar').outerHeight());
 });
-    {% end%}
+    {% endif %}
 
-{% block additional_js %}{% end %}
+{% block additional_js %}{% endblock additional_js %}
     </script>
-{% end %}
+{% endblock js %}
 
 {% block body %}
         <div id="navigation_bar" class="navbar navbar-fixed-top">
@@ -62,13 +62,13 @@ $(document).ready(function () {
 {% if len(available_translations) > 1 %}
                     <p class="navbar-text pull-right">
                         <select id="lang" class="form-control btn btn-info" onchange="utils.switch_lang()">
-                            <option value=""{% if cookie_translation is None %} selected{% end %}>{{ _("Automatic (%s)") % automatic_translation.name }}</option>
+                            <option value=""{% if cookie_translation is None %} selected{% endif %}>{{ _("Automatic (%s)") % automatic_translation.name }}</option>
                         {% for lang_code, t in sorted(iteritems(available_translations), key=lambda x: x[1].name) %}
-                            <option value="{{ lang_code }}"{% if t == cookie_translation %} selected{% end %}>{{ t.name }}</option>
-                        {% end %}
+                            <option value="{{ lang_code }}"{% if t == cookie_translation %} selected{% endif %}>{{ t.name }}</option>
+                        {% endfor %}
                         </select>
                     </p>
-{% end %}
+{% endif %}
 {% if current_user is not None %}
                     <form action="{{ contest_url("logout") }}" method="POST" class="navbar-form pull-right">
                         {% module xsrf_form_html() %}
@@ -77,7 +77,7 @@ $(document).ready(function () {
                     <p class="navbar-text pull-right">
                         {% raw _("Logged in as <strong>%(first_name)s %(last_name)s</strong> <em>(%(username)s)</em>") % {"first_name": escape(current_user.user.first_name), "last_name": escape(current_user.user.last_name), "username": escape(current_user.user.username)} %}
                     </p>
-{% end %}
+{% endif %}
                 </div>
             </div>
         </div>
@@ -89,7 +89,7 @@ $(document).ready(function () {
                 <h4 class="alert-heading">{{ _("Failed to log in.") }}</h4>
             </div>
         </div>
-    {% end %}
+    {% endif %}
         <div class="login_container">
             <div class="login_box hero-unit">
                 <h1>{{ _("Welcome") }}</h1>
@@ -99,7 +99,7 @@ $(document).ready(function () {
                     {% set next_page = handler.get_argument("next", None) %}
                     {% if next_page is not None %}
                     <input type="hidden" name="next" value="{{ next_page }}">
-                    {% end %}
+                    {% endif %}
                     <fieldset>
                         <div class="control-group">
                             <label class="control-label" for="username">{{ _("Username") }}</label>
@@ -168,10 +168,10 @@ $(document).ready(function () {
                     <div class="well" style="padding: 8px 0;">
                         <ul class="nav nav-list">
 
-                            <li{% if request.path == '/' %} class="active"{% end %}>
+                            <li{% if request.path == '/' %} class="active"{% endif %}>
                                 <a href="{{ contest_url() }}">{{ _("Overview") }}</a>
                             </li>
-                            <li{% if request.path == '/communication' %} class="active"{% end %}>
+                            <li{% if request.path == '/communication' %} class="active"{% endif %}>
                                 <a href="{{ contest_url("communication") }}">{{ _("Communication") }}
                                     <span id="unread_count" class="label label-warning no_unread">{{ _("%d unread") % 0 }}</span>
                                 </a>
@@ -181,30 +181,30 @@ $(document).ready(function () {
                             <li class="nav-header">
                                 {{ t_iter.name }}
                             </li>
-                            <li{% if request.path == '/tasks/%s/description' % encode_for_url(t_iter.name) %} class="active"{% end %}>
+                            <li{% if request.path == '/tasks/%s/description' % encode_for_url(t_iter.name) %} class="active"{% endif %}>
                                 <a href="{{ contest_url("tasks", t_iter.name, "description") }}">{{ _("Statement") }}</a>
                             </li>
-                            <li{% if request.path == '/tasks/%s/submissions' % encode_for_url(t_iter.name) %} class="active"{% end %}>
+                            <li{% if request.path == '/tasks/%s/submissions' % encode_for_url(t_iter.name) %} class="active"{% endif %}>
                                 <a href="{{ contest_url("tasks", t_iter.name, "submissions") }}">{{ _("Submissions") }}</a>
                             </li>
-        {% end %}
-    {% end %}
+        {% endfor %}
+    {% endif %}
                             <li class="divider"></li>
-                            <li{% if request.path == '/documentation' %} class="active"{% end %}>
+                            <li{% if request.path == '/documentation' %} class="active"{% endif %}>
                                 <a href="{{ contest_url("documentation") }}">{{ _("Documentation") }}</a>
                             </li>
     {% if actual_phase == 0 or current_user.unrestricted %}{% comment FIXME maybe >= 0? %}
         {% if testing_enabled %}
-                            <li{% if request.path == '/testing' %} class="active"{% end %}>
+                            <li{% if request.path == '/testing' %} class="active"{% endif %}>
                                 <a href="{{ contest_url("testing") }}">{{ _("Testing") }}</a>
                             </li>
-        {% end %}
+        {% endif %}
         {% if printing_enabled %}
-                            <li{% if request.path == '/printing' %} class="active"{% end %}>
+                            <li{% if request.path == '/printing' %} class="active"{% endif %}>
                                 <a href="{{ contest_url("printing") }}">{{ _("Printing") }}</a>
                             </li>
-        {% end %}
-    {% end %}
+        {% endif %}
+    {% endif %}
                         </ul>
                     </div>
                     <span class="license_notice">
@@ -214,9 +214,9 @@ $(document).ready(function () {
                     .
                     </span>
                 </div>
-    {% block core %}{% end %}
+    {% block core %}{% endblock core %}
             </div>
         </div>
 
-{% end %}
-{% end %}
+{% endif %}
+{% endblock body %}

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -55,7 +55,7 @@ $(document).ready(function () {
                     <p class="navbar-text pull-right">
                         <select id="lang" class="form-control btn btn-info" onchange="utils.switch_lang()">
                             <option value=""{% if cookie_translation is none %} selected{% endif %}>{{ _("Automatic (%s)") % automatic_translation.name }}</option>
-                        {% for lang_code, t in iteritems(available_translations)|sort %}
+                        {% for lang_code, t in available_translations|dictsort(by="key") %}
                             <option value="{{ lang_code }}"{% if t == cookie_translation %} selected{% endif %}>{{ t.name }}</option>
                         {% endfor %}
                         </select>

--- a/cms/server/contest/templates/contest_list.html
+++ b/cms/server/contest/templates/contest_list.html
@@ -1,4 +1,4 @@
-{% extends base.html %}
+{% extends "base.html" %}
 {% block title %}
     Choose a contest
 {% endblock title %}

--- a/cms/server/contest/templates/contest_list.html
+++ b/cms/server/contest/templates/contest_list.html
@@ -1,16 +1,16 @@
 {% extends base.html %}
 {% block title %}
     Choose a contest
-{% end %}
+{% endblock title %}
 {% block body %}
     <div class="hero-unit contest-list">
         <h3>Choose a contest</h3>
         <ul class="nav nav-list">
     {% for c_name, c_iter in iteritems(contest_list) %}
             <li>
-                <a {% if c_iter.stop < now %} style="color: #adadad" {% end %} href="{{ url(c_iter.name) }}">{{ c_iter.description }}</a>
+                <a {% if c_iter.stop < now %} style="color: #adadad" {% endif %} href="{{ url(c_iter.name) }}">{{ c_iter.description }}</a>
             </li>
-    {% end %}
+    {% endfor %}
         </ul>
     </div>
-{% end %}
+{% endblock body %}

--- a/cms/server/contest/templates/contest_list.html
+++ b/cms/server/contest/templates/contest_list.html
@@ -6,7 +6,7 @@
     <div class="hero-unit contest-list">
         <h3>Choose a contest</h3>
         <ul class="nav nav-list">
-    {% for c_name, c_iter in iteritems(contest_list) %}
+    {% for c_name, c_iter in contest_list|dictsort %}
             <li>
                 <a {% if c_iter.stop < now %} style="color: #adadad" {% endif %} href="{{ url(c_iter.name) }}">{{ c_iter.description }}</a>
             </li>

--- a/cms/server/contest/templates/documentation.html
+++ b/cms/server/contest/templates/documentation.html
@@ -1,4 +1,4 @@
-{% extends contest.html %}
+{% extends "contest.html" %}
 {% block core %}
 <div class="span9">
 

--- a/cms/server/contest/templates/documentation.html
+++ b/cms/server/contest/templates/documentation.html
@@ -12,13 +12,13 @@
 <h3>C++</h3>
 
 <p><a href="{{ contest_url("stl", "index.html") }}">{{ _("Standard Template Library") }}</a></p>
-{% end %}
+{% endif %}
 
 {% if any(".java" in get_language(lang).source_extensions for lang in contest.languages) %}
 <h3>Java</h3>
 
 <p>{{ _("The main Java class of the solution should have exactly the same name as the task.") }}</p>
-{% end %}
+{% endif %}
 
 
 <h2>{{ _("Submission details for compilation") }}</h2>
@@ -36,7 +36,7 @@
       <td><em>{{ _(message.message) }}</em></td>
       <td>{{ _(message.help) }}</td>
     </tr>
-    {% end %}
+    {% endfor %}
   </tbody>
 </table>
 
@@ -55,9 +55,9 @@
       <td><em>{{ _(message.message) }}</em></td>
       <td>{{ _(message.help) }}</td>
     </tr>
-    {% end %}
+    {% endfor %}
   </tbody>
 </table>
 
 </div>
-{% end %}
+{% endblock core %}

--- a/cms/server/contest/templates/documentation.html
+++ b/cms/server/contest/templates/documentation.html
@@ -8,13 +8,13 @@
 
 <h2>{{ _("Programming languages and libraries") }}</h2>
 
-{% if contest.languages|map("get_language")|map(attribute="source_extensions")|select("contains", ".cpp")|list|length > 0 %}
+{% if contest.languages|map("get_language")|map(attribute="source_extensions")|any("endswith", ".cpp") %}
 <h3>C++</h3>
 
 <p><a href="{{ contest_url("stl", "index.html") }}">{{ _("Standard Template Library") }}</a></p>
 {% endif %}
 
-{% if contest.languages|map("get_language")|map(attribute="source_extensions")|select("contains", ".java")|list|length > 0 %}
+{% if contest.languages|map("get_language")|map(attribute="source_extensions")|any("endswith", ".java") %}
 <h3>Java</h3>
 
 <p>{{ _("The main Java class of the solution should have exactly the same name as the task.") }}</p>

--- a/cms/server/contest/templates/documentation.html
+++ b/cms/server/contest/templates/documentation.html
@@ -8,13 +8,13 @@
 
 <h2>{{ _("Programming languages and libraries") }}</h2>
 
-{% if any(".cpp" in get_language(lang).source_extensions for lang in contest.languages) %}
+{% if any(contest.languages|map("get_language")|map(attribute="source_extensions")|select("contains", ".cpp")) %}
 <h3>C++</h3>
 
 <p><a href="{{ contest_url("stl", "index.html") }}">{{ _("Standard Template Library") }}</a></p>
 {% endif %}
 
-{% if any(".java" in get_language(lang).source_extensions for lang in contest.languages) %}
+{% if any(contest.languages|map("get_language")|map(attribute="source_extensions")|select("contains", ".java")) %}
 <h3>Java</h3>
 
 <p>{{ _("The main Java class of the solution should have exactly the same name as the task.") }}</p>

--- a/cms/server/contest/templates/documentation.html
+++ b/cms/server/contest/templates/documentation.html
@@ -8,13 +8,13 @@
 
 <h2>{{ _("Programming languages and libraries") }}</h2>
 
-{% if contest.languages|map("get_language")|map(attribute="source_extensions")|any("endswith", ".cpp") %}
+{% if contest.languages|map("to_language")|map(attribute="source_extensions")|any("endswith", ".cpp") %}
 <h3>C++</h3>
 
 <p><a href="{{ contest_url("stl", "index.html") }}">{{ _("Standard Template Library") }}</a></p>
 {% endif %}
 
-{% if contest.languages|map("get_language")|map(attribute="source_extensions")|any("endswith", ".java") %}
+{% if contest.languages|map("to_language")|map(attribute="source_extensions")|any("endswith", ".java") %}
 <h3>Java</h3>
 
 <p>{{ _("The main Java class of the solution should have exactly the same name as the task.") }}</p>

--- a/cms/server/contest/templates/documentation.html
+++ b/cms/server/contest/templates/documentation.html
@@ -8,13 +8,13 @@
 
 <h2>{{ _("Programming languages and libraries") }}</h2>
 
-{% if any(contest.languages|map("get_language")|map(attribute="source_extensions")|select("contains", ".cpp")) %}
+{% if contest.languages|map("get_language")|map(attribute="source_extensions")|select("contains", ".cpp")|list|length > 0 %}
 <h3>C++</h3>
 
 <p><a href="{{ contest_url("stl", "index.html") }}">{{ _("Standard Template Library") }}</a></p>
 {% endif %}
 
-{% if any(contest.languages|map("get_language")|map(attribute="source_extensions")|select("contains", ".java")) %}
+{% if contest.languages|map("get_language")|map(attribute="source_extensions")|select("contains", ".java")|list|length > 0 %}
 <h3>Java</h3>
 
 <p>{{ _("The main Java class of the solution should have exactly the same name as the task.") }}</p>

--- a/cms/server/contest/templates/error.html
+++ b/cms/server/contest/templates/error.html
@@ -1,7 +1,7 @@
 {% extends base.html %}
 {% block title %}
   {{ _("Error %d") % status_code }}
-{% end %}
+{% endblock title %}
 {% block body %}
 
 <div class="span9">
@@ -23,4 +23,4 @@
 </p>
 
 </div>
-{% end %}
+{% endblock body %}

--- a/cms/server/contest/templates/error.html
+++ b/cms/server/contest/templates/error.html
@@ -1,4 +1,4 @@
-{% extends base.html %}
+{% extends "base.html" %}
 {% block title %}
   {{ _("Error %d") % status_code }}
 {% endblock title %}

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -1,4 +1,4 @@
-{% extends contest.html %}
+{% extends "contest.html" %}
 {% block core %}
 
 

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -122,7 +122,7 @@
     <div class="span4">
         <div class="well per_user_time">
             <p>
-        {% comment TODO would be very nice to write something like "just for 3 consecutive hours"... %}
+        {# TODO would be very nice to write something like "just for 3 consecutive hours"... #}
         {{ _("Every user is allowed to compete (i.e. submit solutions) for a uninterrupted time frame of %(per_user_time)s.") % {"per_user_time": translation.format_timedelta(contest.per_user_time)} }}
             </p>
 

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -1,8 +1,6 @@
 {% extends contest.html %}
 {% block core %}
 
-{% from cms.server.contest.formatting import format_token_rules %}
-{% from cms.grading.tasktypes import get_task_type %}
 
 <div class="span9">
 

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -147,7 +147,7 @@
 
     {% if actual_phase == -1 %}
         <form action="{{ contest_url("start") }}" method="POST" style="margin: 0">
-            {% module xsrf_form_html() %}
+            {{ xsrf_form_html|safe }}
             <input type="hidden" name="next" value="{{ contest_url() }}">
             <button type="submit" class="btn btn-danger btn-large" style="width:100%;-moz-box-sizing:border-box;box-sizing:border-box;" type="submit">{{ _("Start!") }}</button>
         </form>

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -10,7 +10,7 @@
 
 <h2>{{ _("General information") }}</h2>
 <div class="row">
-{% if contest.per_user_time is not None %}
+{% if contest.per_user_time is not none %}
     <div class="span5">
 {% else %}
     <div class="span9">
@@ -101,20 +101,20 @@
     {% endif %}
 {% endif %}
 
-{% if contest.max_submission_number is not None %}
+{% if contest.max_submission_number is not none %}
     <p>
     {{ _("You can submit at most %(submissions)s solutions during this contest.") % {"submissions": contest.max_submission_number} }}
     </p>
 {% endif %}
 
-{% if contest.max_user_test_number is not None %}
+{% if contest.max_user_test_number is not none %}
     <p>
     {{ _("You can submit at most %(user_tests)s user tests during this contest.") % {"user_tests": contest.max_user_test_number} }}
     </p>
 {% endif %}
 
     </div>
-{% if contest.per_user_time is not None %}
+{% if contest.per_user_time is not none %}
     <div class="span4">
         <div class="well per_user_time">
             <p>
@@ -136,7 +136,7 @@
         {{ _("You started your time frame at %(start_time)s and you already finished it.") % {"start_time": translation.format_datetime_smart(current_user.starting_time, now, timezone)} }}
         {{ _("There's nothing you can do now.") }}
     {% elif actual_phase == +2 %}
-        {% if current_user.starting_time is None %}
+        {% if current_user.starting_time is none %}
             {{ _("You never started your time frame. Now it's too late.") }}
         {% else %}
             {{ _("You started your time frame at %(start_time)s and you already finished it.") % {"start_time": translation.format_datetime_smart(current_user.starting_time, now, timezone)} }}
@@ -192,14 +192,14 @@
             <th>{{ t_iter.name }}</th>
             <td>{{ t_iter.title }}</td>
             <td>
-    {% if t_iter.active_dataset.time_limit is not None %}
+    {% if t_iter.active_dataset.time_limit is not none %}
         {{ translation.format_duration(t_iter.active_dataset.time_limit, length="long") }}
     {% else %}
         {{ _("N/A") }}
     {% endif %}
             </td>
             <td>
-    {% if t_iter.active_dataset.memory_limit is not None %}
+    {% if t_iter.active_dataset.memory_limit is not none %}
         {{ translation.format_size(t_iter.active_dataset.memory_limit * 1024 * 1024) }}
     {% else %}
         {{ _("N/A") }}

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -16,7 +16,7 @@
     <div class="span5">
 {% else %}
     <div class="span9">
-{% end %}
+{% endif %}
         <p>
 {% if phase == -1 %}
         {{ _("The contest hasn't started yet.") }}
@@ -33,7 +33,7 @@
         </p>
         <p>
         {{ _("The contest started at %(start_time)s and ended at %(stop_time)s.") % {"start_time": translation.format_datetime_smart(contest.start + current_user.delay_time, now, timezone), "stop_time": translation.format_datetime_smart(contest.stop + current_user.delay_time + current_user.extra_time, now, timezone)} }}
-{% end %}
+{% endif %}
         </p>
 {% if contest.analysis_enabled %}
         <p>
@@ -52,10 +52,10 @@
         </p>
         <p>
         {{ _("The analysis mode started at %(start_time)s and ended at %(stop_time)s.") % {"start_time": translation.format_datetime_smart(contest.analysis_start, now, timezone), "stop_time": translation.format_datetime_smart(contest.analysis_stop, now, timezone)} }}
-  {% end %}
+  {% endif %}
         </p>
 
-{% end %}
+{% endif %}
 
 
 
@@ -102,20 +102,20 @@
         {{ _("You can see the detailed result of a submission by using two tokens on it, one of each type.") }}
         {{ _("Your score for each task will be the maximum among the tokened submissions and the last one.") }}
         </p>
-    {% end %}
-{% end %}
+    {% endif %}
+{% endif %}
 
 {% if contest.max_submission_number is not None %}
     <p>
     {{ _("You can submit at most %(submissions)s solutions during this contest.") % {"submissions": contest.max_submission_number} }}
     </p>
-{% end %}
+{% endif %}
 
 {% if contest.max_user_test_number is not None %}
     <p>
     {{ _("You can submit at most %(user_tests)s user tests during this contest.") % {"user_tests": contest.max_user_test_number} }}
     </p>
-{% end %}
+{% endif %}
 
     </div>
 {% if contest.per_user_time is not None %}
@@ -144,9 +144,9 @@
             {{ _("You never started your time frame. Now it's too late.") }}
         {% else %}
             {{ _("You started your time frame at %(start_time)s and you already finished it.") % {"start_time": translation.format_datetime_smart(current_user.starting_time, now, timezone)} }}
-        {% end %}
+        {% endif %}
         {{ _("There's nothing you can do now.") }}
-    {% end %}
+    {% endif %}
             </p>
 
     {% if actual_phase == -1 %}
@@ -155,11 +155,11 @@
             <input type="hidden" name="next" value="{{ contest_url() }}">
             <button type="submit" class="btn btn-danger btn-large" style="width:100%;-moz-box-sizing:border-box;box-sizing:border-box;" type="submit">{{ _("Start!") }}</button>
         </form>
-    {% end %}
+    {% endif %}
 
         </div>
     </div>
-{% end %}
+{% endif %}
 </div>
 
 
@@ -186,7 +186,7 @@
             <th>{{ _("Files") }}</th>
 {% if tokens_contest != 0 and tokens_tasks != 0 %}
             <th>{{ _("Tokens") }}</th>
-{% end %}
+{% endif %}
         </tr>
     </thead>
     <tbody>
@@ -200,14 +200,14 @@
         {{ translation.format_duration(t_iter.active_dataset.time_limit, length="long") }}
     {% else %}
         {{ _("N/A") }}
-    {% end %}
+    {% endif %}
             </td>
             <td>
     {% if t_iter.active_dataset.memory_limit is not None %}
         {{ translation.format_size(t_iter.active_dataset.memory_limit * 1024 * 1024) }}
     {% else %}
         {{ _("N/A") }}
-    {% end %}
+    {% endif %}
             </td>
             <td>{{ get_task_type(dataset=t_iter.active_dataset).name }}</td>
             <td>{{ " ".join(a.filename.replace(".%l", extensions) for a in t_iter.submission_format) }}</td>
@@ -217,15 +217,13 @@
             {{ _("Yes") }}
         {% else %}
             {{ _("No") }}
-        {% end %}
+        {% endif %}
             </td>
-    {% end %}
+    {% endif %}
         </tr>
-{% end %}
+{% endfor %}
     </tbody>
 </table>
 
-{% end %}
-
 </div>
-{% end %}
+{% endblock core %}

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -186,7 +186,7 @@
         </tr>
     </thead>
     <tbody>
-{% set extensions = "[%s]" %  ("|".join(contest.languages|map("get_language")|map(attribute="source_extension")|unique)) %}
+{% set extensions = "[%s]" %  (contest.languages|map("get_language")|map(attribute="source_extension")|unique|join("|")) %}
 {% for t_iter in contest.tasks %}
         <tr>
             <th>{{ t_iter.name }}</th>
@@ -206,7 +206,7 @@
     {% endif %}
             </td>
             <td>{{ get_task_type(dataset=t_iter.active_dataset).name }}</td>
-            <td>{{ " ".join(t_iter.submission_format|map(attribute="filename")|map("replace", ".%l", extensions)) }}</td>
+            <td>{{ t_iter.submission_format|map(attribute="filename")|map("replace", ".%l", extensions)|join(" ") }}</td>
     {% if tokens_contest != 0 and tokens_tasks != 0 %}
             <td>
         {% if t_iter.token_mode in ("finite", "infinite") %}

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -80,8 +80,7 @@
     {% elif tokens_tasks == 2 %}
         <p>
         {{ _("You have a set of tokens shared among all tasks.") }}
-        {% set tokens = {k[6:]: v for k, v in iteritems(contest.__dict__) if k.startswith("token_")} %}
-        {{ format_token_rules(tokens, translation=translation) }}
+        {{ format_token_rules(contest|extract_token_params, translation=translation) }}
         </p>
 
         <p>
@@ -91,8 +90,7 @@
     {% else %}
         <p>
         {% raw _("You have two types of tokens: a set of <em>contest-tokens</em> shared among all tasks and a distinct set of <em>task-tokens</em> for each task.") %}
-        {% set tokens = {k[6:]: v for k, v in iteritems(contest.__dict__) if k.startswith("token_")} %}
-        {{ format_token_rules(tokens, t_type="contest", translation=translation) }}
+        {{ format_token_rules(contest|extract_token_params, t_type="contest", translation=translation) }}
         {{ _("You can find the rules for the %(type_pl)s on each task's description page.") % {"type_pl": _("task-tokens")} }}
         </p>
 
@@ -188,7 +186,7 @@
         </tr>
     </thead>
     <tbody>
-{% set extensions = "[%s]" %  ("|".join(set(get_language(lang).source_extension for lang in contest.languages))) %}
+{% set extensions = "[%s]" %  ("|".join(set(contest.languages|map("get_language")|map(attribute="source_extension")))) %}
 {% for t_iter in contest.tasks %}
         <tr>
             <th>{{ t_iter.name }}</th>
@@ -208,7 +206,7 @@
     {% endif %}
             </td>
             <td>{{ get_task_type(dataset=t_iter.active_dataset).name }}</td>
-            <td>{{ " ".join(a.filename.replace(".%l", extensions) for a in t_iter.submission_format) }}</td>
+            <td>{{ " ".join(t_iter.submission_format|map(attribute="filename")|map("replace", ".%l", extensions)) }}</td>
     {% if tokens_contest != 0 and tokens_tasks != 0 %}
             <td>
         {% if t_iter.token_mode in ("finite", "infinite") %}

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -186,7 +186,7 @@
         </tr>
     </thead>
     <tbody>
-{% set extensions = "[%s]" %  (contest.languages|map("get_language")|map(attribute="source_extension")|unique|join("|")) %}
+{% set extensions = "[%s]"|format(contest.languages|map("get_language")|map(attribute="source_extension")|unique|join("|")) %}
 {% for t_iter in contest.tasks %}
         <tr>
             <th>{{ t_iter.name }}</th>

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -186,7 +186,7 @@
         </tr>
     </thead>
     <tbody>
-{% set extensions = "[%s]"|format(contest.languages|map("get_language")|map(attribute="source_extension")|unique|join("|")) %}
+{% set extensions = "[%s]"|format(contest.languages|map("to_language")|map(attribute="source_extension")|unique|join("|")) %}
 {% for t_iter in contest.tasks %}
         <tr>
             <th>{{ t_iter.name }}</th>

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -186,7 +186,7 @@
         </tr>
     </thead>
     <tbody>
-{% set extensions = "[%s]" %  ("|".join(set(contest.languages|map("get_language")|map(attribute="source_extension")))) %}
+{% set extensions = "[%s]" %  ("|".join(contest.languages|map("get_language")|map(attribute="source_extension")|unique)) %}
 {% for t_iter in contest.tasks %}
         <tr>
             <th>{{ t_iter.name }}</th>

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -2,7 +2,6 @@
 
 {% block core %}
 
-{% from cms.grading import format_status_text %}
 
 <div class="span9 printing">
 
@@ -45,7 +44,6 @@
 
 <h2 style="margin: 40px 0 10px">{{ _("Previous print jobs") }}</h2>
 
-{% from cmscommon.datetime import utc %}
 {% set show_date = any(p.timestamp.replace(tzinfo=utc).astimezone(timezone).date() != now.replace(tzinfo=utc).astimezone(timezone).date() for p in printjobs) %}
 
 

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -1,4 +1,4 @@
-{% extends contest.html %}
+{% extends "contest.html" %}
 
 {% block core %}
 

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -74,7 +74,7 @@
             <td colspan="3" class="no_printjobs">{{ _("no print jobs yet") }}</td>
         </tr>
 {% else %}
-    {% for p_idx, p in enumerate(printjobs|sort(attribute="timestamp")|reverse) %}
+    {% for p in printjobs|sort(attribute="timestamp")|reverse %}
         <tr>
         {% if show_date %}
             <td class="datetime">{{ translation.format_datetime(p.timestamp, timezone) }}</td>

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -20,7 +20,7 @@
 
 <div id="print" class="row">
     <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("printing") }}" method="POST">
-        {% module xsrf_form_html() %}
+        {{ xsrf_form_html|safe }}
         <fieldset>
             <div class="control-group">
                 <label class="control-label" for="input">{% if pdf_printing_allowed %}{{ _("File (text or PDF)") }}{% else %}{{ _("File (text)") }}{% endif %}</label>

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -17,14 +17,14 @@
     {{ _("You can print %(remaining_jobs)d more text or PDF files of up to %(max_pages)d pages each.") % {"remaining_jobs": remaining_jobs, "max_pages": max_pages} }}
     {% else %}
     {{ _("You can print %(remaining_jobs)d more text files of up to %(max_pages)d pages each.") % {"remaining_jobs": remaining_jobs, "max_pages": max_pages} }}
-    {% end %}
+    {% endif %}
 
 <div id="print" class="row">
     <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("printing") }}" method="POST">
         {% module xsrf_form_html() %}
         <fieldset>
             <div class="control-group">
-                <label class="control-label" for="input">{% if pdf_printing_allowed %}{{ _("File (text or PDF)") }}{% else %}{{ _("File (text)") }}{% end %}</label>
+                <label class="control-label" for="input">{% if pdf_printing_allowed %}{{ _("File (text or PDF)") }}{% else %}{{ _("File (text)") }}{% endif %}</label>
                 <div class="controls">
                     <input type="file" class="input-xlarge" id="input" name="file"/>
                 </div>
@@ -40,7 +40,7 @@
 </div>
 {% else %}
     {{ _("You cannot print anything any more as you have used up your printing quota.") }}
-{% end %}
+{% endif %}
 
 
 <h2 style="margin: 40px 0 10px">{{ _("Previous print jobs") }}</h2>
@@ -55,7 +55,7 @@
         <col class="datetime"/>
 {% else %}
         <col class="time"/>
-{% end %}
+{% endif %}
         <col class="filename"/>
         <col class="status"/>
     </colgroup>
@@ -65,7 +65,7 @@
             <th class="datetime">{{ _("Date and time") }}</th>
 {% else %}
             <th class="time">{{ _("Time") }}</th>
-{% end %}
+{% endif %}
             <th class="filename">{{ _("File name") }}</th>
             <th class="status">{{ _("Status") }}</th>
         </tr>
@@ -82,13 +82,13 @@
             <td class="datetime">{{ translation.format_datetime(p.timestamp, timezone) }}</td>
         {% else %}
             <td class="time">{{ translation.format_time(p.timestamp, timezone) }}</td>
-        {% end %}
+        {% endif %}
             <td class="filename">{{ p.filename }}</td>
             <td class="status">{{ format_status_text(p.status, translation=translation) if p.done else _("Preparing...") }}</td>
         </tr>
-    {% end %}
-{% end %}
+    {% endfor %}
+{% endif %}
     </tbody>
 </table>
 
-{% end %}
+{% endblock core %}

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -74,7 +74,7 @@
             <td colspan="3" class="no_printjobs">{{ _("no print jobs yet") }}</td>
         </tr>
 {% else %}
-    {% for p_idx, p in enumerate(sorted(printjobs, key=lambda p: p.timestamp, reverse=True)) %}
+    {% for p_idx, p in enumerate(printjobs|sort(attribute="timestamp")|reverse) %}
         <tr>
         {% if show_date %}
             <td class="datetime">{{ translation.format_datetime(p.timestamp, timezone) }}</td>

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -69,7 +69,7 @@
         </tr>
     </thead>
     <tbody>
-{% if len(printjobs) == 0 %}
+{% if printjobs|length == 0 %}
         <tr>
             <td colspan="3" class="no_printjobs">{{ _("no print jobs yet") }}</td>
         </tr>

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -44,7 +44,7 @@
 
 <h2 style="margin: 40px 0 10px">{{ _("Previous print jobs") }}</h2>
 
-{% set show_date = any(p.timestamp.replace(tzinfo=utc).astimezone(timezone).date() != now.replace(tzinfo=utc).astimezone(timezone).date() for p in printjobs) %}
+{% set show_date = any(printjobs|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())) %}
 
 
 <table id="printjob_list" class="table table-bordered table-striped">

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -44,7 +44,7 @@
 
 <h2 style="margin: 40px 0 10px">{{ _("Previous print jobs") }}</h2>
 
-{% set show_date = printjobs|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())|list|length > 0 %}
+{% set show_date = not printjobs|map(attribute="timestamp")|all("today") %}
 
 
 <table id="printjob_list" class="table table-bordered table-striped">

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -44,7 +44,7 @@
 
 <h2 style="margin: 40px 0 10px">{{ _("Previous print jobs") }}</h2>
 
-{% set show_date = any(printjobs|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())) %}
+{% set show_date = printjobs|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())|list|length > 0 %}
 
 
 <table id="printjob_list" class="table table-bordered table-striped">

--- a/cms/server/contest/templates/submission_details.html
+++ b/cms/server/contest/templates/submission_details.html
@@ -6,7 +6,7 @@
 <div class="score_details">
 {% raw details %}
 </div>
-{% end %}
+{% endif %}
 
 {% if sr is not None and sr.compiled() %}
 <h3>{{ _("Compilation output") }}</h3>{% comment TODO: trim long outputs and add facility to see raw %}
@@ -23,7 +23,7 @@
     {{ _("N/A") }}
 {% else %}
     {{ translation.format_duration(sr.compilation_time) }}
-{% end %}
+{% endif %}
             </td>
         </tr>
             <th>{{ _("Memory used:") }}</th>
@@ -32,7 +32,7 @@
     {{ _("N/A") }}
 {% else %}
     {{ translation.format_size(sr.compilation_memory) }}
-{% end %}
+{% endif %}
             </td>
         </tr>
     </tbody>
@@ -40,9 +40,9 @@
 {% if sr.compilation_stdout is not None %}
 <h4>{{ _("Standard output") }}</h4>
 <pre>{{ sr.compilation_stdout }}</pre>
-{% end %}
+{% endif %}
 {% if sr.compilation_stderr is not None %}
 <h4>{{ _("Standard error") }}</h4>
 <pre>{{ sr.compilation_stderr }}</pre>
-{% end %}
-{% end %}
+{% endif %}
+{% endif %}

--- a/cms/server/contest/templates/submission_details.html
+++ b/cms/server/contest/templates/submission_details.html
@@ -2,7 +2,7 @@
 
 {% if details is not none %}
 <div class="score_details">
-{% raw details %}
+{{ details|safe }}
 </div>
 {% endif %}
 

--- a/cms/server/contest/templates/submission_details.html
+++ b/cms/server/contest/templates/submission_details.html
@@ -9,7 +9,7 @@
 {% endif %}
 
 {% if sr is not None and sr.compiled() %}
-<h3>{{ _("Compilation output") }}</h3>{% comment TODO: trim long outputs and add facility to see raw %}
+<h3>{{ _("Compilation output") }}</h3>{# TODO: trim long outputs and add facility to see raw #}
 <table class="table table-bordered" style="table-layout: fixed;">
     <tbody>
         <tr>

--- a/cms/server/contest/templates/submission_details.html
+++ b/cms/server/contest/templates/submission_details.html
@@ -1,12 +1,12 @@
 
 
-{% if details is not None %}
+{% if details is not none %}
 <div class="score_details">
 {% raw details %}
 </div>
 {% endif %}
 
-{% if sr is not None and sr.compiled() %}
+{% if sr is not none and sr.compiled() %}
 <h3>{{ _("Compilation output") }}</h3>{# TODO: trim long outputs and add facility to see raw #}
 <table class="table table-bordered" style="table-layout: fixed;">
     <tbody>
@@ -17,7 +17,7 @@
         <tr>
             <th>{{ _("Compilation time:") }}</th>
             <td>
-{% if sr.compilation_time is None %}
+{% if sr.compilation_time is none %}
     {{ _("N/A") }}
 {% else %}
     {{ translation.format_duration(sr.compilation_time) }}
@@ -26,7 +26,7 @@
         </tr>
             <th>{{ _("Memory used:") }}</th>
             <td>
-{% if sr.compilation_memory is None %}
+{% if sr.compilation_memory is none %}
     {{ _("N/A") }}
 {% else %}
     {{ translation.format_size(sr.compilation_memory) }}
@@ -35,11 +35,11 @@
         </tr>
     </tbody>
 </table>
-{% if sr.compilation_stdout is not None %}
+{% if sr.compilation_stdout is not none %}
 <h4>{{ _("Standard output") }}</h4>
 <pre>{{ sr.compilation_stdout }}</pre>
 {% endif %}
-{% if sr.compilation_stderr is not None %}
+{% if sr.compilation_stderr is not none %}
 <h4>{{ _("Standard error") }}</h4>
 <pre>{{ sr.compilation_stderr }}</pre>
 {% endif %}

--- a/cms/server/contest/templates/submission_details.html
+++ b/cms/server/contest/templates/submission_details.html
@@ -1,6 +1,4 @@
-{% from six import iterkeys, itervalues, iteritems %}
 
-{% from cms.grading import format_status_text %}
 
 {% if details is not None %}
 <div class="score_details">

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -137,7 +137,7 @@
             {# TODO If the expiration or generation time are greater than valid_phase_end they "don't exist". It's useless to show "Wait..." in those cases. #}
             {% if can_play_token and not need_to_wait %}
         <form action="{{ contest_url("tasks", task.name, "submissions", s_idx, "token") }}" method="POST">
-            {% module xsrf_form_html() %}
+            {{ xsrf_form_html|safe }}
             <button type="submit" class="btn btn-warning">{{ _("Play!") }}</button>
         </form>
             {% elif (can_play_token and need_to_wait) or (not can_play_token and tokens_info[1] is not none) %}

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -1,7 +1,7 @@
 {% if show_date %}
-    {% set col1 = "<td class=\"datetime\">%s</td>" % translation.format_datetime(s.timestamp, timezone) %}
+    {% set col1 = "<td class=\"datetime\">%s</td>"|format(translation.format_datetime(s.timestamp, timezone)) %}
 {% else %}
-    {% set col1 = "<td class=\"time\">%s</td>" % translation.format_time(s.timestamp, timezone) %}
+    {% set col1 = "<td class=\"time\">%s</td>"|format(translation.format_time(s.timestamp, timezone)) %}
 {% endif %}
 {% if sr is none or not sr.compiled() %}
 <tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.COMPILING }}">

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -89,9 +89,9 @@
 {% endif %}
 {% if submissions_download_allowed %}
     <td class="files">
-        {% comment We replace '.%l' with the actual language only when it occurs as an extension at the end of the string and only when %}
-        {% comment there isn't another file with that name. This allows to securily reverse the replacement and should work great in %}
-        {% comment the common case. Yet, it still allows the marginal case of both 'foo.%l' and 'foo.c' in the submission format. %}
+        {# We replace '.%l' with the actual language only when it occurs as an extension at the end of the string and only when #}
+        {# there isn't another file with that name. This allows to securily reverse the replacement and should work great in #}
+        {# the common case. Yet, it still allows the marginal case of both 'foo.%l' and 'foo.c' in the submission format. #}
         {% if len(s.files) == 0 %}
         <a class="btn disabled">
             {{ _("None") }}
@@ -134,7 +134,7 @@
         {% if s.token is not None %}
         <a class="btn disabled">{{ _("Played") }}</a>
         {% else %}
-            {% comment TODO If the expiration or generation time are greater than valid_phase_end they "don't exist". It's useless to show "Wait..." in those cases. %}
+            {# TODO If the expiration or generation time are greater than valid_phase_end they "don't exist". It's useless to show "Wait..." in those cases. #}
             {% if can_play_token and not need_to_wait %}
         <form action="{{ contest_url("tasks", task.name, "submissions", s_idx, "token") }}" method="POST">
             {% module xsrf_form_html() %}

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -92,11 +92,11 @@
         {# We replace '.%l' with the actual language only when it occurs as an extension at the end of the string and only when #}
         {# there isn't another file with that name. This allows to securily reverse the replacement and should work great in #}
         {# the common case. Yet, it still allows the marginal case of both 'foo.%l' and 'foo.c' in the submission format. #}
-        {% if len(s.files) == 0 %}
+        {% if s.files|length == 0 %}
         <a class="btn disabled">
             {{ _("None") }}
         </a>
-        {% elif len(s.files) == 1 %}
+        {% elif s.files|length == 1 %}
             {% set filename = next(iterkeys(s.files)) %}
             {% if s.language is not None %}
                 {% set filename = re.sub("\.%l$", get_language(s.language).source_extension, filename) %}

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -2,7 +2,7 @@
     {% set col1 = "<td class=\"datetime\">%s</td>" % translation.format_datetime(s.timestamp, timezone) %}
 {% else %}
     {% set col1 = "<td class=\"time\">%s</td>" % translation.format_time(s.timestamp, timezone) %}
-{% end %}
+{% endif %}
 {% if sr is None or not sr.compiled() %}
 <tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.COMPILING }}">
     {% raw col1 %}
@@ -11,10 +11,10 @@
     </td>
     {% if score_type is not None and score_type.max_public_score != 0 %}
     <td class="public_score undefined">{{ _("N/A") }}</td>
-    {% end %}
+    {% endif %}
     {% if score_type is not None and score_type.max_public_score != score_type.max_score %}
     <td class="total_score undefined">{{ _("N/A") }}</td>
-    {% end %}
+    {% endif %}
 {% elif sr.compilation_outcome == "fail" %}
 <tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.COMPILATION_FAILED }}">
     {% raw col1 %}
@@ -24,10 +24,10 @@
     </td>
     {% if score_type is not None and score_type.max_public_score != 0 %}
     <td class="public_score undefined">{{ _("N/A") }}</td>
-    {% end %}
+    {% endif %}
     {% if score_type is not None and score_type.max_public_score != score_type.max_score %}
     <td class="total_score undefined">{{ _("N/A") }}</td>
-    {% end %}
+    {% endif %}
 {% elif not sr.evaluated() %}
 <tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.EVALUATING }}">
     {% raw col1 %}
@@ -36,10 +36,10 @@
     </td>
     {% if score_type is not None and score_type.max_public_score != 0 %}
     <td class="public_score undefined">{{ _("N/A") }}</td>
-    {% end %}
+    {% endif %}
     {% if score_type is not None and score_type.max_public_score != score_type.max_score %}
     <td class="total_score undefined">{{ _("N/A") }}</td>
-    {% end %}
+    {% endif %}
 {% elif not sr.scored() %}
 <tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.SCORING }}">
     {% raw col1 %}
@@ -48,10 +48,10 @@
     </td>
     {% if score_type is not None and score_type.max_public_score != 0 %}
     <td class="public_score undefined">{{ _("N/A") }}</td>
-    {% end %}
+    {% endif %}
     {% if score_type is not None and score_type.max_public_score != score_type.max_score %}
     <td class="total_score undefined">{{ _("N/A") }}</td>
-    {% end %}
+    {% endif %}
 {% else %}
 <tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.SCORED }}">
     {% raw col1 %}
@@ -64,7 +64,7 @@
     <td class="public_score {{ get_score_class(sr.public_score, score_type.max_public_score) }}">
         {{ score_type.format_score(sr.public_score, score_type.max_public_score, sr.public_score_details, task.score_precision, translation=translation) }}
     </td>
-    {% end %}
+    {% endif %}
 
     {% if score_type.max_public_score != score_type.max_score %}
         {% if s.token is not None or actual_phase == 3 %}
@@ -75,18 +75,18 @@
     <td class="total_score undefined">
         {{ _("N/A") }}
     </td>
-        {% end %}
-    {% end %}
-{% end %}
+        {% endif %}
+    {% endif %}
+{% endif %}
 {% if actual_phase >= +3 %}
     <td class="considered_in_score">
       {% if s.official %}
       Yes
       {% else %}
       No
-      {% end %}
+      {% endif %}
     </td>
-{% end %}
+{% endif %}
 {% if submissions_download_allowed %}
     <td class="files">
         {% comment We replace '.%l' with the actual language only when it occurs as an extension at the end of the string and only when %}
@@ -100,7 +100,7 @@
             {% set filename = next(iterkeys(s.files)) %}
             {% if s.language is not None %}
                 {% set filename = re.sub("\.%l$", get_language(s.language).source_extension, filename) %}
-            {% end %}
+            {% endif %}
         <a class="btn" href="{{ contest_url("tasks", task.name, "submissions", s_idx, "files", filename) }}">
             {{ _("Download") }}
         </a>
@@ -116,19 +116,19 @@
                     {% set temp_filename = re.sub("\.%l$", get_language(s.language).source_extension, filename) %}
                     {% if temp_filename not in s.files %}
                         {% set filename = temp_filename %}
-                    {% end %}
-                {% end %}
+                    {% endif %}
+                {% endif %}
                 <li>
                     <a href="{{ contest_url("tasks", task.name, "submissions", s_idx, "files", filename) }}">
                         {{ filename }}
                     </a>
                 </li>
-            {% end %}
+            {% endfor %}
             </ul>
         </div>
-        {% end %}
+        {% endif %}
     </td>
-{% end %}
+{% endif %}
 {% if tokens_contest != 0 and tokens_tasks != 0 and actual_phase == 0 %}
     <td class="token">
         {% if s.token is not None %}
@@ -144,8 +144,8 @@
         <a class="btn btn-warning disabled">{{ _("Wait...") }}</a>
             {% else %}
         <a class="btn disabled">{{ _("No tokens") }}</a>
-            {% end %}
-        {% end %}
+            {% endif %}
+        {% endif %}
     </td>
-{% end %}
+{% endif %}
 </tr>

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -3,16 +3,16 @@
 {% else %}
     {% set col1 = "<td class=\"time\">%s</td>" % translation.format_time(s.timestamp, timezone) %}
 {% endif %}
-{% if sr is None or not sr.compiled() %}
+{% if sr is none or not sr.compiled() %}
 <tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.COMPILING }}">
     {% raw col1 %}
     <td class="status">
         {{ _("Compiling...") }}
     </td>
-    {% if score_type is not None and score_type.max_public_score != 0 %}
+    {% if score_type is not none and score_type.max_public_score != 0 %}
     <td class="public_score undefined">{{ _("N/A") }}</td>
     {% endif %}
-    {% if score_type is not None and score_type.max_public_score != score_type.max_score %}
+    {% if score_type is not none and score_type.max_public_score != score_type.max_score %}
     <td class="total_score undefined">{{ _("N/A") }}</td>
     {% endif %}
 {% elif sr.compilation_outcome == "fail" %}
@@ -22,10 +22,10 @@
         {{ _("Compilation failed") }}
         <a class="details">{{ _("details") }}</a>
     </td>
-    {% if score_type is not None and score_type.max_public_score != 0 %}
+    {% if score_type is not none and score_type.max_public_score != 0 %}
     <td class="public_score undefined">{{ _("N/A") }}</td>
     {% endif %}
-    {% if score_type is not None and score_type.max_public_score != score_type.max_score %}
+    {% if score_type is not none and score_type.max_public_score != score_type.max_score %}
     <td class="total_score undefined">{{ _("N/A") }}</td>
     {% endif %}
 {% elif not sr.evaluated() %}
@@ -34,10 +34,10 @@
     <td class="status">
         {{ _("Evaluating...") }}
     </td>
-    {% if score_type is not None and score_type.max_public_score != 0 %}
+    {% if score_type is not none and score_type.max_public_score != 0 %}
     <td class="public_score undefined">{{ _("N/A") }}</td>
     {% endif %}
-    {% if score_type is not None and score_type.max_public_score != score_type.max_score %}
+    {% if score_type is not none and score_type.max_public_score != score_type.max_score %}
     <td class="total_score undefined">{{ _("N/A") }}</td>
     {% endif %}
 {% elif not sr.scored() %}
@@ -46,10 +46,10 @@
     <td class="status">
         {{ _("Scoring...") }}
     </td>
-    {% if score_type is not None and score_type.max_public_score != 0 %}
+    {% if score_type is not none and score_type.max_public_score != 0 %}
     <td class="public_score undefined">{{ _("N/A") }}</td>
     {% endif %}
-    {% if score_type is not None and score_type.max_public_score != score_type.max_score %}
+    {% if score_type is not none and score_type.max_public_score != score_type.max_score %}
     <td class="total_score undefined">{{ _("N/A") }}</td>
     {% endif %}
 {% else %}
@@ -67,7 +67,7 @@
     {% endif %}
 
     {% if score_type.max_public_score != score_type.max_score %}
-        {% if s.token is not None or actual_phase == 3 %}
+        {% if s.token is not none or actual_phase == 3 %}
     <td class="total_score {{ get_score_class(sr.score, score_type.max_score) }}">
         {{ score_type.format_score(sr.score, score_type.max_score, sr.score_details, task.score_precision, translation=translation) }}
     </td>
@@ -98,7 +98,7 @@
         </a>
         {% elif s.files|length == 1 %}
             {% set filename = next(iterkeys(s.files)) %}
-            {% if s.language is not None %}
+            {% if s.language is not none %}
                 {% set filename = re.sub("\.%l$", get_language(s.language).source_extension, filename) %}
             {% endif %}
         <a class="btn" href="{{ contest_url("tasks", task.name, "submissions", s_idx, "files", filename) }}">
@@ -112,7 +112,7 @@
             </a>
             <ul class="dropdown-menu">
             {% for filename in s.files %}
-                {% if s.language is not None %}
+                {% if s.language is not none %}
                     {% set temp_filename = re.sub("\.%l$", get_language(s.language).source_extension, filename) %}
                     {% if temp_filename not in s.files %}
                         {% set filename = temp_filename %}
@@ -131,7 +131,7 @@
 {% endif %}
 {% if tokens_contest != 0 and tokens_tasks != 0 and actual_phase == 0 %}
     <td class="token">
-        {% if s.token is not None %}
+        {% if s.token is not none %}
         <a class="btn disabled">{{ _("Played") }}</a>
         {% else %}
             {# TODO If the expiration or generation time are greater than valid_phase_end they "don't exist". It's useless to show "Wait..." in those cases. #}
@@ -140,7 +140,7 @@
             {% module xsrf_form_html() %}
             <button type="submit" class="btn btn-warning">{{ _("Play!") }}</button>
         </form>
-            {% elif (can_play_token and need_to_wait) or (not can_play_token and tokens_info[1] is not None) %}
+            {% elif (can_play_token and need_to_wait) or (not can_play_token and tokens_info[1] is not none) %}
         <a class="btn btn-warning disabled">{{ _("Wait...") }}</a>
             {% else %}
         <a class="btn disabled">{{ _("No tokens") }}</a>

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -99,7 +99,7 @@
         {% elif s.files|length == 1 %}
             {% set filename = next(iterkeys(s.files)) %}
             {% if s.language is not none %}
-                {% set filename = re.sub("\.%l$", get_language(s.language).source_extension, filename) %}
+                {% set filename = filename|replace(".%l", get_language(s.language).source_extension) %}
             {% endif %}
         <a class="btn" href="{{ contest_url("tasks", task.name, "submissions", s_idx, "files", filename) }}">
             {{ _("Download") }}
@@ -113,7 +113,7 @@
             <ul class="dropdown-menu">
             {% for filename in s.files %}
                 {% if s.language is not none %}
-                    {% set temp_filename = re.sub("\.%l$", get_language(s.language).source_extension, filename) %}
+                    {% set temp_filename = filename|replace(".%l", get_language(s.language).source_extension) %}
                     {% if temp_filename not in s.files %}
                         {% set filename = temp_filename %}
                     {% endif %}

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -99,7 +99,7 @@
         {% elif s.files|length == 1 %}
             {% set filename = next(iterkeys(s.files)) %}
             {% if s.language is not none %}
-                {% set filename = filename|replace(".%l", get_language(s.language).source_extension) %}
+                {% set filename = filename|replace(".%l", (s.language|get_language).source_extension) %}
             {% endif %}
         <a class="btn" href="{{ contest_url("tasks", task.name, "submissions", s_idx, "files", filename) }}">
             {{ _("Download") }}
@@ -113,7 +113,7 @@
             <ul class="dropdown-menu">
             {% for filename in s.files %}
                 {% if s.language is not none %}
-                    {% set temp_filename = filename|replace(".%l", get_language(s.language).source_extension) %}
+                    {% set temp_filename = filename|replace(".%l", (s.language|get_language).source_extension) %}
                     {% if temp_filename not in s.files %}
                         {% set filename = temp_filename %}
                     {% endif %}

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -99,7 +99,7 @@
         {% elif s.files|length == 1 %}
             {% set filename = next(iterkeys(s.files)) %}
             {% if s.language is not none %}
-                {% set filename = filename|replace(".%l", (s.language|get_language).source_extension) %}
+                {% set filename = filename|replace(".%l", (s.language|to_language).source_extension) %}
             {% endif %}
         <a class="btn" href="{{ contest_url("tasks", task.name, "submissions", s_idx, "files", filename) }}">
             {{ _("Download") }}
@@ -113,7 +113,7 @@
             <ul class="dropdown-menu">
             {% for filename in s.files %}
                 {% if s.language is not none %}
-                    {% set temp_filename = filename|replace(".%l", (s.language|get_language).source_extension) %}
+                    {% set temp_filename = filename|replace(".%l", (s.language|to_language).source_extension) %}
                     {% if temp_filename not in s.files %}
                         {% set filename = temp_filename %}
                     {% endif %}

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -119,7 +119,7 @@
     <td>{{ get_language(l).name }}</td>
     <td class="compilation_command_cell">
 {% for cmd in c %}
-        <code class="compilation_command">{{ " ".join(cmd) }}</code>
+        <code class="compilation_command">{{ cmd|join(" ") }}</code>
 {% endfor %}
     </td>
     {% endfor %}

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -1,4 +1,4 @@
-{% extends contest.html %}
+{% extends "contest.html" %}
 {% block core %}
 
 

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -1,8 +1,6 @@
 {% extends contest.html %}
 {% block core %}
 
-{% from cms.server.contest.formatting import format_token_rules %}
-{% from cms.grading.tasktypes import get_task_type %}
 
 {% if actual_phase == 0 or actual_phase == 3 or current_user.unrestricted %}
 
@@ -168,12 +166,11 @@
     <h2>{{ _("Attachments") }}</h2>
     <div id="attachments">
         <ul>
-    {% from cmscommon import mimetypes %}
     {% for filename, attachment in sorted(iteritems(task.attachments)) %}
-        {% set mime_type = mimetypes.get_type_for_file_name(filename) %}
+        {% set mime_type = get_mimetype_for_file_name(filename) %}
         {% if mime_type is not None %}
-            {% set type_name = mimetypes.get_name_for_type(mime_type) %}
-            {% set type_icon = mimetypes.get_icon_for_type(mime_type) %}
+            {% set type_name = get_name_for_mimetype(mime_type) %}
+            {% set type_icon = get_icon_for_mimetype(mime_type) %}
         {% else %}
             {% set type_name = None %}
             {% set type_icon = None %}

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -177,7 +177,7 @@
             <li>
                 <a href="{{ contest_url("tasks", task.name, "attachments", filename) }}" class="btn">
             {% if type_icon is not none %}
-                    <img src="{{ url("static", "img", "mimetypes", "%s.png" % type_icon) }}" alt="{{ mime_type }}" />
+                    <img src="{{ url("static", "img", "mimetypes", "%s.png"|format(type_icon)) }}" alt="{{ mime_type }}" />
             {% else %}
                     <img src="{{ url("static", "img", "mimetypes", "unknown.png") }}" alt="{{ _("unknown") }}" />
             {% endif %}

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -27,7 +27,7 @@
     <div class="span9">
     {% for lang_code in task.statements %}
         <a href="{{ contest_url("tasks", task.name, "statements", lang_code) }}" class="btn btn-large btn-success">{{ _("Download task statement") }}</a>
-    {% end %}
+    {% endfor %}
     </div>
 </div>
 {% else %}
@@ -46,10 +46,10 @@
                 {% raw _("Statement in <b>%s</b>") % escape(statement.language_name) %}
             {% else %}
                 {% raw _("Statement in %s") % escape(statement.language_name) %}
-            {% end %}
+            {% endif %}
         </a>
-        {% end %}
-    {% end %}
+        {% endif %}
+    {% endfor %}
     {% for statement in sorted(itervalues(task.statements), key=lambda x: x.language_name) %}
         {% if statement.language in user_primary and statement.language not in task_primary %}
         <a href="{{ contest_url("tasks", task.name, "statements", statement.language) }}" class="btn btn-large">
@@ -57,10 +57,10 @@
                 {% raw _("Statement in <b>%s</b>") % escape(statement.language_name) %}
             {% else %}
                 {% raw _("Statement in %s") % escape(statement.language_name) %}
-            {% end %}
+            {% endif %}
         </a>
-        {% end %}
-    {% end %}
+        {% endif %}
+    {% endfor %}
     </div>
     <div class="all_statements well">
         <div>
@@ -72,15 +72,15 @@
             {% raw _("<b>%s</b>") % escape(statement.language_name) %}
         {% else %}
             {% raw _("%s") % escape(statement.language_name) %}
-        {% end %}
+        {% endif %}
                     </a>
                 </li>
-    {% end %}
+    {% endfor %}
             </ul>
         </div>
     </div>
 </div>
-{% end %}
+{% endif %}
 
 
 <h2>{{ _("Some details") }}</h2>
@@ -101,13 +101,13 @@
             <th>{{ _("Time limit") }}</th>
             <td colspan="2">{{ translation.format_duration(task.active_dataset.time_limit, length="long") }}</td>
         </tr>
-{% end %}
+{% endif %}
 {% if task.active_dataset.memory_limit is not None %}
         <tr>
             <th>{{ _("Memory limit") }}</th>
             <td colspan="2">{{ translation.format_size(task.active_dataset.memory_limit * 1024 * 1024) }}</td>
         </tr>
-{% end %}
+{% endif %}
 {% set compilation_commands = task_type.get_compilation_commands([x.filename for x in task.submission_format]) %}
 {% if compilation_commands is not None %}
 {% set compilation_commands = {lang: compilation_commands[lang] for lang in contest.languages} %}
@@ -117,16 +117,16 @@
         {% if i > 0 %}
 </tr>
 <tr>
-        {% end %}
+        {% endif %}
     <td>{{ get_language(l).name }}</td>
     <td class="compilation_command_cell">
 {% for cmd in c %}
         <code class="compilation_command">{{ " ".join(cmd) }}</code>
-{% end %}
+{% endfor %}
     </td>
-    {% end %}
+    {% endfor %}
 </tr>
-{% end %}
+{% endif %}
 
 {% if tokens_contest != 0 and tokens_tasks != 0 %}
 <tr>
@@ -155,10 +155,10 @@
         {{ _("Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token.") }}
         {% raw _("You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>.") % {"type_pl": _("contest-tokens"), "contest_root": contest_url()} %}
         </p>
-    {% end %}
+    {% endif %}
     </td>
 </tr>
-{% end %}
+{% endif %}
     </tbody>
 </table>
 
@@ -177,7 +177,7 @@
         {% else %}
             {% set type_name = None %}
             {% set type_icon = None %}
-        {% end %}
+        {% endif %}
         {% set file_size = handler.application.service.file_cacher.get_size(attachment.digest) %}
             <li>
                 <a href="{{ contest_url("tasks", task.name, "attachments", filename) }}" class="btn">
@@ -185,22 +185,22 @@
                     <img src="{{ url("static", "img", "mimetypes", "%s.png" % type_icon) }}" alt="{{ mime_type }}" />
             {% else %}
                     <img src="{{ url("static", "img", "mimetypes", "unknown.png") }}" alt="{{ _("unknown") }}" />
-            {% end %}
+            {% endif %}
                     <span class="first_line">
                         <span class="name">{{ filename }}</span>
                         <span class="size">{{ translation.format_size(file_size) }}</span>
                     </span>
             {% if type_name is not None %}
                     <span class="type">{{ translation.translate_mimetype(type_name) }}</span>
-            {% end %}
+            {% endif %}
                 </a>
             </li>
-    {% end %}
+    {% endfor %}
         </ul>
     </div>
-{% end %}
+{% endif %}
 
 </div>
-{% end %}
+{% endif %}
 
-{% end %}
+{% endblock core %}

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -106,9 +106,9 @@
             <td colspan="2">{{ translation.format_size(task.active_dataset.memory_limit * 1024 * 1024) }}</td>
         </tr>
 {% endif %}
-{% set compilation_commands = task_type.get_compilation_commands([x.filename for x in task.submission_format]) %}
+{% set compilation_commands = task_type.get_compilation_commands(task.submission_format|map(attribute="filename")|list) %}
 {% if compilation_commands is not None %}
-{% set compilation_commands = {lang: compilation_commands[lang] for lang in contest.languages} %}
+{% set compilation_commands = compilation_commands|dictselect("in", contest.languages, by="key") %}
 <tr>
     <th rowspan="{{ len(compilation_commands) }}">{{ _("Compilation commands") }}</th>
     {% for i, (l, c) in enumerate(sorted(iteritems(compilation_commands))) %}
@@ -136,8 +136,7 @@
         </p>
     {% elif tokens_contest == 2 %}
         <p>
-        {% set tokens = {k[6:]: v for k, v in iteritems(task.__dict__) if k.startswith("token_")} %}
-        {{ format_token_rules(tokens, translation=translation) }}
+        {{ format_token_rules(task|extract_token_params, translation=translation) }}
         </p>
     {% elif tokens_tasks == 2 %}
         <p>
@@ -145,8 +144,7 @@
         </p>
     {% else %}
         <p>
-        {% set tokens = {k[6:]: v for k, v in iteritems(task.__dict__) if k.startswith("token_")} %}
-        {{ format_token_rules(tokens, t_type="task", translation=translation) }}
+        {{ format_token_rules(task|extract_token_params, t_type="task", translation=translation) }}
         </p>
 
         <p>

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -94,20 +94,20 @@
             <th>{{ _("Type") }}</th>
             <td colspan="2">{% set task_type = get_task_type(dataset=task.active_dataset) %}{{ task_type.name }}</td>
         </tr>
-{% if task.active_dataset.time_limit is not None %}
+{% if task.active_dataset.time_limit is not none %}
         <tr>
             <th>{{ _("Time limit") }}</th>
             <td colspan="2">{{ translation.format_duration(task.active_dataset.time_limit, length="long") }}</td>
         </tr>
 {% endif %}
-{% if task.active_dataset.memory_limit is not None %}
+{% if task.active_dataset.memory_limit is not none %}
         <tr>
             <th>{{ _("Memory limit") }}</th>
             <td colspan="2">{{ translation.format_size(task.active_dataset.memory_limit * 1024 * 1024) }}</td>
         </tr>
 {% endif %}
 {% set compilation_commands = task_type.get_compilation_commands(task.submission_format|map(attribute="filename")|list) %}
-{% if compilation_commands is not None %}
+{% if compilation_commands is not none %}
 {% set compilation_commands = compilation_commands|dictselect("in", contest.languages, by="key") %}
 <tr>
     <th rowspan="{{ compilation_commands|length }}">{{ _("Compilation commands") }}</th>
@@ -166,17 +166,17 @@
         <ul>
     {% for filename, attachment in iteritems(task.attachments|sort) %}
         {% set mime_type = get_mimetype_for_file_name(filename) %}
-        {% if mime_type is not None %}
+        {% if mime_type is not none %}
             {% set type_name = get_name_for_mimetype(mime_type) %}
             {% set type_icon = get_icon_for_mimetype(mime_type) %}
         {% else %}
-            {% set type_name = None %}
-            {% set type_icon = None %}
+            {% set type_name = none %}
+            {% set type_icon = none %}
         {% endif %}
         {% set file_size = handler.application.service.file_cacher.get_size(attachment.digest) %}
             <li>
                 <a href="{{ contest_url("tasks", task.name, "attachments", filename) }}" class="btn">
-            {% if type_icon is not None %}
+            {% if type_icon is not none %}
                     <img src="{{ url("static", "img", "mimetypes", "%s.png" % type_icon) }}" alt="{{ mime_type }}" />
             {% else %}
                     <img src="{{ url("static", "img", "mimetypes", "unknown.png") }}" alt="{{ _("unknown") }}" />
@@ -185,7 +185,7 @@
                         <span class="name">{{ filename }}</span>
                         <span class="size">{{ translation.format_size(file_size) }}</span>
                     </span>
-            {% if type_name is not None %}
+            {% if type_name is not none %}
                     <span class="type">{{ translation.translate_mimetype(type_name) }}</span>
             {% endif %}
                 </a>

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -116,7 +116,7 @@
 </tr>
 <tr>
         {% endif %}
-    <td>{{ get_language(l).name }}</td>
+    <td>{{ (l|get_language).name }}</td>
     <td class="compilation_command_cell">
 {% for cmd in c %}
         <code class="compilation_command">{{ cmd|join(" ") }}</code>

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -111,8 +111,8 @@
 {% set compilation_commands = compilation_commands|dictselect("in", contest.languages, by="key") %}
 <tr>
     <th rowspan="{{ len(compilation_commands) }}">{{ _("Compilation commands") }}</th>
-    {% for i, (l, c) in enumerate(iteritems(contest.languages)|sort) %}
-        {% if i > 0 %}
+    {% for l, c in iteritems(contest.languages)|sort %}
+        {% if not loop.first %}
 </tr>
 <tr>
         {% endif %}

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -116,7 +116,7 @@
 </tr>
 <tr>
         {% endif %}
-    <td>{{ (l|get_language).name }}</td>
+    <td>{{ (l|to_language).name }}</td>
     <td class="compilation_command_cell">
 {% for cmd in c %}
         <code class="compilation_command">{{ cmd|join(" ") }}</code>

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -37,7 +37,7 @@
             {{ _("Some suggested translations follow.") }}
         </p>
     {% set task_primary = primary_statements %}
-    {% for statement in sorted(itervalues(task.statements), key=lambda x: x.language_name) %}
+    {% for statement in itervalues(task.statements)|sort(attribute="language_name") %}
         {% if statement.language in task_primary %}
         <a href="{{ contest_url("tasks", task.name, "statements", statement.language) }}" class="btn btn-large btn-success">
             {% if statement.language != statement.language_name %}
@@ -48,7 +48,7 @@
         </a>
         {% endif %}
     {% endfor %}
-    {% for statement in sorted(itervalues(task.statements), key=lambda x: x.language_name) %}
+    {% for statement in itervalues(task.statements)|sort(attribute="language_name") %}
         {% if statement.language in user_primary and statement.language not in task_primary %}
         <a href="{{ contest_url("tasks", task.name, "statements", statement.language) }}" class="btn btn-large">
             {% if statement.language != statement.language_name %}
@@ -63,7 +63,7 @@
     <div class="all_statements well">
         <div>
             <ul>
-    {% for statement in sorted(itervalues(task.statements), key=lambda x: x.language_name) %}
+    {% for statement in itervalues(task.statements)|sort(attribute="language_name") %}
                 <li>
                     <a href="{{ contest_url("tasks", task.name, "statements", statement.language) }}">
         {% if statement.language != statement.language_name %}
@@ -111,7 +111,7 @@
 {% set compilation_commands = compilation_commands|dictselect("in", contest.languages, by="key") %}
 <tr>
     <th rowspan="{{ len(compilation_commands) }}">{{ _("Compilation commands") }}</th>
-    {% for i, (l, c) in enumerate(sorted(iteritems(compilation_commands))) %}
+    {% for i, (l, c) in enumerate(iteritems(contest.languages)|sort) %}
         {% if i > 0 %}
 </tr>
 <tr>
@@ -164,7 +164,7 @@
     <h2>{{ _("Attachments") }}</h2>
     <div id="attachments">
         <ul>
-    {% for filename, attachment in sorted(iteritems(task.attachments)) %}
+    {% for filename, attachment in iteritems(task.attachments|sort) %}
         {% set mime_type = get_mimetype_for_file_name(filename) %}
         {% if mime_type is not None %}
             {% set type_name = get_name_for_mimetype(mime_type) %}

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -111,7 +111,7 @@
 {% set compilation_commands = compilation_commands|dictselect("in", contest.languages, by="key") %}
 <tr>
     <th rowspan="{{ compilation_commands|length }}">{{ _("Compilation commands") }}</th>
-    {% for l, c in iteritems(contest.languages)|sort %}
+    {% for l, c in contest.languages|dictsort(by="key") %}
         {% if not loop.first %}
 </tr>
 <tr>
@@ -164,7 +164,7 @@
     <h2>{{ _("Attachments") }}</h2>
     <div id="attachments">
         <ul>
-    {% for filename, attachment in iteritems(task.attachments|sort) %}
+    {% for filename, attachment in task.attachments|dictsort(by="key") %}
         {% set mime_type = get_mimetype_for_file_name(filename) %}
         {% if mime_type is not none %}
             {% set type_name = get_name_for_mimetype(mime_type) %}

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -14,13 +14,13 @@
 
 <h2>{{ _("Statement") }}</h2>
 
-{% if len(task.statements) == 0 %}
+{% if task.statements|length == 0 %}
 <div class="row statement no_statements">
     <div class="span9">
         {{ _("no statement available") }}
     </div>
 </div>
-{% elif len(task.statements) == 1 %}
+{% elif task.statements|length == 1 %}
 <div class="row statement one_statement">
     <div class="span9">
     {% for lang_code in task.statements %}
@@ -110,7 +110,7 @@
 {% if compilation_commands is not None %}
 {% set compilation_commands = compilation_commands|dictselect("in", contest.languages, by="key") %}
 <tr>
-    <th rowspan="{{ len(compilation_commands) }}">{{ _("Compilation commands") }}</th>
+    <th rowspan="{{ compilation_commands|length }}">{{ _("Compilation commands") }}</th>
     {% for l, c in iteritems(contest.languages)|sort %}
         {% if not loop.first %}
 </tr>
@@ -160,7 +160,7 @@
 
 
 
-{% if task.attachments != {} %}
+{% if task.attachments|length > 0 %}
     <h2>{{ _("Attachments") }}</h2>
     <div id="attachments">
         <ul>

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -105,12 +105,12 @@ $(document).ready(function () {
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "submit") }}" method="POST">
             {% module xsrf_form_html() %}
             <fieldset>
-{% for idx, filename in enumerate(task.submission_format|map(attribute="filename")) %}
+{% for filename in task.submission_format|map(attribute="filename") %}
                 <div class="control-group">
-                    <label class="control-label" for="input{{ idx }}">{{ filename.replace(".%l", ": ") }}</label>
+                    <label class="control-label" for="input{{ loop.index0 }}">{{ filename.replace(".%l", ": ") }}</label>
                     <div class="controls">
                         <input type="file" class="input-xlarge"
-                               id="input{{ idx }}" name="{{ filename }}"
+                               id="input{{ loop.index0 }}" name="{{ filename }}"
                                onchange="CMS.CWSUtils.filter_languages($('#language option'), $(this).parents('fieldset').find('input[type=file]'))"/>
                     </div>
                 </div>
@@ -269,8 +269,9 @@ $(document).ready(function () {
         {% endif %}
         </tr>
     {% else %}
-        {% for s_idx, s in enumerate(submissions|sort(attribute="timestamp")|reverse) %}
-            {% set s_idx = len(submissions) - s_idx %}
+        {% for s in submissions|sort(attribute="timestamp")|reverse %}
+            {# loop.revindex is broken: https://github.com/pallets/jinja/issues/794 #}
+            {% set s_idx = len(submissions) - loop.index0 %}
             {% set sr = s.get_result(s.task.active_dataset) %}
             {% include "submission_row.html" %}
         {% endfor %}

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -269,7 +269,7 @@ $(document).ready(function () {
         {% endif %}
         </tr>
     {% else %}
-        {% for s_idx, s in enumerate(sorted(submissions, key=lambda s: s.timestamp, reverse=True)) %}
+        {% for s_idx, s in enumerate(submissions|sort(attribute="timestamp")|reverse) %}
             {% set s_idx = len(submissions) - s_idx %}
             {% set sr = s.get_result(s.task.active_dataset) %}
             {% include "submission_row.html" %}

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -87,7 +87,6 @@ $(document).ready(function () {
 
 <h2 style="margin-bottom: 10px">{{ _("Submit a solution") }}</h2>
 
-{% from cms.grading.tasktypes import get_task_type %}
 {% set task_type = get_task_type(dataset=task.active_dataset) %}
 {% if task_type.ALLOW_PARTIAL_SUBMISSION %}
   <p><strong>{{ _("You may submit any subset of outputs in a single submission.") }}</strong></p>
@@ -202,14 +201,12 @@ $(document).ready(function () {
 {% endif %}
 
 
-{% from cms.grading.scoretypes import get_score_type %}
 {% try %}
     {% set score_type = get_score_type(dataset=task.active_dataset) %}
 {% except %}
     {% set score_type = None %}
 {% endtry %}
 
-{% from cmscommon.datetime import utc %}
 {% set show_date = any(s.timestamp.replace(tzinfo=utc).astimezone(timezone).date() != now.replace(tzinfo=utc).astimezone(timezone).date() for s in submissions) %}
 
 

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -107,7 +107,7 @@ $(document).ready(function () {
             <fieldset>
 {% for filename in task.submission_format|map(attribute="filename") %}
                 <div class="control-group">
-                    <label class="control-label" for="input{{ loop.index0 }}">{{ filename.replace(".%l", ": ") }}</label>
+                    <label class="control-label" for="input{{ loop.index0 }}">{{ filename|replace(".%l", ": ") }}</label>
                     <div class="controls">
                         <input type="file" class="input-xlarge"
                                id="input{{ loop.index0 }}" name="{{ filename }}"

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -72,7 +72,7 @@ $(document).ready(function () {
     });
 });
 
-{% end %}
+{% endblock additional_js %}
 
 {% block core %}
 
@@ -91,7 +91,7 @@ $(document).ready(function () {
 {% set task_type = get_task_type(dataset=task.active_dataset) %}
 {% if task_type.ALLOW_PARTIAL_SUBMISSION %}
   <p><strong>{{ _("You may submit any subset of outputs in a single submission.") }}</strong></p>
-{% end %}
+{% endif %}
 
 {% if submissions_left is not None %}
     <div class="span5">
@@ -99,7 +99,7 @@ $(document).ready(function () {
         {{ _("You can submit %(submissions_left)s more solution(s).") % {"submissions_left": submissions_left} }}
         </p>
     </div>
-{% end %}
+{% endif %}
 
 <div id="submit_solution" class="row">
     <div class="span5">
@@ -115,18 +115,18 @@ $(document).ready(function () {
                                onchange="CMS.CWSUtils.filter_languages($('#language option'), $(this).parents('fieldset').find('input[type=file]'))"/>
                     </div>
                 </div>
-{% end %}
+{% endfor %}
 {% if any(x.filename.endswith(".%l") for x in task.submission_format) %}
                 <div class="control-group">
                     <div class="controls">
                         <select id="language" name="language">
 {% for lang in contest.languages %}
                             <option value="{{ lang }}">{{ lang }}</option>
-{% end %}
+{% endfor %}
                         </select>
                     </div>
                 </div>
-{% end %}
+{% endif %}
                 <div class="control-group">
                     <div class="controls">
                         <button type="submit" class="btn btn-success">{{ _("Submit") }}</button>
@@ -156,7 +156,7 @@ $(document).ready(function () {
             </fieldset>
         </form>
     </div>
-{% end %}
+{% endif %}
 </div>
 
 
@@ -174,17 +174,17 @@ $(document).ready(function () {
             {{ _("Right now, you have one token available on this task.") }}
         {% else %}
             {{ _("Right now, you have %(tokens)s tokens available on this task.") % { "tokens": tokens_info[0]} }}
-        {% end %}
+        {% endif %}
         {% if need_to_wait %}
             {% set t = translation.format_datetime_smart(tokens_info[2], now, timezone) %}
             {% raw _("But you have to wait until %(expiration_time)s to use them.") % {"expiration_time": t} %}
-        {% end %}
+        {% endif %}
         {% if tokens_info[1] is not None %}
             {% set t = translation.format_datetime_smart(tokens_info[1], now, timezone) %}
             {{ _("You will receive a new token at %(gen_time)s.") % {"gen_time": t} }}
         {% else %}
             {{ _("In the current situation, no more tokens will be generated.") }}
-        {% end %}
+        {% endif %}
     {% else %}
         {{ _("Right now, you do not have tokens available for this task.") }}
         {% if actual_phase == 0 and tokens_info[1] is not None %}
@@ -193,13 +193,13 @@ $(document).ready(function () {
             {% if tokens_info[2] is not None and tokens_info[2] > tokens_info[1] %}
                 {% set t = translation.format_datetime_smart(tokens_info[2], now, timezone) %}
                 {{ _("But you will have to wait until %(expiration_time)s to use it.") % {"expiration_time": t} }}
-            {% end %}
+            {% endif %}
         {% else %}
             {{ _("In the current situation, no more tokens will be generated.") }}
-        {% end %}
-    {% end %}
+        {% endif %}
+    {% endif %}
 </div>
-{% end %}
+{% endif %}
 
 
 {% from cms.grading.scoretypes import get_score_type %}
@@ -207,7 +207,7 @@ $(document).ready(function () {
     {% set score_type = get_score_type(dataset=task.active_dataset) %}
 {% except %}
     {% set score_type = None %}
-{% end %}
+{% endtry %}
 
 {% from cmscommon.datetime import utc %}
 {% set show_date = any(s.timestamp.replace(tzinfo=utc).astimezone(timezone).date() != now.replace(tzinfo=utc).astimezone(timezone).date() for s in submissions) %}
@@ -219,23 +219,23 @@ $(document).ready(function () {
         <col class="datetime"/>
 {% else %}
         <col class="time"/>
-{% end %}
+{% endif %}
         <col class="status"/>
 {% if score_type is not None and score_type.max_public_score != 0 and score_type.max_public_score != score_type.max_score %}
         <col class="public_score"/>
         <col class="total_score"/>
 {% else %}
         <col class="total_score"/>
-{% end %}
+{% endif %}
 {% if actual_phase >= +3 %}
         <col class="considered_in_score"/>
-{% end %}
+{% endif %}
 {% if submissions_download_allowed %}
         <col class="files"/>
-{% end %}
+{% endif %}
 {% if tokens_contest != 0 and tokens_tasks != 0 and actual_phase == 0 %}
         <col class="token"/>
-{% end %}
+{% endif %}
     </colgroup>
     <thead>
         <tr>
@@ -243,23 +243,23 @@ $(document).ready(function () {
             <th class="datetime">{{ _("Date and time") }}</th>
 {% else %}
             <th class="time">{{ _("Time") }}</th>
-{% end %}
+{% endif %}
             <th class="status">{{ _("Status") }}</th>
 {% if score_type is not None and score_type.max_public_score != 0 and score_type.max_public_score != score_type.max_score %}
             <th class="public_score">{{ _("Public score") }}</th>
             <th class="total_score">{{ _("Total score") }}</th>
 {% else %}
             <th class="total_score">{{ _("Score") }}</th>
-{% end %}
+{% endif %}
 {% if actual_phase >= +3 %}
             <th class="considered_in_score">{{ _("Official") }}</th>
-{% end %}
+{% endif %}
 {% if submissions_download_allowed %}
             <th class="files">{{ _("Files") }}</th>
-{% end %}
+{% endif %}
 {% if tokens_contest != 0 and tokens_tasks != 0 and actual_phase == 0 %}
             <th class="token">{{ _("Token") }}</th>
-{% end %}
+{% endif %}
         </tr>
     </thead>
     <tbody>
@@ -269,15 +269,15 @@ $(document).ready(function () {
             <td colspan="6" class="no_submissions">{{ _("no submissions yet") }}</td>
         {% else %}
             <td colspan="5" class="no_submissions">{{ _("no submissions yet") }}</td>
-        {% end %}
+        {% endif %}
         </tr>
     {% else %}
         {% for s_idx, s in enumerate(sorted(submissions, key=lambda s: s.timestamp, reverse=True)) %}
             {% set s_idx = len(submissions) - s_idx %}
             {% set sr = s.get_result(s.task.active_dataset) %}
             {% include submission_row.html %}
-        {% end %}
-    {% end %}
+        {% endfor %}
+    {% endif %}
     </tbody>
 </table>
 
@@ -294,6 +294,6 @@ $(document).ready(function () {
 </div>
 
 </div>
-{% end %}
+{% endif %}
 
-{% end %}
+{% endblock core %}

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -1,4 +1,4 @@
-{% extends contest.html %}
+{% extends "contest.html" %}
 
 {% block additional_js %}
 

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -272,7 +272,7 @@ $(document).ready(function () {
         {% for s_idx, s in enumerate(sorted(submissions, key=lambda s: s.timestamp, reverse=True)) %}
             {% set s_idx = len(submissions) - s_idx %}
             {% set sr = s.get_result(s.task.active_dataset) %}
-            {% include submission_row.html %}
+            {% include "submission_row.html" %}
         {% endfor %}
     {% endif %}
     </tbody>

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -207,7 +207,7 @@ $(document).ready(function () {
     {% set score_type = none %}
 {% endtry %}
 
-{% set show_date = submissions|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())|list|length > 0 %}
+{% set show_date = not submissions|map(attribute="timestamp")|all("today") %}
 
 
 <table id="submission_list" class="table table-bordered table-striped">

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -103,7 +103,7 @@ $(document).ready(function () {
 <div id="submit_solution" class="row">
     <div class="span5">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "submit") }}" method="POST">
-            {% module xsrf_form_html() %}
+            {{ xsrf_form_html|safe }}
             <fieldset>
 {% for filename in task.submission_format|map(attribute="filename") %}
                 <div class="control-group">
@@ -138,7 +138,7 @@ $(document).ready(function () {
 {% if task.submission_format|length > 1 and task.submission_format|map(attribute="filename")|select("endswith", ".%l")|list|length == 0 %}
     <div class="span4">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "submit") }}" method="POST">
-            {% module xsrf_form_html() %}
+            {{ xsrf_form_html|safe }}
             <fieldset>
                 <div class="control-group">
                     <label class="control-label" for="input_zip">{{ _("submission.zip") }}</label>

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -115,7 +115,7 @@ $(document).ready(function () {
                     </div>
                 </div>
 {% endfor %}
-{% if task.submission_format|map(attribute="filename")|select("endswith", ".%l")|list|length > 0 %}
+{% if task.submission_format|map(attribute="filename")|any("endswith", ".%l") %}
                 <div class="control-group">
                     <div class="controls">
                         <select id="language" name="language">
@@ -135,7 +135,7 @@ $(document).ready(function () {
             </fieldset>
         </form>
     </div>
-{% if task.submission_format|length > 1 and task.submission_format|map(attribute="filename")|select("endswith", ".%l")|list|length == 0 %}
+{% if task.submission_format|length > 1 and not task.submission_format|map(attribute="filename")|any("endswith", ".%l") %}
     <div class="span4">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "submit") }}" method="POST">
             {{ xsrf_form_html|safe }}

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -135,7 +135,7 @@ $(document).ready(function () {
             </fieldset>
         </form>
     </div>
-{% if len(task.submission_format) > 1 and not any(task.submission_format|map(attribute="filename")|select("endswith", ".%l")) %}
+{% if task.submission_format|length > 1 and not any(task.submission_format|map(attribute="filename")|select("endswith", ".%l")) %}
     <div class="span4">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "submit") }}" method="POST">
             {% module xsrf_form_html() %}
@@ -260,7 +260,7 @@ $(document).ready(function () {
         </tr>
     </thead>
     <tbody>
-    {% if len(submissions) == 0 %}
+    {% if submissions|length == 0 %}
         <tr>
         {% if tokens_contest != 0 and tokens_tasks != 0 %}
             <td colspan="6" class="no_submissions">{{ _("no submissions yet") }}</td>
@@ -271,7 +271,7 @@ $(document).ready(function () {
     {% else %}
         {% for s in submissions|sort(attribute="timestamp")|reverse %}
             {# loop.revindex is broken: https://github.com/pallets/jinja/issues/794 #}
-            {% set s_idx = len(submissions) - loop.index0 %}
+            {% set s_idx = submissions|length - loop.index0 %}
             {% set sr = s.get_result(s.task.active_dataset) %}
             {% include "submission_row.html" %}
         {% endfor %}

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -115,7 +115,7 @@ $(document).ready(function () {
                     </div>
                 </div>
 {% endfor %}
-{% if any(task.submission_format|map(attribute="filename")|select("endswith", ".%l")) %}
+{% if task.submission_format|map(attribute="filename")|select("endswith", ".%l")|list|length > 0 %}
                 <div class="control-group">
                     <div class="controls">
                         <select id="language" name="language">
@@ -135,7 +135,7 @@ $(document).ready(function () {
             </fieldset>
         </form>
     </div>
-{% if task.submission_format|length > 1 and not any(task.submission_format|map(attribute="filename")|select("endswith", ".%l")) %}
+{% if task.submission_format|length > 1 and task.submission_format|map(attribute="filename")|select("endswith", ".%l")|list|length == 0 %}
     <div class="span4">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "submit") }}" method="POST">
             {% module xsrf_form_html() %}
@@ -207,7 +207,7 @@ $(document).ready(function () {
     {% set score_type = None %}
 {% endtry %}
 
-{% set show_date = any(submissions|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())) %}
+{% set show_date = submissions|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())|list|length > 0 %}
 
 
 <table id="submission_list" class="table table-bordered table-striped">

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -105,7 +105,7 @@ $(document).ready(function () {
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "submit") }}" method="POST">
             {% module xsrf_form_html() %}
             <fieldset>
-{% for idx, filename in enumerate(x.filename for x in task.submission_format) %}
+{% for idx, filename in enumerate(task.submission_format|map(attribute="filename")) %}
                 <div class="control-group">
                     <label class="control-label" for="input{{ idx }}">{{ filename.replace(".%l", ": ") }}</label>
                     <div class="controls">
@@ -115,7 +115,7 @@ $(document).ready(function () {
                     </div>
                 </div>
 {% endfor %}
-{% if any(x.filename.endswith(".%l") for x in task.submission_format) %}
+{% if any(task.submission_format|map(attribute="filename")|select("endswith", ".%l")) %}
                 <div class="control-group">
                     <div class="controls">
                         <select id="language" name="language">
@@ -135,7 +135,7 @@ $(document).ready(function () {
             </fieldset>
         </form>
     </div>
-{% if len(task.submission_format) > 1 and not any(x.filename.endswith(".%l") for x in task.submission_format) %}
+{% if len(task.submission_format) > 1 and not any(task.submission_format|map(attribute="filename")|select("endswith", ".%l")) %}
     <div class="span4">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "submit") }}" method="POST">
             {% module xsrf_form_html() %}
@@ -207,7 +207,7 @@ $(document).ready(function () {
     {% set score_type = None %}
 {% endtry %}
 
-{% set show_date = any(s.timestamp.replace(tzinfo=utc).astimezone(timezone).date() != now.replace(tzinfo=utc).astimezone(timezone).date() for s in submissions) %}
+{% set show_date = any(submissions|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())) %}
 
 
 <table id="submission_list" class="table table-bordered table-striped">

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -92,7 +92,7 @@ $(document).ready(function () {
   <p><strong>{{ _("You may submit any subset of outputs in a single submission.") }}</strong></p>
 {% endif %}
 
-{% if submissions_left is not None %}
+{% if submissions_left is not none %}
     <div class="span5">
         <p>
         {{ _("You can submit %(submissions_left)s more solution(s).") % {"submissions_left": submissions_left} }}
@@ -165,7 +165,7 @@ $(document).ready(function () {
 <div style="padding-bottom:10px">
     {% set tokens_info = contest.tokens_available(current_user, task, now) %}
     {% set can_play_token = actual_phase == 0 and (tokens_info[0] > 0 or tokens_info[0] == -1) %}
-    {% set need_to_wait = tokens_info[2] is not None %}
+    {% set need_to_wait = tokens_info[2] is not none %}
     {% if can_play_token %}
         {% if tokens_info[0] == -1 %}
             {{ _("Right now, you have infinite tokens available on this task.") }}
@@ -178,7 +178,7 @@ $(document).ready(function () {
             {% set t = translation.format_datetime_smart(tokens_info[2], now, timezone) %}
             {% raw _("But you have to wait until %(expiration_time)s to use them.") % {"expiration_time": t} %}
         {% endif %}
-        {% if tokens_info[1] is not None %}
+        {% if tokens_info[1] is not none %}
             {% set t = translation.format_datetime_smart(tokens_info[1], now, timezone) %}
             {{ _("You will receive a new token at %(gen_time)s.") % {"gen_time": t} }}
         {% else %}
@@ -186,10 +186,10 @@ $(document).ready(function () {
         {% endif %}
     {% else %}
         {{ _("Right now, you do not have tokens available for this task.") }}
-        {% if actual_phase == 0 and tokens_info[1] is not None %}
+        {% if actual_phase == 0 and tokens_info[1] is not none %}
             {% set t = translation.format_datetime_smart(tokens_info[1], now, timezone) %}
             {{ _("You will receive a new token at %(gen_time)s.") % {"gen_time": t} }}
-            {% if tokens_info[2] is not None and tokens_info[2] > tokens_info[1] %}
+            {% if tokens_info[2] is not none and tokens_info[2] > tokens_info[1] %}
                 {% set t = translation.format_datetime_smart(tokens_info[2], now, timezone) %}
                 {{ _("But you will have to wait until %(expiration_time)s to use it.") % {"expiration_time": t} }}
             {% endif %}
@@ -204,7 +204,7 @@ $(document).ready(function () {
 {% try %}
     {% set score_type = get_score_type(dataset=task.active_dataset) %}
 {% except %}
-    {% set score_type = None %}
+    {% set score_type = none %}
 {% endtry %}
 
 {% set show_date = submissions|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())|list|length > 0 %}
@@ -218,7 +218,7 @@ $(document).ready(function () {
         <col class="time"/>
 {% endif %}
         <col class="status"/>
-{% if score_type is not None and score_type.max_public_score != 0 and score_type.max_public_score != score_type.max_score %}
+{% if score_type is not none and score_type.max_public_score != 0 and score_type.max_public_score != score_type.max_score %}
         <col class="public_score"/>
         <col class="total_score"/>
 {% else %}
@@ -242,7 +242,7 @@ $(document).ready(function () {
             <th class="time">{{ _("Time") }}</th>
 {% endif %}
             <th class="status">{{ _("Status") }}</th>
-{% if score_type is not None and score_type.max_public_score != 0 and score_type.max_public_score != score_type.max_score %}
+{% if score_type is not none and score_type.max_public_score != 0 and score_type.max_public_score != score_type.max_score %}
             <th class="public_score">{{ _("Public score") }}</th>
             <th class="total_score">{{ _("Total score") }}</th>
 {% else %}

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -100,7 +100,7 @@ $(document).ready(function () {
             <fieldset>
 {% for filename in task.submission_format|map(attribute="filename")|list + task_type.get_user_managers(task.submission_format) %}
                 <div class="control-group">
-                    <label class="control-label" for="input{{ loop.index0 }}">{{ filename.replace(".%l", "") }}</label>
+                    <label class="control-label" for="input{{ loop.index0 }}">{{ filename|replace(".%l", "") }}</label>
                     <div class="controls">
                         <input type="file" class="input-xlarge"
                                id="input{{ loop.index0 }}" name="{{ filename }}"

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -1,4 +1,4 @@
-{% extends contest.html %}
+{% extends "contest.html" %}
 
 {% block additional_js %}
 $(document).on("click", ".user_test_list tbody tr td.status .details", function (event) {

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -205,7 +205,7 @@ $(document).ready(function () {
             <td colspan="7" class="no_user_tests">{{ _("no tests yet") }}</td>
         </tr>
     {% else %}
-        {% for t_idx, t in enumerate(sorted(user_tests[task.id], key=lambda t: t.timestamp, reverse=True)) %}
+        {% for t_idx, t in enumerate(user_tests[task.id]|sort(attribute="timestamp")|reverse) %}
             {% set t_idx = len(user_tests[task.id]) - t_idx %}
             {% set tr = t.get_result(t.task.active_dataset) %}
             {% include "user_test_row.html" %}

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -54,7 +54,7 @@ $(document).ready(function () {
         schedule_update_user_test_row($this.parent().parent().attr("data-task"), $this.attr("data-user-test"));
     });
 });
-{% end %}
+{% endblock additional_js %}
 
 {% block core %}
 
@@ -73,16 +73,16 @@ $(document).ready(function () {
 {% for i, task in enumerate(contest.tasks) %}
     {% set task_type = get_task_type(dataset=task.active_dataset) %}
     {% if task_type.testable %}
-    <li{% if task == default_task %} class="active"{% end %}><a href="#test_{{ task.name }}" data-toggle="tab">{{ task.name }}</a></li>
-    {% end %}
-{% end %}
+    <li{% if task == default_task %} class="active"{% endif %}><a href="#test_{{ task.name }}" data-toggle="tab">{{ task.name }}</a></li>
+    {% endif %}
+{% endfor %}
 </ul>
 
 <div class="tab-content">
 {% for i, task in enumerate(contest.tasks) %}
     {% set task_type = get_task_type(dataset=task.active_dataset) %}
     {% if task_type.testable %}
-<div class="tab-pane{% if task == default_task %} active{% end %}" id="test_{{ task.name }}">
+<div class="tab-pane{% if task == default_task %} active{% endif %}" id="test_{{ task.name }}">
 
 <h2 style="margin-bottom: 10px">{{ _("Submit a test") }}</h2>
 
@@ -92,7 +92,7 @@ $(document).ready(function () {
         {{ _("You can submit %(user_tests_left)s more test(s).") % {"user_tests_left": user_tests_left[task.id]} }}
         </p>
     </div>
-{% end %}
+{% endif %}
 
 <div class="submit_test row">
     <div class="span5">
@@ -108,7 +108,7 @@ $(document).ready(function () {
                                onchange="CMS.CWSUtils.filter_languages($('#language option'), $(this).parents('fieldset').find('input[type=file]').not('#input_file'))"/>
                     </div>
                 </div>
-{% end %}
+{% endfor %}
                 <div class="control-group">
                     <label class="control-label" for="input_file">{{ _("input") }}</label>
                     <div class="controls">
@@ -120,7 +120,7 @@ $(document).ready(function () {
                         <select id="language" name="language">
 {% for lang in contest.languages %}
                             <option value="{{ lang }}">{{ lang }}</option>
-{% end %}
+{% endfor %}
                         </select>
                     </div>
                 </div>
@@ -149,7 +149,7 @@ $(document).ready(function () {
                         <select id="zip_language" name="language">
 {% for lang in contest.languages %}
                             <option value="{{ lang }}">{{ lang }}</option>
-{% end %}
+{% endfor %}
                         </select>
                     </div>
                 </div>
@@ -162,7 +162,7 @@ $(document).ready(function () {
             </fieldset>
         </form>
     </div>
-{% end %}
+{% endif %}
 </div>
 
 
@@ -178,7 +178,7 @@ $(document).ready(function () {
         <col class="datetime"/>
 {% else %}
         <col class="time"/>
-{% end %}
+{% endif %}
         <col class="status"/>
         <col class="time"/>
         <col class="memory"/>
@@ -192,7 +192,7 @@ $(document).ready(function () {
             <th class="datetime">{{ _("Date and time") }}</th>
 {% else %}
             <th class="time">{{ _("Time") }}</th>
-{% end %}
+{% endif %}
             <th class="status">{{ _("Status") }}</th>
             <th class="time">{{ _("Execution time") }}</th>
             <th class="memory">{{ _("Memory used") }}</th>
@@ -211,8 +211,8 @@ $(document).ready(function () {
             {% set t_idx = len(user_tests[task.id]) - t_idx %}
             {% set tr = t.get_result(t.task.active_dataset) %}
             {% include user_test_row.html %}
-        {% end %}
-    {% end %}
+        {% endfor %}
+    {% endif %}
     </tbody>
 </table>
 
@@ -220,8 +220,8 @@ $(document).ready(function () {
 
 
 </div>
-    {% end %}
-{% end %}
+    {% endif %}
+{% endfor %}
 </div>
 
 <div class="modal fade hide" id="user_test_detail">
@@ -237,6 +237,6 @@ $(document).ready(function () {
 </div>
 
 </div>
-{% end %}
+{% endif %}
 
-{% end %}
+{% endblock core %}

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -58,7 +58,6 @@ $(document).ready(function () {
 
 {% block core %}
 
-{% from cms.grading.tasktypes import get_task_type %}
 
 {% if actual_phase == 0 or current_user.unrestricted %}
 
@@ -168,7 +167,6 @@ $(document).ready(function () {
 
 <h2 style="margin: 40px 0 10px">{{ _("Previous tests") }}</h2>
 
-{% from cmscommon.datetime import utc %}
 {% set show_date = any(t.timestamp.replace(tzinfo=utc).astimezone(timezone).date() != now.replace(tzinfo=utc).astimezone(timezone).date() for t in user_tests[task.id]) %}
 
 

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -208,7 +208,7 @@ $(document).ready(function () {
         {% for t_idx, t in enumerate(sorted(user_tests[task.id], key=lambda t: t.timestamp, reverse=True)) %}
             {% set t_idx = len(user_tests[task.id]) - t_idx %}
             {% set tr = t.get_result(t.task.active_dataset) %}
-            {% include user_test_row.html %}
+            {% include "user_test_row.html" %}
         {% endfor %}
     {% endif %}
     </tbody>

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -85,7 +85,7 @@ $(document).ready(function () {
 
 <h2 style="margin-bottom: 10px">{{ _("Submit a test") }}</h2>
 
-{% if user_tests_left[task.id] is not None %}
+{% if user_tests_left[task.id] is not none %}
     <div class="span5">
         <p>
         {{ _("You can submit %(user_tests_left)s more test(s).") % {"user_tests_left": user_tests_left[task.id]} }}

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -96,7 +96,7 @@ $(document).ready(function () {
 <div class="submit_test row">
     <div class="span5">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "test") }}" method="POST">
-            {% module xsrf_form_html() %}
+            {{ xsrf_form_html|safe }}
             <fieldset>
 {% for filename in task.submission_format|map(attribute="filename")|list + task_type.get_user_managers(task.submission_format) %}
                 <div class="control-group">
@@ -135,7 +135,7 @@ $(document).ready(function () {
 {% if task.submission_format|map(attribute="filename")|select("endswith", ".%l")|list|length == 0 %}
     <div class="span4">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "test") }}" method="POST">
-            {% module xsrf_form_html() %}
+            {{ xsrf_form_html|safe }}
             <fieldset>
                 <div class="control-group">
                     <label class="control-label" for="input_zip">{{ _("submission.zip") }}</label>

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -98,7 +98,7 @@ $(document).ready(function () {
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "test") }}" method="POST">
             {% module xsrf_form_html() %}
             <fieldset>
-{% for idx, filename in enumerate([x.filename for x in task.submission_format] + task_type.get_user_managers(task.submission_format)) %}
+{% for idx, filename in enumerate(task.submission_format|map(attribute="filename")|list + task_type.get_user_managers(task.submission_format)) %}
                 <div class="control-group">
                     <label class="control-label" for="input{{ idx }}">{{ filename.replace(".%l", "") }}</label>
                     <div class="controls">
@@ -132,7 +132,7 @@ $(document).ready(function () {
             </fieldset>
         </form>
     </div>
-{% if not any(x.filename.endswith(".%l") for x in task.submission_format) %}
+{% if not any(task.submission_format|map(attribute="filename")|select("endswith", ".%l")) %}
     <div class="span4">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "test") }}" method="POST">
             {% module xsrf_form_html() %}
@@ -167,7 +167,7 @@ $(document).ready(function () {
 
 <h2 style="margin: 40px 0 10px">{{ _("Previous tests") }}</h2>
 
-{% set show_date = any(t.timestamp.replace(tzinfo=utc).astimezone(timezone).date() != now.replace(tzinfo=utc).astimezone(timezone).date() for t in user_tests[task.id]) %}
+{% set show_date = any(user_tests[task.id]|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())) %}
 
 
 <table class="user_test_list table table-bordered table-striped" data-task="{{ task.name }}">

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -167,7 +167,7 @@ $(document).ready(function () {
 
 <h2 style="margin: 40px 0 10px">{{ _("Previous tests") }}</h2>
 
-{% set show_date = user_tests[task.id]|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())|list|length > 0 %}
+{% set show_date = not user_test|map(attribute="timestamp")|all("today") %}
 
 
 <table class="user_test_list table table-bordered table-striped" data-task="{{ task.name }}">

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -132,7 +132,7 @@ $(document).ready(function () {
             </fieldset>
         </form>
     </div>
-{% if not any(task.submission_format|map(attribute="filename")|select("endswith", ".%l")) %}
+{% if task.submission_format|map(attribute="filename")|select("endswith", ".%l")|list|length == 0 %}
     <div class="span4">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "test") }}" method="POST">
             {% module xsrf_form_html() %}
@@ -167,7 +167,7 @@ $(document).ready(function () {
 
 <h2 style="margin: 40px 0 10px">{{ _("Previous tests") }}</h2>
 
-{% set show_date = any(user_tests[task.id]|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())) %}
+{% set show_date = user_tests[task.id]|map(attribute="timestamp")|map("astimezone", timezone)|map(attribute="date")|map("call")|select("ne", (now|astimezone(timezone)).date())|list|length > 0 %}
 
 
 <table class="user_test_list table table-bordered table-striped" data-task="{{ task.name }}">

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -69,7 +69,7 @@ $(document).ready(function () {
 
 
 <ul class="nav nav-tabs">
-{% for i, task in enumerate(contest.tasks) %}
+{% for task in contest.tasks %}
     {% set task_type = get_task_type(dataset=task.active_dataset) %}
     {% if task_type.testable %}
     <li{% if task == default_task %} class="active"{% endif %}><a href="#test_{{ task.name }}" data-toggle="tab">{{ task.name }}</a></li>
@@ -78,7 +78,7 @@ $(document).ready(function () {
 </ul>
 
 <div class="tab-content">
-{% for i, task in enumerate(contest.tasks) %}
+{% for task in contest.tasks %}
     {% set task_type = get_task_type(dataset=task.active_dataset) %}
     {% if task_type.testable %}
 <div class="tab-pane{% if task == default_task %} active{% endif %}" id="test_{{ task.name }}">
@@ -98,12 +98,12 @@ $(document).ready(function () {
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "test") }}" method="POST">
             {% module xsrf_form_html() %}
             <fieldset>
-{% for idx, filename in enumerate(task.submission_format|map(attribute="filename")|list + task_type.get_user_managers(task.submission_format)) %}
+{% for filename in task.submission_format|map(attribute="filename")|list + task_type.get_user_managers(task.submission_format) %}
                 <div class="control-group">
-                    <label class="control-label" for="input{{ idx }}">{{ filename.replace(".%l", "") }}</label>
+                    <label class="control-label" for="input{{ loop.index0 }}">{{ filename.replace(".%l", "") }}</label>
                     <div class="controls">
                         <input type="file" class="input-xlarge"
-                               id="input{{ idx }}" name="{{ filename }}"
+                               id="input{{ loop.index0 }}" name="{{ filename }}"
                                onchange="CMS.CWSUtils.filter_languages($('#language option'), $(this).parents('fieldset').find('input[type=file]').not('#input_file'))"/>
                     </div>
                 </div>
@@ -206,7 +206,8 @@ $(document).ready(function () {
         </tr>
     {% else %}
         {% for t_idx, t in enumerate(user_tests[task.id]|sort(attribute="timestamp")|reverse) %}
-            {% set t_idx = len(user_tests[task.id]) - t_idx %}
+            {# loop.revindex is broken: https://github.com/pallets/jinja/issues/794 #}
+            {% set t_idx = len(user_tests[task.id]) - loop.index0 %}
             {% set tr = t.get_result(t.task.active_dataset) %}
             {% include "user_test_row.html" %}
         {% endfor %}

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -200,14 +200,14 @@ $(document).ready(function () {
         </tr>
     </thead>
     <tbody>
-    {% if len(user_tests[task.id]) == 0 %}
+    {% if user_tests[task.id]|length == 0 %}
         <tr>
             <td colspan="7" class="no_user_tests">{{ _("no tests yet") }}</td>
         </tr>
     {% else %}
         {% for t_idx, t in enumerate(user_tests[task.id]|sort(attribute="timestamp")|reverse) %}
             {# loop.revindex is broken: https://github.com/pallets/jinja/issues/794 #}
-            {% set t_idx = len(user_tests[task.id]) - loop.index0 %}
+            {% set t_idx = user_tests[task.id]|length - loop.index0 %}
             {% set tr = t.get_result(t.task.active_dataset) %}
             {% include "user_test_row.html" %}
         {% endfor %}

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -132,7 +132,7 @@ $(document).ready(function () {
             </fieldset>
         </form>
     </div>
-{% if task.submission_format|map(attribute="filename")|select("endswith", ".%l")|list|length == 0 %}
+{% if not task.submission_format|map(attribute="filename")|any("endswith", ".%l") %}
     <div class="span4">
         <form class="form-horizontal" enctype="multipart/form-data" action="{{ contest_url("tasks", task.name, "test") }}" method="POST">
             {{ xsrf_form_html|safe }}

--- a/cms/server/contest/templates/user_test_details.html
+++ b/cms/server/contest/templates/user_test_details.html
@@ -5,7 +5,7 @@
 {% if tr is not None and tr.evaluated() %}
 <h3>{{ _("Evaluation outcome") }}</h3>{% comment TODO: trim long outputs and add facility to see raw %}
 <pre>{{ format_status_text(tr.evaluation_text, translation=translation) }}</pre>
-{% end %}
+{% endif %}
 
 {% if tr is not None and tr.compiled() %}
 <h3>{{ _("Compilation output") }}</h3>{% comment TODO: trim long outputs and add facility to see raw %}
@@ -22,7 +22,7 @@
     {{ _("N/A") }}
 {% else %}
     {{ translation.format_duration(tr.compilation_time) }}
-{% end %}
+{% endif %}
             </td>
         </tr>
             <th>{{ _("Memory used:") }}</th>
@@ -31,7 +31,7 @@
     {{ _("N/A") }}
 {% else %}
     {{ translation.format_size(tr.compilation_memory) }}
-{% end %}
+{% endif %}
             </td>
         </tr>
     </tbody>
@@ -39,9 +39,9 @@
 {% if tr.compilation_stdout is not None %}
 <h4>{{ _("Standard output") }}</h4>
 <pre>{{ tr.compilation_stdout }}</pre>
-{% end %}
+{% endif %}
 {% if tr.compilation_stderr is not None %}
 <h4>{{ _("Standard error") }}</h4>
 <pre>{{ tr.compilation_stderr }}</pre>
-{% end %}
-{% end %}
+{% endif %}
+{% endif %}

--- a/cms/server/contest/templates/user_test_details.html
+++ b/cms/server/contest/templates/user_test_details.html
@@ -1,11 +1,11 @@
 
 
-{% if tr is not None and tr.evaluated() %}
+{% if tr is not none and tr.evaluated() %}
 <h3>{{ _("Evaluation outcome") }}</h3>{# TODO: trim long outputs and add facility to see raw #}
 <pre>{{ format_status_text(tr.evaluation_text, translation=translation) }}</pre>
 {% endif %}
 
-{% if tr is not None and tr.compiled() %}
+{% if tr is not none and tr.compiled() %}
 <h3>{{ _("Compilation output") }}</h3>{# TODO: trim long outputs and add facility to see raw #}
 <table class="table table-bordered" style="table-layout: fixed;">
     <tbody>
@@ -16,7 +16,7 @@
         <tr>
             <th>{{ _("Compilation time:") }}</th>
             <td>
-{% if tr.compilation_time is None %}
+{% if tr.compilation_time is none %}
     {{ _("N/A") }}
 {% else %}
     {{ translation.format_duration(tr.compilation_time) }}
@@ -25,7 +25,7 @@
         </tr>
             <th>{{ _("Memory used:") }}</th>
             <td>
-{% if tr.compilation_memory is None %}
+{% if tr.compilation_memory is none %}
     {{ _("N/A") }}
 {% else %}
     {{ translation.format_size(tr.compilation_memory) }}
@@ -34,11 +34,11 @@
         </tr>
     </tbody>
 </table>
-{% if tr.compilation_stdout is not None %}
+{% if tr.compilation_stdout is not none %}
 <h4>{{ _("Standard output") }}</h4>
 <pre>{{ tr.compilation_stdout }}</pre>
 {% endif %}
-{% if tr.compilation_stderr is not None %}
+{% if tr.compilation_stderr is not none %}
 <h4>{{ _("Standard error") }}</h4>
 <pre>{{ tr.compilation_stderr }}</pre>
 {% endif %}

--- a/cms/server/contest/templates/user_test_details.html
+++ b/cms/server/contest/templates/user_test_details.html
@@ -1,6 +1,4 @@
-{% from six import iterkeys, itervalues, iteritems %}
 
-{% from cms.grading import format_status_text %}
 
 {% if tr is not None and tr.evaluated() %}
 <h3>{{ _("Evaluation outcome") }}</h3>{# TODO: trim long outputs and add facility to see raw #}

--- a/cms/server/contest/templates/user_test_details.html
+++ b/cms/server/contest/templates/user_test_details.html
@@ -3,12 +3,12 @@
 {% from cms.grading import format_status_text %}
 
 {% if tr is not None and tr.evaluated() %}
-<h3>{{ _("Evaluation outcome") }}</h3>{% comment TODO: trim long outputs and add facility to see raw %}
+<h3>{{ _("Evaluation outcome") }}</h3>{# TODO: trim long outputs and add facility to see raw #}
 <pre>{{ format_status_text(tr.evaluation_text, translation=translation) }}</pre>
 {% endif %}
 
 {% if tr is not None and tr.compiled() %}
-<h3>{{ _("Compilation output") }}</h3>{% comment TODO: trim long outputs and add facility to see raw %}
+<h3>{{ _("Compilation output") }}</h3>{# TODO: trim long outputs and add facility to see raw #}
 <table class="table table-bordered" style="table-layout: fixed;">
     <tbody>
         <tr>

--- a/cms/server/contest/templates/user_test_row.html
+++ b/cms/server/contest/templates/user_test_row.html
@@ -82,7 +82,7 @@
         </a>
         {% elif files|length == 1 %}
             {% set filename = next(iterkeys(t.files)) %}
-            {% set real_filename = filename.replace(".%l", get_language(t.language).source_extension) %}
+            {% set real_filename = filename|replace(".%l", get_language(t.language).source_extension) %}
         <a class="btn" href="{{ contest_url("tasks", task.name, "tests", t_idx, "files", real_filename) }}">
             {{ _("Download") }}
         </a>
@@ -95,7 +95,7 @@
             <ul class="dropdown-menu">
             {% for filename in files %}
                 {% if t.language is not none %}
-                    {% set real_filename = filename.replace(".%l", get_language(t.language).source_extension) %}
+                    {% set real_filename = filename|replace(".%l", get_language(t.language).source_extension) %}
                 {% else %}
                     {% set real_filename = filename %}
                 {% endif %}

--- a/cms/server/contest/templates/user_test_row.html
+++ b/cms/server/contest/templates/user_test_row.html
@@ -3,7 +3,7 @@
     {% set col1 = "<td class=\"datetime\">%s</td>" % translation.format_datetime(t.timestamp, timezone) %}
 {% else %}
     {% set col1 = "<td class=\"time\">%s</td>" % translation.format_time(t.timestamp, timezone) %}
-{% end %}
+{% endif %}
 {% if tr is None or not tr.compiled() %}
 <tr data-user-test="{{ t_idx }}" data-status="1">
     {% raw col1 %}
@@ -30,7 +30,7 @@
         {{ _("Executed") }}
         <a class="details">{{ _("details") }}</a>
     </td>
-{% end %}
+{% endif %}
 {% if tr is None or tr.execution_time is None %}
     <td class="time undefined">
         {{ _("N/A") }}
@@ -39,7 +39,7 @@
     <td class="time">
         {{ translation.format_duration(tr.execution_time) }}
     </td>
-{% end %}
+{% endif %}
 {% if tr is None or tr.execution_memory is None %}
     <td class="memory undefined">
         {{ _("N/A") }}
@@ -48,7 +48,7 @@
     <td class="memory">
         {{ translation.format_size(tr.execution_memory) }}
     </td>
-{% end %}
+{% endif %}
     <td class="input">
         <a class="btn" href="{{ contest_url("tasks", task.name, "tests", t_idx, "input") }}">
             {{ _("Download") }}
@@ -68,8 +68,8 @@
         <a class="btn btn-primary" href="{{ contest_url("tasks", task.name, "tests", t_idx, "output") }}">
             {{ _("Download") }}
         </a>
-        {% end %}
-    {% end %}
+        {% endif %}
+    {% endif %}
     </td>
     <td class="files">
         {% comment We replace '.%l' with the actual language only when it occurs as an extension at the end of the string and only when %}
@@ -98,15 +98,15 @@
                     {% set real_filename = filename.replace(".%l", get_language(t.language).source_extension) %}
                 {% else %}
                     {% set real_filename = filename %}
-                {% end %}
+                {% endif %}
                 <li>
                     <a href="{{ contest_url("tasks", task.name, "tests", t_idx, "files", filename) }}">
                         {{ real_filename }}
                     </a>
                 </li>
-            {% end %}
+            {% endfor %}
             </ul>
         </div>
-        {% end %}
+        {% endif %}
     </td>
 </tr>

--- a/cms/server/contest/templates/user_test_row.html
+++ b/cms/server/contest/templates/user_test_row.html
@@ -1,8 +1,8 @@
 
 {% if show_date %}
-    {% set col1 = "<td class=\"datetime\">%s</td>" % translation.format_datetime(t.timestamp, timezone) %}
+    {% set col1 = "<td class=\"datetime\">%s</td>"|format(translation.format_datetime(t.timestamp, timezone)) %}
 {% else %}
-    {% set col1 = "<td class=\"time\">%s</td>" % translation.format_time(t.timestamp, timezone) %}
+    {% set col1 = "<td class=\"time\">%s</td>"|format(translation.format_time(t.timestamp, timezone)) %}
 {% endif %}
 {% if tr is none or not tr.compiled() %}
 <tr data-user-test="{{ t_idx }}" data-status="1">

--- a/cms/server/contest/templates/user_test_row.html
+++ b/cms/server/contest/templates/user_test_row.html
@@ -72,9 +72,9 @@
     {% endif %}
     </td>
     <td class="files">
-        {% comment We replace '.%l' with the actual language only when it occurs as an extension at the end of the string and only when %}
-        {% comment there isn't another file with that name. This allows to securily reverse the replacement and should work great in %}
-        {% comment the common case. Yet, it still allows the marginal case of both 'foo.%l' and 'foo.c' in the submission format. %}
+        {# We replace '.%l' with the actual language only when it occurs as an extension at the end of the string and only when #}
+        {# there isn't another file with that name. This allows to securily reverse the replacement and should work great in #}
+        {# the common case. Yet, it still allows the marginal case of both 'foo.%l' and 'foo.c' in the submission format. #}
         {% set files = list(iterkeys(t.files)) + list(iterkeys(t.managers)) %}
         {% if len(files) == 0 %}
         <a class="btn disabled">

--- a/cms/server/contest/templates/user_test_row.html
+++ b/cms/server/contest/templates/user_test_row.html
@@ -75,7 +75,7 @@
         {# We replace '.%l' with the actual language only when it occurs as an extension at the end of the string and only when #}
         {# there isn't another file with that name. This allows to securily reverse the replacement and should work great in #}
         {# the common case. Yet, it still allows the marginal case of both 'foo.%l' and 'foo.c' in the submission format. #}
-        {% set files = list(iterkeys(t.files)) + list(iterkeys(t.managers)) %}
+        {% set files = iterkeys(t.files)|list + iterkeys(t.managers)|list %}
         {% if files|length == 0 %}
         <a class="btn disabled">
             {{ _("None") }}

--- a/cms/server/contest/templates/user_test_row.html
+++ b/cms/server/contest/templates/user_test_row.html
@@ -4,7 +4,7 @@
 {% else %}
     {% set col1 = "<td class=\"time\">%s</td>" % translation.format_time(t.timestamp, timezone) %}
 {% endif %}
-{% if tr is None or not tr.compiled() %}
+{% if tr is none or not tr.compiled() %}
 <tr data-user-test="{{ t_idx }}" data-status="1">
     {% raw col1 %}
     <td class="status">
@@ -31,7 +31,7 @@
         <a class="details">{{ _("details") }}</a>
     </td>
 {% endif %}
-{% if tr is None or tr.execution_time is None %}
+{% if tr is none or tr.execution_time is none %}
     <td class="time undefined">
         {{ _("N/A") }}
     </td>
@@ -40,7 +40,7 @@
         {{ translation.format_duration(tr.execution_time) }}
     </td>
 {% endif %}
-{% if tr is None or tr.execution_memory is None %}
+{% if tr is none or tr.execution_memory is none %}
     <td class="memory undefined">
         {{ _("N/A") }}
     </td>
@@ -55,12 +55,12 @@
         </a>
     </td>
     <td class="output">
-    {% if tr is None or not tr.compiled() or (tr.compilation_outcome == 'ok' and not tr.evaluated()) %}
+    {% if tr is none or not tr.compiled() or (tr.compilation_outcome == 'ok' and not tr.evaluated()) %}
         <a class="btn btn-primary disabled">
             {{ _("Wait...") }}
         </a>
     {% else %}
-        {% if tr.output is None %}
+        {% if tr.output is none %}
         <a class="btn btn-primary disabled">
             {{ _("N/A") }}
         </a>
@@ -94,7 +94,7 @@
             </a>
             <ul class="dropdown-menu">
             {% for filename in files %}
-                {% if t.language is not None %}
+                {% if t.language is not none %}
                     {% set real_filename = filename.replace(".%l", get_language(t.language).source_extension) %}
                 {% else %}
                     {% set real_filename = filename %}

--- a/cms/server/contest/templates/user_test_row.html
+++ b/cms/server/contest/templates/user_test_row.html
@@ -76,11 +76,11 @@
         {# there isn't another file with that name. This allows to securily reverse the replacement and should work great in #}
         {# the common case. Yet, it still allows the marginal case of both 'foo.%l' and 'foo.c' in the submission format. #}
         {% set files = list(iterkeys(t.files)) + list(iterkeys(t.managers)) %}
-        {% if len(files) == 0 %}
+        {% if files|length == 0 %}
         <a class="btn disabled">
             {{ _("None") }}
         </a>
-        {% elif len(files) == 1 %}
+        {% elif files|length == 1 %}
             {% set filename = next(iterkeys(t.files)) %}
             {% set real_filename = filename.replace(".%l", get_language(t.language).source_extension) %}
         <a class="btn" href="{{ contest_url("tasks", task.name, "tests", t_idx, "files", real_filename) }}">

--- a/cms/server/contest/templates/user_test_row.html
+++ b/cms/server/contest/templates/user_test_row.html
@@ -82,7 +82,7 @@
         </a>
         {% elif files|length == 1 %}
             {% set filename = next(iterkeys(t.files)) %}
-            {% set real_filename = filename|replace(".%l", get_language(t.language).source_extension) %}
+            {% set real_filename = filename|replace(".%l", (t.language|get_language).source_extension) %}
         <a class="btn" href="{{ contest_url("tasks", task.name, "tests", t_idx, "files", real_filename) }}">
             {{ _("Download") }}
         </a>
@@ -95,7 +95,7 @@
             <ul class="dropdown-menu">
             {% for filename in files %}
                 {% if t.language is not none %}
-                    {% set real_filename = filename|replace(".%l", get_language(t.language).source_extension) %}
+                    {% set real_filename = filename|replace(".%l", (t.language|get_language).source_extension) %}
                 {% else %}
                     {% set real_filename = filename %}
                 {% endif %}

--- a/cms/server/contest/templates/user_test_row.html
+++ b/cms/server/contest/templates/user_test_row.html
@@ -82,7 +82,7 @@
         </a>
         {% elif files|length == 1 %}
             {% set filename = next(iterkeys(t.files)) %}
-            {% set real_filename = filename|replace(".%l", (t.language|get_language).source_extension) %}
+            {% set real_filename = filename|replace(".%l", (t.language|to_language).source_extension) %}
         <a class="btn" href="{{ contest_url("tasks", task.name, "tests", t_idx, "files", real_filename) }}">
             {{ _("Download") }}
         </a>
@@ -95,7 +95,7 @@
             <ul class="dropdown-menu">
             {% for filename in files %}
                 {% if t.language is not none %}
-                    {% set real_filename = filename|replace(".%l", (t.language|get_language).source_extension) %}
+                    {% set real_filename = filename|replace(".%l", (t.language|to_language).source_extension) %}
                 {% else %}
                     {% set real_filename = filename %}
                 {% endif %}

--- a/cms/server/jinja2_toolbox.py
+++ b/cms/server/jinja2_toolbox.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Provide a generic Jinja2 environment.
+
+Create a Jinja2 environment and instrument it with utilities (globals,
+filters, tests, etc. that are useful for generic global usage.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *
+from future.builtins import *
+
+from jinja2 import Environment, StrictUndefined
+
+
+GLOBAL_ENVIRONMENT = Environment(
+    trim_blocks=True, lstrip_blocks=True, undefined=StrictUndefined,
+    autoescape=True, cache_size=-1, auto_reload=False)

--- a/cms/server/jinja2_toolbox.py
+++ b/cms/server/jinja2_toolbox.py
@@ -32,32 +32,64 @@ from future.builtins.disabled import *
 from future.builtins import *
 from six import iterkeys, itervalues, iteritems
 
-from jinja2 import environmentfilter, Environment, StrictUndefined
+from jinja2 import Environment, StrictUndefined, contextfilter
 
-from cmscommon.datetime import make_timestamp
+from cmscommon.datetime import make_timestamp, utc
 from cmscommon.mimetypes import get_type_for_file_name, get_name_for_type, \
     get_icon_for_type
+from cms.grading.languagemanager import get_language
 from cms.grading.scoretypes import get_score_type
 from cms.grading.tasktypes import get_task_type
 from cms.server.contest.formatting import get_score_class
 
 
-@environmentfilter
-def dictselect(env, d, *args, **kwargs):
-    if len(args) == 0:
+@contextfilter
+def all_(ctx, l, test=None, *args):
+    if test is None:
         test = bool
     else:
-        test = env.tests[args[0]]
-        args = args[1:]
+        test = ctx.environment.tests[test]
+    for i in l:
+        if not ctx.call(test, i, *args):
+            return False
+    return True
+
+
+@contextfilter
+def any_(ctx, l, test=None, *args):
+    if test is None:
+        test = bool
+    else:
+        test = ctx.environment.tests[test]
+    for i in l:
+        if ctx.call(test, i, *args):
+            return True
+    return False
+
+
+# FIXME once we drop py2 do dictselect(ctx, d, test=None, *args, by="key")
+@contextfilter
+def dictselect(ctx, d, test=None, *args, **kwargs):
+    if test is None:
+        test = bool
+    else:
+        test = ctx.environment.tests[test]
     by = kwargs.pop("by", "key")
     if len(kwargs) > 0:
         raise ValueError("Invalid keyword argument: %s"
                          % next(iterkeys(kwargs)))
-    if by == "key":
-        return dict((k, v) for k, v in iteritems(d) if test(k, *args))
-    if by == "value":
-        return dict((k, v) for k, v in iteritems(d) if test(v, *args))
-    raise ValueError("Invalid value of \"by\" keyword argument: %s" % by)
+    if by not in {"key", "value"}:
+        raise ValueError("Invalid value of \"by\" keyword argument: %s" % by)
+    test = lambda i: ctx.call(test, i[{"key": 0, "value": 1}[by]], *args)
+    return dict(i for i in iteritems(d) if test(i))
+
+
+@contextfilter
+def today(ctx, dt):
+    now = ctx["now"]
+    timezone = ctx["timezone"]
+    return dt.replace(tzinfo=utc).astimezone(timezone).date() \
+        == now.replace(tzinfo=utc).astimezone(timezone).date()
 
 
 def instrument_generic_toolbox(env):
@@ -68,17 +100,19 @@ def instrument_generic_toolbox(env):
     env.globals["get_task_type"] = get_task_type
     env.globals["get_score_type"] = get_score_type
 
-    env.globals["get_score_class"] = get_score_class()
+    env.globals["get_score_class"] = get_score_class
 
     env.globals["get_mimetype_for_file_name"] = get_type_for_file_name
     env.globals["get_name_for_mimetype"] = get_name_for_type
     env.globals["get_icon_for_mimetype"] = get_icon_for_type
 
-    env.filters["call"] = lambda c, *args, **kwargs: c(*args, **kwargs)
+    env.filters["all"] = all_
+    env.filters["any"] = any_
     env.filters["dictselect"] = dictselect
     env.filters["make_timestamp"] = make_timestamp
 
-    env.tests["contains"] = lambda s, p: p in s
+    env.filters["get_language"] = get_language
+
     env.tests["endswith"] = lambda s, p: s.endswith(p)
 
 

--- a/cms/server/jinja2_toolbox.py
+++ b/cms/server/jinja2_toolbox.py
@@ -34,6 +34,8 @@ from six import iterkeys, itervalues, iteritems
 
 from jinja2 import environmentfilter, Environment, StrictUndefined
 
+from cmscommon.datetime import make_timestamp
+
 
 @environmentfilter
 def dictselect(env, d, *args, **kwargs):
@@ -77,6 +79,7 @@ def instrument_generic_toolbox(env):
 
     env.filters["call"] = lambda c, *args, **kwargs: c(*args, **kwargs)
     env.filters["dictselect"] = dictselect
+    env.filters["make_timestamp"] = make_timestamp
 
     env.tests["contains"] = lambda s, p: p in s
     env.tests["endswith"] = lambda s, p: s.endswith(p)

--- a/cms/server/jinja2_toolbox.py
+++ b/cms/server/jinja2_toolbox.py
@@ -35,6 +35,8 @@ from six import iterkeys, itervalues, iteritems
 from jinja2 import environmentfilter, Environment, StrictUndefined
 
 from cmscommon.datetime import make_timestamp
+from cmscommon.mimetypes import get_type_for_file_name, get_name_for_type, \
+    get_icon_for_type
 
 
 @environmentfilter
@@ -54,7 +56,6 @@ def dictselect(env, d, *args, **kwargs):
         return dict((k, v) for k, v in iteritems(d) if test(v, *args))
     raise ValueError("Invalid value of \"by\" keyword argument: %s" % by)
 
-import cmscommon.mimetypes
 from cms.grading.scoretypes import get_score_type
 from cms.grading.tasktypes import get_task_type
 from cms.server.contest.formatting import get_score_class
@@ -70,12 +71,9 @@ def instrument_generic_toolbox(env):
 
     env.globals["get_score_class"] = get_score_class()
 
-    env.globals["get_mimetype_for_file_name"] = \
-        cmscommon.mimetypes.get_type_for_file_name
-    env.globals["get_name_for_mimetype"] = \
-        cmscommon.mimetypes.get_name_for_type
-    env.globals["get_icon_for_mimetype"] = \
-        cmscommon.mimetypes.get_icon_for_type
+    env.globals["get_mimetype_for_file_name"] = get_type_for_file_name
+    env.globals["get_name_for_mimetype"] = get_name_for_type
+    env.globals["get_icon_for_mimetype"] = get_icon_for_type
 
     env.filters["call"] = lambda c, *args, **kwargs: c(*args, **kwargs)
     env.filters["dictselect"] = dictselect

--- a/cms/server/jinja2_toolbox.py
+++ b/cms/server/jinja2_toolbox.py
@@ -37,6 +37,9 @@ from jinja2 import environmentfilter, Environment, StrictUndefined
 from cmscommon.datetime import make_timestamp
 from cmscommon.mimetypes import get_type_for_file_name, get_name_for_type, \
     get_icon_for_type
+from cms.grading.scoretypes import get_score_type
+from cms.grading.tasktypes import get_task_type
+from cms.server.contest.formatting import get_score_class
 
 
 @environmentfilter
@@ -55,10 +58,6 @@ def dictselect(env, d, *args, **kwargs):
     if by == "value":
         return dict((k, v) for k, v in iteritems(d) if test(v, *args))
     raise ValueError("Invalid value of \"by\" keyword argument: %s" % by)
-
-from cms.grading.scoretypes import get_score_type
-from cms.grading.tasktypes import get_task_type
-from cms.server.contest.formatting import get_score_class
 
 
 def instrument_generic_toolbox(env):

--- a/cms/server/jinja2_toolbox.py
+++ b/cms/server/jinja2_toolbox.py
@@ -30,10 +30,37 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from future.builtins.disabled import *
 from future.builtins import *
+from six import iterkeys, itervalues, iteritems
 
 from jinja2 import Environment, StrictUndefined
+
+import cmscommon.mimetypes
+from cms.grading.scoretypes import get_score_type
+from cms.grading.tasktypes import get_task_type
+from cms.server.contest.formatting import get_score_class
+
+
+def instrument_generic_toolbox(env):
+    env.globals["iterkeys"] = iterkeys
+    env.globals["itervalues"] = itervalues
+    env.globals["iteritems"] = iteritems
+
+    env.globals["get_task_type"] = get_task_type
+    env.globals["get_score_type"] = get_score_type
+
+    env.globals["get_score_class"] = get_score_class()
+
+    env.globals["get_mimetype_for_file_name"] = \
+        cmscommon.mimetypes.get_type_for_file_name
+    env.globals["get_name_for_mimetype"] = \
+        cmscommon.mimetypes.get_name_for_type
+    env.globals["get_icon_for_mimetype"] = \
+        cmscommon.mimetypes.get_icon_for_type
 
 
 GLOBAL_ENVIRONMENT = Environment(
     trim_blocks=True, lstrip_blocks=True, undefined=StrictUndefined,
     autoescape=True, cache_size=-1, auto_reload=False)
+
+
+instrument_generic_toolbox(GLOBAL_ENVIRONMENT)

--- a/cms/server/jinja2_toolbox.py
+++ b/cms/server/jinja2_toolbox.py
@@ -45,6 +45,18 @@ from cms.server.contest.formatting import get_score_class
 
 @contextfilter
 def all_(ctx, l, test=None, *args):
+    """Check if all elements of the given list pass the given test.
+
+    ctx (Context): a Jinja2 context, needed to retrieve the test
+        function by its name and to execute it.
+    l (list): a list of objects.
+    test (str|None): the name of the test to execute on each object of
+        l (leave unspecified to just check their truth value).
+    *args: parameters to pass to the test function.
+
+    return (bool): all(test(i, *args) for i in l).
+
+    """
     if test is None:
         test = bool
     else:
@@ -57,6 +69,18 @@ def all_(ctx, l, test=None, *args):
 
 @contextfilter
 def any_(ctx, l, test=None, *args):
+    """Check if any element of the given list passes the given test.
+
+    ctx (Context): a Jinja2 context, needed to retrieve the test
+        function by its name and to execute it.
+    l (list): a list of objects.
+    test (str|None): the name of the test to execute on each object of
+        l (leave unspecified to just check their truth value).
+    *args: parameters to pass to the test function.
+
+    return (bool): any(test(i, *args) for i in l).
+
+    """
     if test is None:
         test = bool
     else:
@@ -70,6 +94,21 @@ def any_(ctx, l, test=None, *args):
 # FIXME once we drop py2 do dictselect(ctx, d, test=None, *args, by="key")
 @contextfilter
 def dictselect(ctx, d, test=None, *args, **kwargs):
+    """Filter the given dict: keep only items that pass the given test.
+
+    ctx (Context): a Jinja2 context, needed to retrieve the test
+        function by its name and execute it.
+    d (dict): a dict.
+    test (str|None): the name of the test to execute on either the key
+        or the value of each item of d (leave unspecified to just check
+        the truth value).
+    *args: parameters to pass to the test function.
+    by (str): either "key" (default) or "value", specifies on which
+        component to perform the test.
+
+    return (dict): {k, v for k, v in d.items() if test(k/v, *args)}.
+
+    """
     if test is None:
         test = bool
     else:
@@ -86,6 +125,15 @@ def dictselect(ctx, d, test=None, *args, **kwargs):
 
 @contextfilter
 def today(ctx, dt):
+    """Returns whether the given datetime is today.
+
+    ctx (Context): a Jinja2 context, needed to retrieve the current
+        datetime and the timezone to use when comparing.
+    dt (datetime): a datetime.
+
+    return (bool): whether dt occurred today in the timezone.
+
+    """
     now = ctx["now"]
     timezone = ctx["timezone"]
     return dt.replace(tzinfo=utc).astimezone(timezone).date() \
@@ -111,14 +159,24 @@ def instrument_generic_toolbox(env):
     env.filters["dictselect"] = dictselect
     env.filters["make_timestamp"] = make_timestamp
 
-    env.filters["get_language"] = get_language
+    env.filters["to_language"] = get_language
 
     env.tests["endswith"] = lambda s, p: s.endswith(p)
 
 
 GLOBAL_ENVIRONMENT = Environment(
-    trim_blocks=True, lstrip_blocks=True, undefined=StrictUndefined,
-    autoescape=True, cache_size=-1, auto_reload=False)
+    # These cause a line that only contains a control block to be
+    # suppressed from the output, making it more readable.
+    trim_blocks=True, lstrip_blocks=True,
+    # This causes an error when we try to render an undefined value.
+    undefined=StrictUndefined,
+    # Force autoescape of string, always and forever.
+    autoescape=True,
+    # Cache all templates, no matter how many.
+    cache_size=-1,
+    # Don't check the disk every time to see whether the templates'
+    # files have changed.
+    auto_reload=False)
 
 
 instrument_generic_toolbox(GLOBAL_ENVIRONMENT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ ipaddress>=1.0,<1.1  # https://pypi.python.org/pypi/ipaddress
 future>=0.15,<0.16  # https://pypi.python.org/pypi/future
 babel>=2.4,<2.5  # http://babel.pocoo.org/en/latest/changelog.html
 pyxdg>=0.25,<0.26  # https://freedesktop.org/wiki/Software/pyxdg/
+Jinja2>=2.10,<2.11  # http://jinja.pocoo.org/docs/latest/changelog/
 
 # Only for some importers:
 pyyaml>=3.12,<3.13  # http://pyyaml.org/wiki/PyYAML


### PR DESCRIPTION
This is the first of a series of pull requests that ports CWS's templates from the Tornado engine to Jinja2. This pull request does many atomic changes that gap the syntax differences between the two formats.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/845)
<!-- Reviewable:end -->
