### PR TITLE
Fix error on importing testcases from zip file

### DIFF
--- a/cmscommon/importers.py
+++ b/cmscommon/importers.py
@@ -112,7 +112,10 @@ def import_testcases_from_zipfile(
                         output, "Testcase output for task %s" % task_name)
                 except Exception:
                     raise Exception("Testcase storage failed")
-
+                try:
+                    codename = codename.decode("utf-8")
+                except AttributeError:
+                    pass
                 testcase = Testcase(codename, public, input_digest,
                                     output_digest, dataset=dataset)
                 session.add(testcase)


### PR DESCRIPTION
Currently, uploading a zip file in AWS fails with the following error:
```
TypeError(u"Testcase.__init__() got a '<type 'str'>' for keyword argument 'codename', which requires a '<type 'unicode'>'",)
```
This fixes the problem, however I am not sure if it does it the right way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/885)
<!-- Reviewable:end -->
