### PR TITLE
Fix single submission rejudge

### DIFF
--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -894,7 +894,7 @@ class EvaluationService(TriggeredService):
         with SessionGen() as session:
             # When invalidating a dataset we need to know the task_id, otherwise
             # get_submissions will return all the submissions of the contest.
-            if dataset_id is not None and task_id is None:
+            if dataset_id is not None and task_id is None and submission_id is None:
                 task_id = Dataset.get_from_id(dataset_id, session).task_id
             # First we load all involved submissions.
             submissions = get_submissions(


### PR DESCRIPTION
This fixes rejudge of single submissions in AWS by preventing task_id to be automatically filled when submission_id is set. Otherwise an exception in raised here:

https://github.com/cms-dev/cms/blob/2b1d76b8f9ddd5bce06773f6255e10ec75b488d2/cms/service/__init__.py#L79

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/884)
<!-- Reviewable:end -->
