### PR TITLE
Add a WSGI middleware to serve files from the file cacher by digest

### DIFF
--- a/cms/io/web_service.py
+++ b/cms/io/web_service.py
@@ -38,6 +38,9 @@ from gevent.pywsgi import WSGIServer
 from werkzeug.wsgi import DispatcherMiddleware, SharedDataMiddleware
 from werkzeug.contrib.fixers import ProxyFix
 
+from cms.db.filecacher import FileCacher
+from cms.server.file_middleware import FileByDigestMiddleware
+
 from .service import Service
 from .web_rpc import RPCMiddleware
 
@@ -74,6 +77,10 @@ class WebService(Service):
                 self.wsgi_app, {"/static": entry},
                 cache=True, cache_timeout=SECONDS_IN_A_YEAR,
                 fallback_mimetype="application/octet-stream")
+
+        self.file_cacher = FileCacher(self)
+        self.wsgi_app = DispatcherMiddleware(
+            self.wsgi_app, {"/file": FileByDigestMiddleware(self.file_cacher)})
 
         if rpc_enabled:
             self.wsgi_app = DispatcherMiddleware(

--- a/cms/server/__init__.py
+++ b/cms/server/__init__.py
@@ -26,14 +26,11 @@ from future.builtins import *
 
 from .util import \
     CommonRequestHandler, actual_phase_required, compute_actual_phase, \
-    file_handler_gen, filter_ascii, \
-    create_url_builder, multi_contest
+    filter_ascii, create_url_builder, multi_contest
 
 
 __all__ = [
     # util
     "CommonRequestHandler", "actual_phase_required", "compute_actual_phase",
-    "file_handler_gen", "filter_ascii",
-    "create_url_builder",
-    "multi_contest",
+    "filter_ascii", "create_url_builder", "multi_contest",
 ]

--- a/cms/server/admin/handlers/__init__.py
+++ b/cms/server/admin/handlers/__init__.py
@@ -28,7 +28,6 @@ from future.builtins.disabled import *
 from future.builtins import *
 
 from .base import \
-    FileFromDigestHandler, \
     SimpleHandler, \
     SimpleContestHandler
 from .main import \
@@ -119,7 +118,6 @@ HANDLERS = [
     (r"/resources/([0-9]+|all)", ResourcesHandler),
     (r"/resources/([0-9]+|all)/([0-9]+)", ResourcesHandler),
     (r"/notifications", NotificationsHandler),
-    (r"/file/([a-f0-9]+)/([a-zA-Z0-9_.-]+)", FileFromDigestHandler),
 
     # Contest
 

--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -54,7 +54,7 @@ from cms.db import Admin, Contest, Participation, Question, \
     UserTest
 from cms.grading.scoretypes import get_score_type_class
 from cms.grading.tasktypes import get_task_type_class
-from cms.server import CommonRequestHandler, file_handler_gen
+from cms.server import CommonRequestHandler
 from cmscommon.datetime import make_datetime
 from cmscommon.crypto import hash_password, parse_authentication
 
@@ -630,18 +630,6 @@ class BaseHandler(CommonRequestHandler):
 
         """
         return self.url("login")
-
-
-FileHandler = file_handler_gen(BaseHandler)
-
-
-class FileFromDigestHandler(FileHandler):
-    """Return the file, using the given name, and as plain text."""
-    @require_permission(BaseHandler.AUTHENTICATED)
-    def get(self, digest, filename):
-        # TODO: Accept a MIME type
-        self.sql_session.close()
-        self.fetch(digest, "text/plain", filename)
 
 
 def SimpleHandler(page, authenticated=True, permission_all=False):

--- a/cms/server/admin/handlers/submission.py
+++ b/cms/server/admin/handlers/submission.py
@@ -40,7 +40,7 @@ from cms.db import Dataset, File, Submission
 from cms.grading.languagemanager import get_language
 from cmscommon.datetime import make_datetime
 
-from .base import BaseHandler, FileHandler, require_permission
+from .base import BaseHandler, require_permission
 
 
 logger = logging.getLogger(__name__)
@@ -76,7 +76,7 @@ class SubmissionHandler(BaseHandler):
         self.render("submission.html", **self.r_params)
 
 
-class SubmissionFileHandler(FileHandler):
+class SubmissionFileHandler(BaseHandler):
     """Shows a submission file.
 
     """
@@ -93,8 +93,9 @@ class SubmissionFileHandler(FileHandler):
                 ".%l", get_language(submission.language).source_extension)
         digest = sub_file.digest
 
-        self.sql_session.close()
-        self.fetch(digest, "text/plain", real_filename)
+        self.redirect(self.url("file", digest, real_filename,
+                               mimetype="text/plain"),
+                      permanent=False, status=303)
 
 
 class SubmissionCommentHandler(BaseHandler):

--- a/cms/server/admin/handlers/usertest.py
+++ b/cms/server/admin/handlers/usertest.py
@@ -31,7 +31,7 @@ from future.builtins import *
 from cms.db import Dataset, UserTestFile, UserTest
 from cms.grading.languagemanager import get_language
 
-from .base import BaseHandler, FileHandler, require_permission
+from .base import BaseHandler, require_permission
 
 
 class UserTestHandler(BaseHandler):
@@ -59,7 +59,7 @@ class UserTestHandler(BaseHandler):
         self.render("user_test.html", **self.r_params)
 
 
-class UserTestFileHandler(FileHandler):
+class UserTestFileHandler(BaseHandler):
     """Shows a user test file."""
     # We cannot use FileFromDigestHandler as it does not know how to
     # set the proper name (i.e., converting %l to the language).
@@ -74,5 +74,6 @@ class UserTestFileHandler(FileHandler):
                 ".%l", get_language(user_test.language).source_extension)
         digest = user_test_file.digest
 
-        self.sql_session.close()
-        self.fetch(digest, "text/plain", real_filename)
+        self.redirect(self.url("file", digest, real_filename,
+                               mimetype="text/plain"),
+                      permanent=False, status=303)

--- a/cms/server/admin/server.py
+++ b/cms/server/admin/server.py
@@ -42,7 +42,6 @@ from sqlalchemy import func, not_
 from cmscommon.binary import hex_to_bin, bin_to_b64
 from cms import config, ServiceCoord, get_service_shards
 from cms.db import SessionGen, Dataset, Submission, SubmissionResult, Task
-from cms.db.filecacher import FileCacher
 from cms.io import WebService, rpc_method
 from cms.service import EvaluationService
 
@@ -83,7 +82,6 @@ class AdminWebServer(WebService):
         # A list of pending notifications.
         self.notifications = []
 
-        self.file_cacher = FileCacher(self)
         self.admin_web_server = self.connect_to(
             ServiceCoord("AdminWebServer", 0))
         self.evaluation_service = self.connect_to(

--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -48,8 +48,7 @@ from sqlalchemy.orm import contains_eager
 
 from cms import config, TOKEN_MODE_MIXED
 from cms.db import Contest, Participation, User
-from cms.server import compute_actual_phase, file_handler_gen, \
-    create_url_builder
+from cms.server import compute_actual_phase, create_url_builder
 from cms.locale import filter_language_codes
 from cmscommon.datetime import get_timezone, make_datetime, make_timestamp
 
@@ -359,6 +358,3 @@ class ContestHandler(BaseHandler):
 
         """
         return self.contest_url()
-
-
-FileHandler = file_handler_gen(ContestHandler)

--- a/cms/server/contest/handlers/task.py
+++ b/cms/server/contest/handlers/task.py
@@ -44,7 +44,7 @@ import tornado.web
 from cms.server import actual_phase_required, multi_contest
 from cmscommon.mimetypes import get_type_for_file_name
 
-from .contest import ContestHandler, FileHandler
+from .contest import ContestHandler
 
 
 logger = logging.getLogger(__name__)
@@ -80,7 +80,7 @@ class TaskDescriptionHandler(ContestHandler):
         self.render("task_description.html", task=task, **self.r_params)
 
 
-class TaskStatementViewHandler(FileHandler):
+class TaskStatementViewHandler(ContestHandler):
     """Shows the statement file of a task in the contest.
 
     """
@@ -104,10 +104,12 @@ class TaskStatementViewHandler(FileHandler):
         else:
             filename = "%s.pdf" % task.name
 
-        self.fetch(statement, "application/pdf", filename)
+        self.redirect(self.url("file", statement, filename,
+                               mimetype="application/pdf"),
+                      permanent=False, status=303)
 
 
-class TaskAttachmentViewHandler(FileHandler):
+class TaskAttachmentViewHandler(ContestHandler):
     """Shows an attachment file of a task in the contest.
 
     """
@@ -130,4 +132,6 @@ class TaskAttachmentViewHandler(FileHandler):
         if mimetype is None:
             mimetype = 'application/octet-stream'
 
-        self.fetch(attachment, mimetype, filename)
+        self.redirect(self.url("file", attachment, filename,
+                               mimetype=mimetype),
+                      permanent=False, status=303)

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -60,7 +60,7 @@ from cmscommon.crypto import encrypt_number
 from cmscommon.datetime import make_timestamp
 from cmscommon.mimetypes import get_type_for_file_name
 
-from .contest import ContestHandler, FileHandler, NOTIFICATION_ERROR, \
+from .contest import ContestHandler, NOTIFICATION_ERROR, \
     NOTIFICATION_SUCCESS, NOTIFICATION_WARNING
 
 
@@ -528,7 +528,7 @@ class SubmissionDetailsHandler(ContestHandler):
                     **self.r_params)
 
 
-class SubmissionFileHandler(FileHandler):
+class SubmissionFileHandler(ContestHandler):
     """Send back a submission file.
 
     """
@@ -579,7 +579,9 @@ class SubmissionFileHandler(FileHandler):
         if mimetype is None:
             mimetype = 'application/octet-stream'
 
-        self.fetch(digest, mimetype, filename)
+        self.redirect(self.url("file", digest, filename,
+                               mimetype=mimetype),
+                      permanent=False, status=303)
 
 
 class UseTokenHandler(ContestHandler):

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -58,8 +58,7 @@ from cmscommon.crypto import encrypt_number
 from cmscommon.datetime import make_timestamp
 from cmscommon.mimetypes import get_type_for_file_name
 
-from .contest import ContestHandler, FileHandler, NOTIFICATION_ERROR, \
-    NOTIFICATION_SUCCESS
+from .contest import ContestHandler, NOTIFICATION_ERROR, NOTIFICATION_SUCCESS
 
 
 logger = logging.getLogger(__name__)
@@ -532,7 +531,7 @@ class UserTestDetailsHandler(ContestHandler):
                     **self.r_params)
 
 
