### PR TITLE
Continue porting the CWS templates from Tornado to Jinja2

### DIFF
--- a/cms/grading/scoretypes/Sum.py
+++ b/cms/grading/scoretypes/Sum.py
@@ -41,25 +41,35 @@ class Sum(ScoreTypeAlone):
 
     """
     # Mark strings for localization.
+    N_("#")
     N_("Outcome")
     N_("Details")
     N_("Execution time")
     N_("Memory used")
     N_("N/A")
     TEMPLATE = """\
-{% from cms.grading import format_status_text %}
 <table class="testcase-list">
     <thead>
         <tr>
-            <th class="idx">{{ _("#") }}</th>
-            <th class="outcome">{{ _("Outcome") }}</th>
-            <th class="details">{{ _("Details") }}</th>
-            <th class="execution-time">{{ _("Execution time") }}</th>
-            <th class="memory-used">{{ _("Memory used") }}</th>
+            <th class="idx">
+                {% trans %}#{% endtrans %}
+            </th>
+            <th class="outcome">
+                {% trans %}Outcome{% endtrans %}
+            </th>
+            <th class="details">
+                {% trans %}Details{% endtrans %}
+            </th>
+            <th class="execution-time">
+                {% trans %}Execution time{% endtrans %}
+            </th>
+            <th class="memory-used">
+                {% trans %}Memory used{% endtrans %}
+            </th>
         </tr>
     </thead>
     <tbody>
-    {% for idx, tc in enumerate(details, start=1) %}
+    {% for tc in details %}
         {% if "outcome" in tc and "text" in tc %}
             {% if tc["outcome"] == "Correct" %}
         <tr class="correct">
@@ -67,34 +77,32 @@ class Sum(ScoreTypeAlone):
         <tr class="notcorrect">
             {% else %}
         <tr class="partiallycorrect">
-            {% end %}
-            <td class="idx">{{ idx }}</td>
+            {% endif %}
+            <td class="idx">{{ loop.index }}</td>
             <td class="outcome">{{ _(tc["outcome"]) }}</td>
-            <td class="details">
-                {{ format_status_text(tc["text"], translation=translation) }}
-            </td>
+            <td class="details">{{ tc["text"]|format_status_text }}</td>
             <td class="execution-time">
-            {% if tc["time"] is not None %}
-                {{ translation.format_duration(tc["time"]) }}
+            {% if tc["time"] is not none %}
+                {{ tc["time"]|format_duration }}
             {% else %}
-                {{ _("N/A") }}
-            {% end %}
+                {% trans %}N/A{% endtrans %}
+            {% endif %}
             </td>
             <td class="memory-used">
-            {% if tc["memory"] is not None %}
-                {{ translation.format_size(tc["memory"]) }}
+            {% if tc["memory"] is not none %}
+                {{ tc["memory"]|format_size }}
             {% else %}
-                {{ _("N/A") }}
-            {% end %}
+                {% trans %}N/A{% endtrans %}
+            {% endif %}
             </td>
         {% else %}
         <tr class="undefined">
             <td colspan="5">
-                {{ _("N/A") }}
+                {% trans %}N/A{% endtrans %}
             </td>
         </tr>
