### PR TITLE
Fix partial scores in testlib.h

### DIFF
--- a/cmscontrib/loaders/polygon/testlib.h
+++ b/cmscontrib/loaders/polygon/testlib.h
@@ -1926,6 +1926,9 @@ NORETURN void InStream::quit(TResult result, const char* msg)
     } else if (result == _dirt) {
       std::fprintf(stdout, "0.0\n");
       std::fprintf(stderr, "Wrong Output Format\n");
+    } else if (result == _points) {
+      std::fprintf(stdout, "%f\n", __testlib_points);
+      std::fprintf(stderr, "Partial Score\n");
     } else if (result == _unexpected_eof) {
       std::fprintf(stdout, "0.0\n");
       std::fprintf(stderr, "Wrong Output Format\n");


### PR DESCRIPTION
CMS contains a customized testlib.h library, and the customizations fail to process partial scores properly. This PR fixes the problem.

Consider this checker:
```
#include "testlib.h"

using namespace std;

int main(int argc, char * argv[])
{
    registerTestlibCmd(argc, argv);

    quitp(0.42, "partial score");
}
```

Output with master:
```
> ./checker /dev/null /dev/null /dev/null
0.0
FAILURE, CONTACT JURY, ERROR 2 5
```

Output with branch:
```
> ./checker /dev/null /dev/null /dev/null
0.420000
Partial Score
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/881)
<!-- Reviewable:end -->