-class UserTestIOHandler(FileHandler):
+class UserTestIOHandler(ContestHandler):
     """Send back a submission file.
 
     """
@@ -571,10 +570,12 @@ class UserTestIOHandler(FileHandler):
 
         mimetype = 'text/plain'
 
-        self.fetch(digest, mimetype, io)
+        self.redirect(self.url("file", digest, io,
+                               mimetype=mimetype),
+                      permanent=False, status=303)
 
 
-class UserTestFileHandler(FileHandler):
+class UserTestFileHandler(ContestHandler):
     """Send back a submission file.
 
     """
@@ -622,4 +623,6 @@ class UserTestFileHandler(FileHandler):
         if mimetype is None:
             mimetype = 'application/octet-stream'
 
-        self.fetch(digest, mimetype, filename)
+        self.redirect(self.url("file", digest, filename,
+                               mimetype=mimetype),
+                      permanent=False, status=303)

--- a/cms/server/contest/server.py
+++ b/cms/server/contest/server.py
@@ -53,7 +53,6 @@ from cms.server.contest.jinja2_toolbox import CWS_ENVIRONMENT
 from cmscommon.binary import hex_to_bin, bin_to_b64
 from cms import ConfigError, ServiceCoord, config
 from cms.io import WebService
-from cms.db.filecacher import FileCacher
 from cms.locale import get_translations
 
 from .handlers import HANDLERS