-        {% end %}
-    {% end %}
+        {% endif %}
+    {% endfor %}
     </tbody>
 </table>"""
 

--- a/cms/server/contest/formatting.py
+++ b/cms/server/contest/formatting.py
@@ -30,8 +30,6 @@ from __future__ import unicode_literals
 from future.builtins.disabled import *
 from future.builtins import *
 
-from future.moves.urllib.parse import quote
-
 from cms.locale import DEFAULT_TRANSLATION
 
 
@@ -148,17 +146,3 @@ def get_score_class(score, max_score):
         return "score_100"
     else:
         return "score_0_100"
-
-
-def encode_for_url(url_fragment):
-    """Return the string encoded safely for becoming a url fragment.
-
-    In particular, this means encoding it to UTF-8 and then
-    percent-encoding it.
-
-    url_fragment(unicode): the string to be encoded.
-
-    return (str): the encoded string.
-
-    """
-    return quote(url_fragment.encode('utf-8'), safe='')

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -147,6 +147,9 @@ class BaseHandler(CommonRequestHandler):
         ret["gettext"] = self._
         ret["ngettext"] = self.n_
 
+        # FIXME this is cheating
+        ret["handler"] = self
+
         ret["xsrf_form_html"] = self.xsrf_form_html()
 
         return ret

--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -338,6 +338,8 @@ class ContestHandler(BaseHandler):
 
         if self.current_user is not None:
             participation = self.current_user
+            ret["participation"] = participation
+            ret["user"] = participation.user
 
             res = compute_actual_phase(
                 self.timestamp, self.contest.start, self.contest.stop,

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -1,4 +1,7 @@
 {% extends "contest.html" %}
+
+{% set page = "communication" %}
+
 {% block core %}
 <div class="span9">
 

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -63,9 +63,9 @@
 </div>
 
 
-{% if current_user.questions|length > 0 %}
+{% if participation.questions|length > 0 %}
 <div class="question_list">
-    {% for msg in current_user.questions|reverse %}
+    {% for msg in participation.questions|reverse %}
     <div class="question">
         {% if msg.subject|length > 0 %}
         <h4 class="subject">{{ msg.subject }}</h4>
@@ -101,10 +101,10 @@
 {% endif %}
 
 
-{% if current_user.messages|length > 0 %}
+{% if participation.messages|length > 0 %}
 <h2>{% trans %}Messages{% endtrans %}</h2>
 <div class="message_list">
-    {% for msg in current_user.messages|reverse %}
+    {% for msg in participation.messages|reverse %}
     <div class="message">
         {% if msg.subject|length > 0 %}
         <h4 class="subject">{{ msg.subject }}</h4>

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -35,7 +35,7 @@ $(document).ready(function () {
     setInterval(function() {
         utils.update_time({{ "true" if contest.per_user_time is not none else "false" }});
     }, 1000);
-    utils.update_unread_count(0{% if request.path == '/communication' %}, 0{% endif %});
+    utils.update_unread_count(0{% if page == "communication" %}, 0{% endif %});
     utils.update_notifications(true);
     setInterval(function() { utils.update_notifications(); }, 30000);
     $('#main').css('top', $('#navigation_bar').outerHeight());
@@ -164,10 +164,10 @@ $(document).ready(function () {
                     <div class="well" style="padding: 8px 0;">
                         <ul class="nav nav-list">
 
-                            <li{% if request.path == '/' %} class="active"{% endif %}>
+                            <li{% if page == "overview" %} class="active"{% endif %}>
                                 <a href="{{ contest_url() }}">{% trans %}Overview{% endtrans %}</a>
                             </li>
-                            <li{% if request.path == '/communication' %} class="active"{% endif %}>
+                            <li{% if page == "communication" %} class="active"{% endif %}>
                                 <a href="{{ contest_url("communication") }}">{% trans %}Communication{% endtrans %}
                                     <span id="unread_count" class="label label-warning no_unread"></span>
                                 </a>
@@ -177,26 +177,26 @@ $(document).ready(function () {
                             <li class="nav-header">
                                 {{ t_iter.name }}
                             </li>
-                            <li{% if request.path == '/tasks/%s/description' % encode_for_url(t_iter.name) %} class="active"{% endif %}>
+                            <li{% if page == "task_description" and task == t_iter %} class="active"{% endif %}>
                                 <a href="{{ contest_url("tasks", t_iter.name, "description") }}">{% trans %}Statement{% endtrans %}</a>
                             </li>
-                            <li{% if request.path == '/tasks/%s/submissions' % encode_for_url(t_iter.name) %} class="active"{% endif %}>
+                            <li{% if page == "task_submissions" and task == t_iter %} class="active"{% endif %}>
                                 <a href="{{ contest_url("tasks", t_iter.name, "submissions") }}">{% trans %}Submissions{% endtrans %}</a>
                             </li>
         {% endfor %}
     {% endif %}
                             <li class="divider"></li>
-                            <li{% if request.path == '/documentation' %} class="active"{% endif %}>
+                            <li{% if page == "documentation" %} class="active"{% endif %}>
                                 <a href="{{ contest_url("documentation") }}">{% trans %}Documentation{% endtrans %}</a>
                             </li>
     {% if actual_phase == 0 or participation.unrestricted %}{# FIXME maybe >= 0? #}
         {% if testing_enabled %}
-                            <li{% if request.path == '/testing' %} class="active"{% endif %}>
+                            <li{% if page == "testing" %} class="active"{% endif %}>
                                 <a href="{{ contest_url("testing") }}">{% trans %}Testing{% endtrans %}</a>
                             </li>
         {% endif %}
         {% if printing_enabled %}
-                            <li{% if request.path == '/printing' %} class="active"{% endif %}>
+                            <li{% if page == "printing" %} class="active"{% endif %}>
                                 <a href="{{ contest_url("printing") }}">{% trans %}Printing{% endtrans %}</a>
                             </li>
         {% endif %}

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -18,7 +18,7 @@ var LANGUAGES = {
 {% endfor %}
 };
 
-{% if current_user is none %}
+{% if participation is undefined %}
 var utils = new CMS.CWSUtils("{{ url() }}", "{{ contest_url() }}", "{{ contest.name }}",
                              0, 0, 0, 0, 0);
 {% else %}
@@ -61,15 +61,15 @@ $(document).ready(function () {
                         </select>
                     </p>
 {% endif %}
-{% if current_user is not none %}
+{% if participation is defined %}
                     <form action="{{ contest_url("logout") }}" method="POST" class="navbar-form pull-right">
                         {{ xsrf_form_html|safe }}
                         <button type="submit" class="btn btn-warning">{% trans %}Logout{% endtrans %}</button>
                     </form>
                     <p class="navbar-text pull-right">
-                        {% trans first_name=current_user.user.first_name,
-                                 last_name=current_user.user.last_name,
-                                 username=current_user.user.username %}
+                        {% trans first_name=user.first_name,
+                                 last_name=user.last_name,
+                                 username=user.username %}
                             Logged in as <strong>{{ first_name }} {{ last_name }}</strong> <em>({{ username }})</em>
                         {% endtrans %}
                     </p>
@@ -77,7 +77,7 @@ $(document).ready(function () {
                 </div>
             </div>
         </div>
-{% if current_user is none %}
+{% if participation is undefined %}
     {% if handler.get_argument("login_error", "") != "" %}
         <div id="notifications" class="notifications">
             <div class="alert alert-block alert-error notification">
@@ -172,7 +172,7 @@ $(document).ready(function () {
                                     <span id="unread_count" class="label label-warning no_unread"></span>
                                 </a>
                             </li>
-    {% if actual_phase == 0 or actual_phase == 3 or current_user.unrestricted %}
+    {% if actual_phase == 0 or actual_phase == 3 or participation.unrestricted %}
         {% for t_iter in contest.tasks %}
                             <li class="nav-header">
                                 {{ t_iter.name }}
@@ -189,7 +189,7 @@ $(document).ready(function () {
                             <li{% if request.path == '/documentation' %} class="active"{% endif %}>
                                 <a href="{{ contest_url("documentation") }}">{% trans %}Documentation{% endtrans %}</a>
                             </li>
-    {% if actual_phase == 0 or current_user.unrestricted %}{# FIXME maybe >= 0? #}
+    {% if actual_phase == 0 or participation.unrestricted %}{# FIXME maybe >= 0? #}
         {% if testing_enabled %}
                             <li{% if request.path == '/testing' %} class="active"{% endif %}>
                                 <a href="{{ contest_url("testing") }}">{% trans %}Testing{% endtrans %}</a>

--- a/cms/server/contest/templates/documentation.html
+++ b/cms/server/contest/templates/documentation.html
@@ -1,4 +1,7 @@
 {% extends "contest.html" %}
+
+{% set page = "documentation" %}
+
 {% block core %}
 <div class="span9">
 

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -20,24 +20,24 @@
         {% trans %}The contest hasn't started yet.{% endtrans %}
         </p>
         <p>
-        {% trans start_time=(contest.start + current_user.delay_time)|format_datetime_smart,
-                 stop_time=(contest.stop + current_user.delay_time + current_user.extra_time)|format_datetime_smart %}
+        {% trans start_time=(contest.start + participation.delay_time)|format_datetime_smart,
+                 stop_time=(contest.stop + participation.delay_time + participation.extra_time)|format_datetime_smart %}
           The contest will start at {{ start_time }} and will end at {{ stop_time }}.
         {% endtrans %}
 {% elif phase == 0 %}
         {% trans %}The contest is currently running.{% endtrans %}
         </p>
         <p>
-        {% trans start_time=(contest.start + current_user.delay_time)|format_datetime_smart,
-                 stop_time=(contest.stop + current_user.delay_time + current_user.extra_time)|format_datetime_smart %}
+        {% trans start_time=(contest.start + participation.delay_time)|format_datetime_smart,
+                 stop_time=(contest.stop + participation.delay_time + participation.extra_time)|format_datetime_smart %}
           The contest started at {{ start_time }} and will end at {{ stop_time }}.
         {% endtrans %}
 {% elif phase >= +1 %}
         {% trans %}The contest has already ended.{% endtrans %}
         </p>
         <p>
-        {% trans start_time=(contest.start + current_user.delay_time)|format_datetime_smart,
-                 stop_time=(contest.stop + current_user.delay_time + current_user.extra_time)|format_datetime_smart %}
+        {% trans start_time=(contest.start + participation.delay_time)|format_datetime_smart,
+                 stop_time=(contest.stop + participation.delay_time + participation.extra_time)|format_datetime_smart %}
           The contest started at {{ start_time }} and ended at {{ stop_time }}.
         {% endtrans %}
 {% endif %}
@@ -148,16 +148,16 @@
         {% trans %}By clicking on the button below you can start your time frame.{% endtrans %}
         {% trans %}Once you start, you can submit solutions until the end of the time frame or until the end of the contest, whatever comes first.{% endtrans %}
     {% elif actual_phase == 0 %}
-        {% trans start_time=current_user.starting_time|format_datetime_smart %}You started your time frame at {{ start_time }}.{% endtrans %}
+        {% trans start_time=participation.starting_time|format_datetime_smart %}You started your time frame at {{ start_time }}.{% endtrans %}
         {% trans %}You can submit solutions until the end of the time frame or until the end of the contest, whatever comes first.{% endtrans %}
     {% elif actual_phase == +1 %}
-        {% trans start_time=current_user.starting_time|format_datetime_smart %}You started your time frame at {{ start_time }} and you already finished it.{% endtrans %}
+        {% trans start_time=participation.starting_time|format_datetime_smart %}You started your time frame at {{ start_time }} and you already finished it.{% endtrans %}
         {% trans %}There's nothing you can do now.{% endtrans %}
     {% elif actual_phase == +2 %}
-        {% if current_user.starting_time is none %}
+        {% if participation.starting_time is none %}
             {% trans %}You never started your time frame. Now it's too late.{% endtrans %}
         {% else %}
-            {% trans start_time=current_user.starting_time|format_datetime_smart %}You started your time frame at {{ start_time }} and you already finished it.{% endtrans %}
+            {% trans start_time=participation.starting_time|format_datetime_smart %}You started your time frame at {{ start_time }} and you already finished it.{% endtrans %}
         {% endif %}
         {% trans %}There's nothing you can do now.{% endtrans %}
     {% endif %}

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -1,4 +1,7 @@
 {% extends "contest.html" %}
+
+{% set page = "overview" %}
+
 {% block core %}
 
 

--- a/cms/server/contest/templates/printing.html
+++ b/cms/server/contest/templates/printing.html
@@ -1,5 +1,7 @@
 {% extends "contest.html" %}
 
+{% set page = "printing" %}
+
 {% block core %}
 
 

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -9,10 +9,10 @@
     <td class="status">
         {% trans %}Compiling...{% endtrans %}
     </td>
-    {% if score_type is not none and score_type.max_public_score != 0 %}
+    {% if score_type is defined and score_type.max_public_score != 0 %}
     <td class="public_score undefined">{% trans %}N/A{% endtrans %}</td>
     {% endif %}
-    {% if score_type is not none and score_type.max_public_score != score_type.max_score %}
+    {% if score_type is defined and score_type.max_public_score != score_type.max_score %}
     <td class="total_score undefined">{% trans %}N/A{% endtrans %}</td>
     {% endif %}
 {% elif sr.compilation_outcome == "fail" %}
@@ -22,10 +22,10 @@
         {% trans %}Compilation failed{% endtrans %}
         <a class="details">{% trans %}details{% endtrans %}</a>
     </td>
-    {% if score_type is not none and score_type.max_public_score != 0 %}
+    {% if score_type is defined and score_type.max_public_score != 0 %}
     <td class="public_score undefined">{% trans %}N/A{% endtrans %}</td>
     {% endif %}
-    {% if score_type is not none and score_type.max_public_score != score_type.max_score %}
+    {% if score_type is defined and score_type.max_public_score != score_type.max_score %}
     <td class="total_score undefined">{% trans %}N/A{% endtrans %}</td>
     {% endif %}
 {% elif not sr.evaluated() %}
@@ -34,10 +34,10 @@
     <td class="status">
         {% trans %}Evaluating...{% endtrans %}
     </td>
-    {% if score_type is not none and score_type.max_public_score != 0 %}
+    {% if score_type is defined and score_type.max_public_score != 0 %}
     <td class="public_score undefined">{% trans %}N/A{% endtrans %}</td>
     {% endif %}
-    {% if score_type is not none and score_type.max_public_score != score_type.max_score %}
+    {% if score_type is defined and score_type.max_public_score != score_type.max_score %}
     <td class="total_score undefined">{% trans %}N/A{% endtrans %}</td>
     {% endif %}
 {% elif not sr.scored() %}
@@ -46,10 +46,10 @@
     <td class="status">
         {% trans %}Scoring...{% endtrans %}
     </td>
-    {% if score_type is not none and score_type.max_public_score != 0 %}
+    {% if score_type is defined and score_type.max_public_score != 0 %}
     <td class="public_score undefined">{% trans %}N/A{% endtrans %}</td>
     {% endif %}
-    {% if score_type is not none and score_type.max_public_score != score_type.max_score %}
+    {% if score_type is defined and score_type.max_public_score != score_type.max_score %}
     <td class="total_score undefined">{% trans %}N/A{% endtrans %}</td>
     {% endif %}
 {% else %}

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -1,72 +1,37 @@
+<tr data-submission="{{ s_idx }}" data-status="{{ sr.get_status() }}">
 {% if show_date %}
-    {% set col1 = "<td class=\"datetime\">%s</td>"|format(s.timestamp|format_datetime) %}
+    <td class="datetime">{{ s.timestamp|format_datetime }}</td>
 {% else %}
-    {% set col1 = "<td class=\"time\">%s</td>"|format(s.timestamp|format_time) %}
+    <td class="time">{{ s.timestamp|format_time }}</td>
 {% endif %}
-{% if sr is none or not sr.compiled() %}
-<tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.COMPILING }}">
-    {% raw col1 %}
     <td class="status">
+{% if sr.get_status() == SubmissionResult.COMPILING %}
         {% trans %}Compiling...{% endtrans %}
-    </td>
-    {% if score_type is defined and score_type.max_public_score != 0 %}
-    <td class="public_score undefined">{% trans %}N/A{% endtrans %}</td>
-    {% endif %}
-    {% if score_type is defined and score_type.max_public_score != score_type.max_score %}
-    <td class="total_score undefined">{% trans %}N/A{% endtrans %}</td>
-    {% endif %}
-{% elif sr.compilation_outcome == "fail" %}
-<tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.COMPILATION_FAILED }}">
-    {% raw col1 %}
-    <td class="status">
+{% elif sr.get_status() == SubmissionResult.COMPILATION_FAILED %}
         {% trans %}Compilation failed{% endtrans %}
         <a class="details">{% trans %}details{% endtrans %}</a>
-    </td>
-    {% if score_type is defined and score_type.max_public_score != 0 %}
-    <td class="public_score undefined">{% trans %}N/A{% endtrans %}</td>
-    {% endif %}
-    {% if score_type is defined and score_type.max_public_score != score_type.max_score %}
-    <td class="total_score undefined">{% trans %}N/A{% endtrans %}</td>
-    {% endif %}
-{% elif not sr.evaluated() %}
-<tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.EVALUATING }}">
-    {% raw col1 %}
-    <td class="status">
+{% elif sr.get_status() == SubmissionResult.EVALUATING %}
         {% trans %}Evaluating...{% endtrans %}
-    </td>
-    {% if score_type is defined and score_type.max_public_score != 0 %}
-    <td class="public_score undefined">{% trans %}N/A{% endtrans %}</td>
-    {% endif %}
-    {% if score_type is defined and score_type.max_public_score != score_type.max_score %}
-    <td class="total_score undefined">{% trans %}N/A{% endtrans %}</td>
-    {% endif %}
-{% elif not sr.scored() %}
-<tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.SCORING }}">
-    {% raw col1 %}
-    <td class="status">
+{% elif sr.get_status() == SubmissionResult.SCORING %}
         {% trans %}Scoring...{% endtrans %}
-    </td>
-    {% if score_type is defined and score_type.max_public_score != 0 %}
-    <td class="public_score undefined">{% trans %}N/A{% endtrans %}</td>
-    {% endif %}
-    {% if score_type is defined and score_type.max_public_score != score_type.max_score %}
-    <td class="total_score undefined">{% trans %}N/A{% endtrans %}</td>
-    {% endif %}
-{% else %}
-<tr data-submission="{{ s_idx }}" data-status="{{ SubmissionResult.SCORED }}">
-    {% raw col1 %}
-    <td class="status">
+{% elif sr.get_status() == SubmissionResult.SCORED %}
         {% trans %}Evaluated{% endtrans %}
         <a class="details">{% trans %}details{% endtrans %}</a>
+{% endif %}
     </td>
-
-    {% if score_type.max_public_score > 0 %}
+{% if score_type is defined and score_type.max_public_score > 0 %}
+    {% if sr.get_status() == SubmissionResult.SCORED %}
     <td class="public_score {{ get_score_class(sr.public_score, score_type.max_public_score) }}">
         {{ score_type.format_score(sr.public_score, score_type.max_public_score, sr.public_score_details, task.score_precision, translation=translation) }}
     </td>
+    {% else %}
+    <td class="public_score undefined">
+        {% trans %}N/A{% endtrans %}
+    </td>
     {% endif %}
-
-    {% if score_type.max_public_score != score_type.max_score %}
+{% endif %}
+{% if score_type is defined and score_type.max_public_score < score_type.max_score %}
+    {% if sr.get_status() == SubmissionResult.SCORED %}
         {% if s.token is not none or actual_phase == 3 %}
     <td class="total_score {{ get_score_class(sr.score, score_type.max_score) }}">
         {{ score_type.format_score(sr.score, score_type.max_score, sr.score_details, task.score_precision, translation=translation) }}
@@ -76,6 +41,10 @@
         {% trans %}N/A{% endtrans %}
     </td>
         {% endif %}
+    {% else %}
+    <td class="total_score undefined">
+        {% trans %}N/A{% endtrans %}
+    </td>
     {% endif %}
 {% endif %}
 {% if actual_phase >= +3 %}

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -1,4 +1,7 @@
 {% extends "contest.html" %}
+
+{% set page = "task_description" %}
+
 {% block core %}
 
 

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -163,7 +163,7 @@ $(document).ready(function () {
 
 {% if tokens_contest != 0 and tokens_tasks != 0 and actual_phase == 0 %}
 <div style="padding-bottom:10px">
-    {% set tokens_info = contest.tokens_available(current_user, task, now) %}
+    {% set tokens_info = contest.tokens_available(participation, task, now) %}
     {% set can_play_token = actual_phase == 0 and (tokens_info[0] > 0 or tokens_info[0] == -1) %}
     {% set need_to_wait = tokens_info[2] is not none %}
     {% if can_play_token %}

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -1,5 +1,7 @@
 {% extends "contest.html" %}
 
+{% set page = "task_submissions" %}
+
 {% block additional_js %}
 
 $(document).on("click", "#submission_list tbody tr td.status .details", function (event) {

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -205,11 +205,7 @@ $(document).ready(function () {
 {% endif %}
 
 
-{% try %}
-    {% set score_type = get_score_type(dataset=task.active_dataset) %}
-{% except %}
-    {% set score_type = none %}
-{% endtry %}
+{% set score_type = get_score_type(dataset=task.active_dataset) %}
 
 {% set show_date = not submissions|map(attribute="timestamp")|all("today") %}
 
@@ -222,7 +218,7 @@ $(document).ready(function () {
         <col class="time"/>
 {% endif %}
         <col class="status"/>
-{% if score_type is not none and score_type.max_public_score != 0 and score_type.max_public_score != score_type.max_score %}
+{% if score_type is defined and score_type.max_public_score != 0 and score_type.max_public_score != score_type.max_score %}
         <col class="public_score"/>
         <col class="total_score"/>
 {% else %}
@@ -246,7 +242,7 @@ $(document).ready(function () {
             <th class="time">{% trans %}Time{% endtrans %}</th>
 {% endif %}
             <th class="status">{% trans %}Status{% endtrans %}</th>
-{% if score_type is not none and score_type.max_public_score != 0 and score_type.max_public_score != score_type.max_score %}
+{% if score_type is defined and score_type.max_public_score != 0 and score_type.max_public_score != score_type.max_score %}
             <th class="public_score">{% trans %}Public score{% endtrans %}</th>
             <th class="total_score">{% trans %}Total score{% endtrans %}</th>
 {% else %}

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -272,7 +272,7 @@ $(document).ready(function () {
         {% for s in submissions|sort(attribute="timestamp")|reverse %}
             {# loop.revindex is broken: https://github.com/pallets/jinja/issues/794 #}
             {% set s_idx = submissions|length - loop.index0 %}
-            {% set sr = s.get_result(s.task.active_dataset) %}
+            {% set sr = s.get_result_or_create(s.task.active_dataset) %}
             {% include "submission_row.html" %}
         {% endfor %}
     {% endif %}

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -1,5 +1,7 @@
 {% extends "contest.html" %}
 
+{% set page = "test_interface" %}
+
 {% block additional_js %}
 $(document).on("click", ".user_test_list tbody tr td.status .details", function (event) {
     var $this = $(this);

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -208,7 +208,7 @@ $(document).ready(function () {
         {% for t in user_tests[task.id]|sort(attribute="timestamp")|reverse %}
             {# loop.revindex is broken: https://github.com/pallets/jinja/issues/794 #}
             {% set t_idx = user_tests[task.id]|length - loop.index0 %}
-            {% set tr = t.get_result(t.task.active_dataset) %}
+            {% set tr = t.get_result_or_create(t.task.active_dataset) %}
             {% include "user_test_row.html" %}
         {% endfor %}
     {% endif %}

--- a/cms/server/contest/templates/user_test_row.html
+++ b/cms/server/contest/templates/user_test_row.html
@@ -1,37 +1,23 @@
-
+<tr data-user-test="{{ t_idx }}" data-status="{{ tr.get_status() }}">
 {% if show_date %}
-    {% set col1 = "<td class=\"datetime\">%s</td>"|format(t.timestamp|format_datetime) %}
+    <td class="datetime">{{ t.timestamp|format_datetime }}</td>
 {% else %}
-    {% set col1 = "<td class=\"time\">%s</td>"|format(t.timestamp|format_time) %}
+    <td class="time">{{ t.timestamp|format_time }}</td>
 {% endif %}
-{% if tr is none or not tr.compiled() %}
-<tr data-user-test="{{ t_idx }}" data-status="1">
-    {% raw col1 %}
     <td class="status">
+{% if tr.get_status() == UserTestResult.COMPILING %}
         {% trans %}Compiling...{% endtrans %}
-    </td>
-{% elif tr.compilation_outcome == "fail" %}
-<tr data-user-test="{{ t_idx }}" data-status="2">
-    {% raw col1 %}
-    <td class="status">
+{% elif tr.get_status() == UserTestResult.COMPILATION_FAILED %}
         {% trans %}Compilation failed{% endtrans %}
         <a class="details">{% trans %}details{% endtrans %}</a>
-    </td>
-{% elif not tr.evaluated() %}
-<tr data-user-test="{{ t_idx }}" data-status="3">
-    {% raw col1 %}
-    <td class="status">
+{% elif tr.get_status() == UserTestResult.EVALUATING %}
         {% trans %}Executing...{% endtrans %}
-    </td>
-{% else %}
-<tr data-user-test="{{ t_idx }}" data-status="4">
-    {% raw col1 %}
-    <td class="status">
+{% elif tr.get_status() == UserTestResult.EVALUATED %}
         {% trans %}Executed{% endtrans %}
         <a class="details">{% trans %}details{% endtrans %}</a>
-    </td>
 {% endif %}
-{% if tr is none or tr.execution_time is none %}
+    </td>
+{% if tr.execution_time is none %}
     <td class="time undefined">
         {% trans %}N/A{% endtrans %}
     </td>
@@ -40,7 +26,7 @@
         {{ tr.execution_time|format_duration }}
     </td>
 {% endif %}
-{% if tr is none or tr.execution_memory is none %}
+{% if tr.execution_memory is none %}
     <td class="memory undefined">
         {% trans %}N/A{% endtrans %}
     </td>
@@ -55,7 +41,7 @@
         </a>
     </td>
     <td class="output">
-    {% if tr is none or not tr.compiled() or (tr.compilation_outcome == 'ok' and not tr.evaluated()) %}
+    {% if tr.get_status() == UserTestResult.COMPILING or tr.get_status() == UserTestResult.EVALUATING %}
         <a class="btn btn-primary disabled">
             {% trans %}Wait...{% endtrans %}
         </a>

--- a/cms/server/jinja2_toolbox.py
+++ b/cms/server/jinja2_toolbox.py
@@ -32,7 +32,8 @@ from future.builtins.disabled import *
 from future.builtins import *
 from six import iterkeys, itervalues, iteritems
 
-from jinja2 import Environment, StrictUndefined, contextfilter, contextfunction
+from jinja2 import Environment, StrictUndefined, contextfilter, contextfunction, \
+    environmentfunction
 
 from cmscommon.datetime import make_timestamp, utc
 from cmscommon.mimetypes import get_type_for_file_name, get_name_for_type, \
@@ -140,14 +141,30 @@ def today(ctx, dt):
         == now.replace(tzinfo=utc).astimezone(timezone).date()
 
 
+@environmentfunction
+def safe_get_task_type(env, *args, **kwargs):
+    try:
+        return get_task_type(*args, **kwargs)
+    except Exception as err:
+        return env.undefined("TaskType not found", exc=err)
+
+
+@environmentfunction
+def safe_get_score_type(env, *args, **kwargs):
+    try:
+        return get_score_type(*args, **kwargs)
+    except Exception as err:
+        return env.undefined("ScoreType not found", exc=err)
+
+
 def instrument_generic_toolbox(env):
     env.globals["iterkeys"] = iterkeys
     env.globals["itervalues"] = itervalues
     env.globals["iteritems"] = iteritems
     env.globals["next"] = next
 
-    env.globals["get_task_type"] = get_task_type
-    env.globals["get_score_type"] = get_score_type
+    env.globals["get_task_type"] = safe_get_task_type
+    env.globals["get_score_type"] = safe_get_score_type
 
     env.globals["get_score_class"] = get_score_class
 


### PR DESCRIPTION
This is the second of a series of pull requests that ports CWS's templates from the Tornado engine to Jinja2. This pull request improves the way we do localization in the templates.
* Using context-aware filters allows us to reduce the boilerplate for most formatting operations.
* Using the `{% trans %}` blocks allows to better manage the escaping (e.g., no need to disable autoescaping when the message contains HTML) and the parameters injection.
* Finally, since Jinja2 provides a Babel extractor, we can reenable templates in Babel's mapping. The fact that the extractor does in fact perform a complete parsing of the templates, builds an AST and then extracts messages from there makes sure that they are all caught (unlike in Tornado, where xgettext was parsing the templates as if they were Python files and mysteriously missed some messages (it is in fact surprising that it *only* missed a couple)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/846)
<!-- Reviewable:end -->
