### PR TITLE
FileCacher consistency and temp file handling fixes

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -57,7 +57,7 @@ __all__ = [
     # base
     "metadata", "Base",
     # fsobject
-    "FSObject",
+    "FSObject", "LargeObject",
     # validation
     "CodenameConstraint", "FilenameConstraint", "DigestConstraint",
     # contest
@@ -100,7 +100,7 @@ from .session import Session, ScopedSession, SessionGen, \
 
 from .types import CastingArray
 from .base import metadata, Base
-from .fsobject import FSObject
+from .fsobject import FSObject, LargeObject
 from .validation import CodenameConstraint, FilenameConstraint, \
     DigestConstraint
 from .contest import Contest, Announcement

--- a/cms/db/filecacher.py
+++ b/cms/db/filecacher.py
@@ -101,9 +101,7 @@ class FileCacherBackend(object):
         be used.
 
         fobj (fileobj): the object returned by create_file()
-
         digest (unicode): the digest of the file to store.
-
         desc (unicode): the optional description of the file to
             store, intended for human beings.
 

--- a/cms/db/filecacher.py
+++ b/cms/db/filecacher.py
@@ -663,7 +663,7 @@ class FileCacher(object):
         # compressed or require network communication).
         # XXX We're *almost* reimplementing copyfileobj.
         with tempfile.NamedTemporaryFile('wb', delete=False,
-                                         dir=config.temp_dir) as dst:
+                                         dir=self.temp_dir) as dst:
             hasher = hashlib.sha1()
             buf = src.read(self.CHUNK_SIZE)
             while len(buf) > 0:

--- a/cms/db/filecacher.py
+++ b/cms/db/filecacher.py
@@ -32,6 +32,7 @@ from __future__ import unicode_literals
 from future.builtins.disabled import *
 from future.builtins import *
 
+import atexit
 import hashlib
 import io
 import logging
@@ -465,6 +466,7 @@ class FileCacher(object):
 
         if service is None:
             self.file_dir = tempfile.mkdtemp(dir=config.temp_dir)