@@ -126,7 +125,6 @@ class ContestWebServer(WebService):
         # Retrieve the available translations.
         self.translations = get_translations()
 
-        self.file_cacher = FileCacher(self)
         self.evaluation_service = self.connect_to(
             ServiceCoord("EvaluationService", 0))
         self.scoring_service = self.connect_to(

--- a/cms/server/file_middleware.py
+++ b/cms/server/file_middleware.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *
+from future.builtins import *
+from six import itervalues
+
+import re
+import string
+
+import xdg.Mime
+from werkzeug.exceptions import HTTPException, BadRequest, NotFound, \
+    ServiceUnavailable
+
+from werkzeug.routing import Map, Rule, BaseConverter
+from werkzeug.wrappers import Response, Request
+from werkzeug.wsgi import responder, wrap_file
+
+from cms.db.filecacher import FileCacher, TombstoneError
+
+
+SECONDS_IN_A_YEAR = 365 * 24 * 60 * 60
+
+
+class DigestConverter(BaseConverter):
+    def __init__(self, url_map):
+        super(DigestConverter, self).__init__(url_map)
+        self.regex = '[0-9A-Fa-f]{40}'
+
+    def to_python(self, value):
+        return value.lower()
+
+
+class FilenameConverter(BaseConverter):
+    def __init__(self, url_map):
+        super(FilenameConverter, self).__init__(url_map)
+        self.regex = '[%s]+' % re.escape(string.printable.replace('/', ''))
+
+
+class FileByDigestMiddleware(object):
+    def __init__(self, file_cacher):
+        """Create an instance.
+
+        file_cacher (FileCacher): the cacher to retrieve files from.
+
+        """
+        self.file_cacher = file_cacher
+        self.url_map = Map([Rule("/<digest:digest>/<filename:filename>",
+                                 methods=["GET"], endpoint="fetch")],
+                           encoding_errors="strict",
+                           converters={"digest": DigestConverter,
+                                       "filename": FilenameConverter})
+        xdg.Mime.update_cache()
+        self.valid_mimetypes = set(str(t) for t in itervalues(xdg.Mime.types))
+
+    def __call__(self, environ, start_response):
+        """Execute this instance as a WSGI application.
+
+        See the PEP for the meaning of parameters. The separation of
+        __call__ and wsgi_app eases the insertion of middlewares.
+
+        """
+        return self.wsgi_app(environ, start_response)
+
+    @responder
+    def wsgi_app(self, environ, start_response):
+        """Execute this instance as a WSGI application.
+
+        See the PEP for the meaning of parameters. The separation of
+        __call__ and wsgi_app eases the insertion of middlewares.
+
+        """
+        urls = self.url_map.bind_to_environ(environ)
+        try:
+            endpoint, args = urls.match()
+        except HTTPException as exc:
+            return exc
+
+        assert endpoint == "fetch"
+
+        digest = args["digest"]
+        filename = args["filename"]
+
+        try:
+            fobj = self.file_cacher.get_file(digest)
+            size = self.file_cacher.get_size(digest)
+        except KeyError:
+            return NotFound()
+        except TombstoneError:
+            return ServiceUnavailable()
+
+        request = Request(environ)
+        request.encoding_errors = "strict"
+
+        # TODO maybe try to parse the beginning of the content as well?
+        mimetype = request.args.get("mimetype")
+        if mimetype is None:
+            guessed_mimetype = xdg.Mime.get_type_by_name(filename)
+            if guessed_mimetype is not None:
+                mimetype = str(guessed_mimetype)
+            else:
+                mimetype = "application/octet-stream"
+        elif mimetype not in self.valid_mimetypes:
+            return BadRequest()
+
+        response = Response()
+        response.status_code = 200
+        response.mimetype = mimetype
+        response.headers.add(
+            "Content-Disposition", "attachment", filename=filename)
+        response.set_etag(digest)
+        response.cache_control.max_age = SECONDS_IN_A_YEAR
+        response.cache_control.public = True
+        response.response = \
+            wrap_file(environ, fobj, buffer_size=FileCacher.CHUNK_SIZE)
+        response.direct_passthrough = True
+
+        try:
+            # This takes care of conditional and partial requests.
+            response.make_conditional(
+                request, accept_ranges=True, complete_length=size)
+        except HTTPException as exc:
+            return exc
+
+        return response

--- a/cmstestsuite/unit_tests/server/file_middleware_test.py
+++ b/cmstestsuite/unit_tests/server/file_middleware_test.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *
+from future.builtins import *
+
+import hashlib
+import io
+import random
+import unittest
+
+from mock import Mock
+from werkzeug.http import quote_header_value
+from werkzeug.test import Client
+from werkzeug.wrappers import Response
+
+from cmscommon.binary import bin_to_hex
+from cms.db.filecacher import TombstoneError
+from cms.server.file_middleware import FileByDigestMiddleware
+
+
+class TestFileByDigestMiddleware(unittest.TestCase):
+
+    def setUp(self):
+        # We need to wrap the generator in a list because of a
+        # shortcoming of future's bytes implementation.
+        self.content = bytes([random.getrandbits(8) for _ in range(1024)])
+        hasher = hashlib.sha1()
+        hasher.update(self.content)
+        self.digest = bin_to_hex(hasher.digest())
+
+        self.file_cacher = Mock()
+        self.file_cacher.get_file = Mock(
+            side_effect=lambda digest: io.BytesIO(self.content))
+        self.file_cacher.get_size = Mock(return_value=len(self.content))
+
+        self.wsgi_app = FileByDigestMiddleware(self.file_cacher)
+        self.client = Client(self.wsgi_app, Response)
+
+    def test_success(self):
+        filename = "foobar.sh"
+        # Use a MIME type that doesn't match the extension.
+        mimetype = "image/jpeg"
+        # Test with an uppercase digest.
+        response = self.client.get("/%s/%s" % (self.digest.upper(), filename),
+                                   query_string={"mimetype": mimetype})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, mimetype)
+        self.assertEqual(
+            response.headers.get("content-disposition"),
+            "attachment; filename=%s" % quote_header_value(filename))
+        self.assertTupleEqual(response.get_etag(), (self.digest, False))
+        self.assertEqual(response.accept_ranges, "bytes")
+        self.assertGreater(response.cache_control.max_age, 0)
+        self.assertTrue(response.cache_control.public)
+        self.assertEqual(response.data, self.content)
+
+        self.file_cacher.get_file.assert_called_once_with(self.digest)
+
+    def test_mimetype_guessing(self):
+        filenames_and_mimetypes = [
+            ("foobar.c", "text/x-csrc"),
+            ("foobar.pdf", "application/pdf"),
+            ("foobar.tar.gz", "application/x-compressed-tar"),
+            ("foobar", "application/octet-stream")]
+
+        for filename, mimetype in filenames_and_mimetypes:
+            response = self.client.get("/%s/%s" % (self.digest, filename))
+
+            self.assertEqual(response.mimetype, mimetype)
+
+            self.file_cacher.get_file.assert_called_once_with(self.digest)
+            self.file_cacher.get_file.reset_mock()
+
+    def test_not_found(self):
+        self.file_cacher.get_file.side_effect = KeyError()
+
+        response = self.client.get("/%s/%s" % (self.digest, "foobar.py"))
+
+        self.assertEqual(response.status_code, 404)
+
+        self.file_cacher.get_file.assert_called_once_with(self.digest)
+
+    def test_tombstone(self):
+        self.file_cacher.get_file.side_effect = TombstoneError()
+
+        response = self.client.get("/%s/%s" % (self.digest, "foobar.txt"))
+
+        self.assertEqual(response.status_code, 503)
+
+        self.file_cacher.get_file.assert_called_once_with(self.digest)
+
+    def test_bad_path(self):
+        response = self.client.get("/bad_path")
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.get("/bad_digest/foobar.exe")
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.get("/%s/path/with/slashes" % self.digest)
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.get("/%s/\N{NULL}" % self.digest)
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.get("/%s/\N{BELL}" % self.digest)
+        self.assertEqual(response.status_code, 404)
+
+        self.file_cacher.get_file.assert_not_called()
+
+    def test_bad_method(self):
+        response = self.client.post("/%s/%s" % (self.digest, "foobar.java"))
+        self.assertEqual(response.status_code, 405)
+
+        response = self.client.put("/%s/%s" % (self.digest, "foobar.doc"))
+        self.assertEqual(response.status_code, 405)
+
+        response = self.client.delete("/%s/%s" % (self.digest, "foobar.rar"))
+        self.assertEqual(response.status_code, 405)
+
+        self.file_cacher.get_file.assert_not_called()
+
+    def test_invalid_mimetype(self):
+        response = self.client.get("/%s/%s" % (self.digest, "foobar"),
+                                   query_string={"mimetype": "not/a/mimetype"})
+        self.assertEqual(response.status_code, 400)
+
+        # Needs to call this anyways to make sure the file exists: if
+        # it didn't it would have to return a 404 error.
+        self.file_cacher.get_file.assert_called_once_with(self.digest)
+
+    def test_conditional_request(self):
+        # Test an etag that matches.
+        response = self.client.get("/%s/%s" % (self.digest, "foobar"),
+                                   headers=[("If-None-Match", self.digest)])
+        self.assertEqual(response.status_code, 304)
+        self.assertEqual(len(response.data), 0)
+
+        # Test an etag that doesn't match.
+        response = self.client.get("/%s/%s" % (self.digest, "foobar"),
+                                   headers=[("If-None-Match", "not the etag")])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, self.content)
+
+    def test_range_request(self):
+        # Test a range that is strictly included.
+        response = self.client.get("/%s/%s" % (self.digest, "foobar"),
+                                   headers=[("Range", "bytes=256-767")])
+        self.assertEqual(response.status_code, 206)
+        self.assertEqual(response.content_range.units, "bytes")
+        self.assertEqual(response.content_range.start, 256)
+        self.assertEqual(response.content_range.stop, 768)
+        self.assertEqual(response.content_range.length, 1024)
+        self.assertEqual(response.data, self.content[256:768])
+
+        # Test a range that ends after the end of the file.
+        response = self.client.get("/%s/%s" % (self.digest, "foobar"),
+                                   headers=[("Range", "bytes=256-2047")])
+        self.assertEqual(response.status_code, 206)
+        self.assertEqual(response.content_range.units, "bytes")
+        self.assertEqual(response.content_range.start, 256)
+        self.assertEqual(response.content_range.stop, 1024)
+        self.assertEqual(response.content_range.length, 1024)
+        self.assertEqual(response.data, self.content[256:])
+
+        # Test a range that starts after the end of the file.
+        response = self.client.get("/%s/%s" % (self.digest, "foobar"),
+                                   headers=[("Range", "bytes=1536-")])
+        self.assertEqual(response.status_code, 416)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The Tornado WSGI adapter buffers the whole response before starting to
send it to the client. This causes unexpected spikes in memory usage and
could be a vector for a denial-of-service attack. The Tornado devs have
no intention of fixing this, as their WSGI support is sub-standard by
design.

The most reasonable solution was to implement file serving as a "native"
WSGI application and insert it as a middleware into our stack. The
Tornado handlers that want to serve files have to issue a redirect to
this application. Files are accessed by digest, which means that
potentially every user can access any file, without restrictions (no
autentication, no authorization, ...). Yet, given the large space
digests live in, the likeliness of this happening is so small that we
don't believe it to be a security concern. Users are also able to
specify the file name and the MIME type they want the response to be
served as, though these are validated.

The new WSGI middleware replaces the classes obtained by using
file_handler_gen (and, as such, reduces dynamic class generation magic
and improves static analysis) and also replaces a similar handler in
AWS. It supports conditional requests (based on the ETag header) and
partial requests (based on the Range header).

Unit tests are introduced too.

Fixes #870.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/882)
<!-- Reviewable:end -->
