### PR TITLE
Improve cmstestsuite determinism and usability

### DIFF
--- a/cmstestsuite/RunUnitTests.py
+++ b/cmstestsuite/RunUnitTests.py
@@ -174,7 +174,7 @@ def main():
 
     if args.dry_run:
         for t in test_list:
-            print(t[0].name, t[1])
+            print(t[0], t[1])
         return 0
 
     if args.retry_failed:

--- a/cmstestsuite/RunUnitTests.py
+++ b/cmstestsuite/RunUnitTests.py
@@ -115,7 +115,7 @@ def get_all_tests():
     tests = []
     files = sorted(os.walk(os.path.join("cmstestsuite", "unit_tests")))
     for path, _, names in files:
-        for name in names:
+        for name in sorted(names):
             if name.endswith(".py"):
                 tests.append((path, name))
     return tests

--- a/cmstestsuite/RunUnitTests.py
+++ b/cmstestsuite/RunUnitTests.py
@@ -29,6 +29,7 @@ import argparse
 import io
 import logging
 import os
+import re
 import sys
 import subprocess
 import datetime
@@ -171,6 +172,15 @@ def main():
         test_list = load_failed_tests()
     else:
         test_list = get_all_tests()
+
+    if args.regex:
+        # Require at least one regex to match to include it in the list.
+        filter_regexps = [re.compile(regex) for regex in args.regex]
+
+        def test_match(t):
+            return any([r.search(t) is not None for r in filter_regexps])
+
+        test_list = [t for t in test_list if test_match(' '.join(t))]
 
     if args.dry_run:
         for t in test_list:

--- a/cmstestsuite/RunUnitTests.py
+++ b/cmstestsuite/RunUnitTests.py
@@ -113,7 +113,8 @@ def load_test_list_from_file(filename):
 
 def get_all_tests():
     tests = []
-    for path, _, names in os.walk(os.path.join("cmstestsuite", "unit_tests")):
+    files = sorted(os.walk(os.path.join("cmstestsuite", "unit_tests")))
+    for path, _, names in files:
         for name in names:
             if name.endswith(".py"):
                 tests.append((path, name))

--- a/cmstestsuite/RunUnitTests.py
+++ b/cmstestsuite/RunUnitTests.py
@@ -133,6 +133,9 @@ def main():
     parser = argparse.ArgumentParser(
         description="Runs the CMS unittest suite.")
     parser.add_argument(
+        "regex", action="store", type=utf8_decoder, nargs='*',
+        help="a regex to match to run a subset of tests")
+    parser.add_argument(
         "-n", "--dry-run", action="store_true",
         help="show what tests would be run, but do not run them")
     parser.add_argument(
@@ -144,9 +147,6 @@ def main():
         FAILED_UNITTEST_FILENAME)
 
     # Unused parameters.
-    parser.add_argument(
-        "regex", action="store", type=utf8_decoder, nargs='*',
-        help="unused")
     parser.add_argument(
         "-l", "--languages", action="store", type=utf8_decoder, default="",
         help="unused")
@@ -179,7 +179,7 @@ def main():
         filter_regexps = [re.compile(regex) for regex in args.regex]
 
         def test_match(t):
-            return any([r.search(t) is not None for r in filter_regexps])
+            return any(r.search(t) is not None for r in filter_regexps)
 
         test_list = [t for t in test_list if test_match(' '.join(t))]
 


### PR DESCRIPTION
These commits add the ability to run individual unit tests, and make the test ordering deterministic (not dependent on filesystem inode ordering). Unfortunately, this also exposes the fact that ImportTaskTest and ImportContestTest can fail unless ImportDatasetTest has run first. And even then, there are some weird dependency issues I haven't figured out yet. So this commit causes the unit tests to fail. But I'm hoping someone else can fix the failure who better understands what exploded! This reproduces it on a fresh database:

`$ TEST_SUITE=unittests cmsRunTests ImportTask
`

If you run the tests in reverse order, they all pass, but I'd prefer to get the failure fixed (presumably before this can be merged!) Or we can not merge the last commit in the sequence (that sorts the tests), but then it's still a ticking time bomb.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/858)
<!-- Reviewable:end -->