+            atexit.register(lambda: rmtree(self.file_dir))
         else:
             self.file_dir = os.path.join(
                 config.cache_dir,
@@ -476,6 +478,7 @@ class FileCacher(object):
                 or not mkdir(self.file_dir) or not mkdir(self.temp_dir):
             logger.error("Cannot create necessary directories.")
             raise RuntimeError("Cannot create necessary directories.")
+        atexit.register(lambda: rmtree(self.temp_dir))
 
     def load(self, digest, if_needed=False):
         """Load the file with the given digest into the cache.

--- a/cms/db/filecacher.py
+++ b/cms/db/filecacher.py
@@ -493,6 +493,8 @@ class FileCacher(object):
 
         if service is None:
             self.file_dir = tempfile.mkdtemp(dir=config.temp_dir)
+            # Delete this directory on exit since it has a random name and
+            # won't be used again.
             atexit.register(lambda: rmtree(self.file_dir))
         else:
             self.file_dir = os.path.join(

--- a/cms/db/fsobject.py
+++ b/cms/db/fsobject.py
@@ -394,10 +394,10 @@ class FSObject(Base):
              given, `rb' is used.
 
         """
+        assert self.loid != 0, "Expected LO to have already been created!"
         # Here we rely on the fact that we're using psycopg2 as
         # PostgreSQL backend.
         lobj = LargeObject(self.loid, mode)
-        self.loid = lobj.loid
 
         # FIXME Wrap with a io.BufferedReader/Writer/Random?
         return lobj

--- a/cmstestsuite/unit_tests/db/filecacher_test.py
+++ b/cmstestsuite/unit_tests/db/filecacher_test.py
@@ -142,6 +142,30 @@ class TestFileCacher(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.cache_base_path, ignore_errors=True)
 
+    def check_stored_file(self, digest):
+        """Ensure that a given file digest has been stored correctly."""
+        # Remove it from the filesystem.
+        cache_path = os.path.join(self.cache_base_path, digest)
+        try:
+            os.unlink(cache_path)
+        except OSError:
+            pass
+
+        # Pull it out of the file_cacher and compute the hash
+        hash_file = HashingFile()
+        try:
+            self.file_cacher.get_file_to_fobj(digest, hash_file)
+        except Exception as error:
+            self.fail("Error received: %r." % error)
+        my_digest = hash_file.digest
+        hash_file.close()
+
+        # Ensure the digest matches.
+        if digest != my_digest:
+            self.fail("Content differs.")
+        if not os.path.exists(cache_path):
+            self.fail("File not stored in local cache.")
+
     def test_file_life(self):
         """Send a ~100B random binary file to the storage through
         FileCacher as a file-like object. FC should cache the content
@@ -302,24 +326,52 @@ class TestFileCacher(unittest.TestCase):
         self.cache_path = os.path.join(self.cache_base_path, data)
         self.digest = data
 
-        # Get the ~100MB file from FileCacher.
-        os.unlink(self.cache_path)
-        hash_file = HashingFile()
-        try:
-            self.file_cacher.get_file_to_fobj(self.digest, hash_file)
-        except Exception as error:
-            self.fail("Error received: %r." % error)
-        my_digest = hash_file.digest
-        hash_file.close()
+        # Check file is stored correctly in FileCacher.
+        self.check_stored_file(self.digest)
 
-        try:
-            if self.digest != my_digest:
-                self.fail("Content differs.")
-            if not os.path.exists(self.cache_path):
-                self.fail("File not stored in local cache.")
-        finally:
-            self.file_cacher.delete(self.digest)
+        self.file_cacher.delete(self.digest)
 
+    def test_file_duplicates(self):
+        """Send multiple copies of the same random file to the storage through
+        FileCacher. FC should handle this gracefully and only end up with one
+        copy.
+        """
+        # We need to wrap the generator in a list because of a
+        # shortcoming of future's bytes implementation.
+        size = 100
+        rand_file = RandomFile(size)
+        content = rand_file.read(size)
+        digest = rand_file.digest
+        rand_file.close()
+
+        # Test writing the same file to the DB in parallel.
+        # Create empty files.
+        num_files = 4
+        fobjs = []
+        for i in range(num_files):
+            fobj = self.file_cacher.backend.create_file(digest)
+            # As the file contains random data, we don't expect to have put
+            # this into the DB previously.
+            assert fobj is not None
+            fobjs.append(fobj)
+
+        # Close them in a different order.
+        random.shuffle(fobjs)
+
+        # Write the files and commit them.
+        for i, fobj in enumerate(fobjs):
+            fobj.write(content)
+            # Ensure that only one copy made it into the database.
+            commit_ok = \
+                self.file_cacher.backend.commit_file(fobj,
+                                                     digest,
+                                                     desc='Copy %d' % i)
+            # Only the first commit should succeed.
+            assert commit_ok == (i == 0), \
+                "Commit of %d was %s unexpectedly" % (i, commit_ok)
+
+        # Check that the file was stored correctly.
+        self.check_stored_file(digest)
 
 if __name__ == "__main__":
     unittest.main()

--- a/cmstestsuite/unit_tests/db/filecacher_test.py
+++ b/cmstestsuite/unit_tests/db/filecacher_test.py
@@ -129,7 +129,8 @@ class TestFileCacherBase(object):
 
     """
 
-    def setUp(self, file_cacher):
+    def _setUp(self, file_cacher):
+        """Common initialization that should be called by derived classes."""
         self.file_cacher = file_cacher
         self.cache_base_path = self.file_cacher.file_dir
         self.cache_path = None
@@ -382,7 +383,7 @@ class TestFileCacherDB(TestFileCacherBase, unittest.TestCase):
 
     def setUp(self):
         file_cacher = FileCacher()
-        super(TestFileCacherDB, self).setUp(file_cacher)
+        self._setUp(file_cacher)
 
     def tearDown(self):
         shutil.rmtree(self.cache_base_path, ignore_errors=True)
@@ -395,7 +396,7 @@ class TestFileCacherFS(TestFileCacherBase, unittest.TestCase):
 
     def setUp(self):
         file_cacher = FileCacher(path="fs-storage")
-        super(TestFileCacherFS, self).setUp(file_cacher)
+        self._setUp(file_cacher)
 
     def tearDown(self):
         shutil.rmtree(self.cache_base_path, ignore_errors=True)


### PR DESCRIPTION
If storage of a large object (LO) fails, for example, by running out of disk
space or a KeyboardInterrupt, then we leave the database in an inconsistent
state, because the FSObject table refers to a large object which has not been
written out correctly.

This commit fixes this using a suggestion from @wafrelka: ensure first that the
file has been committed to storage before making any reference to it in the
FSObjects table. There is a risk that we leave stale large objects in the
database, but overcoming this would need both the LO write and the FSObject to
be updated in the same transaction, which requires bending SQLAlchemy in ways
we'd rather not.

Stale objects are not a functional problem, and unlikely to arise in normal
operation. We should consider writing a consistency checker that finds stale
LOs and discards them!

Other commits stop leaving temp files around in case of failure, and ensure we create temp files on the same FS as the destination.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/863)
<!-- Reviewable:end -->
