### PR TITLE
Avoid classes between unittest.TestCase and actual tests

### DIFF
--- a/cmstestsuite/unit_tests/cmscommon/digest_test.py
+++ b/cmstestsuite/unit_tests/cmscommon/digest_test.py
@@ -27,14 +27,11 @@ from future.builtins.disabled import *  # noqa
 from future.builtins import *  # noqa
 from six import PY2
 
-import io
-import os
-import shutil
-import tempfile
 import unittest
 
-from cmscommon.digest import Digester, bytes_digest, path_digest
+from cmstestsuite.unit_tests.filesystemmixin import FileSystemMixin
 
+from cmscommon.digest import Digester, bytes_digest, path_digest
 
 _EMPTY_DIGEST = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 _CONTENT_DIGEST = "040f06fd774092478d450774f5ba30c5da78acc8"
@@ -75,32 +72,24 @@ class TestBytesDigest(unittest.TestCase):
             bytes_digest("")
 
 
-class TestPathDigest(unittest.TestCase):
+class TestPathDigest(FileSystemMixin, unittest.TestCase):
 
     def setUp(self):
         super(TestPathDigest, self).setUp()
-        self.base = tempfile.mkdtemp()
-        self.path = os.path.join(self.base, "f")
-
-    def tearDown(self):
-        shutil.rmtree(self.base)
-        super(TestPathDigest, self).tearDown()
-
-    def write_file(self, content):
-        with io.open(self.path, "wb") as f:
-            f.write(content)
+        self.filename = "f"
+        self.path = self.get_path(self.filename)
 
     def test_success(self):
-        self.write_file(b"content")
+        self.write_file(self.filename, b"content")
         self.assertEqual(path_digest(self.path), _CONTENT_DIGEST)
 
     def test_empty(self):
-        self.write_file(b"")
+        self.write_file(self.filename, b"")
         self.assertEqual(path_digest(self.path), _EMPTY_DIGEST)
 
     def test_long(self):
         content = b"0" * 1000000
-        self.write_file(content)
+        self.write_file(self.filename, content)
         self.assertEqual(path_digest(self.path), bytes_digest(content))
 
     @unittest.skipIf(PY2, "Python2 uses IOError")

--- a/cmstestsuite/unit_tests/cmscommon/digest_test.py
+++ b/cmstestsuite/unit_tests/cmscommon/digest_test.py
@@ -33,6 +33,7 @@ from cmstestsuite.unit_tests.filesystemmixin import FileSystemMixin
 
 from cmscommon.digest import Digester, bytes_digest, path_digest
 
+
 _EMPTY_DIGEST = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 _CONTENT_DIGEST = "040f06fd774092478d450774f5ba30c5da78acc8"
 

--- a/cmstestsuite/unit_tests/cmscontrib/DumpExporterTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/DumpExporterTest.py
@@ -35,7 +35,7 @@ import tempfile
 import unittest
 
 # Needs to be first to allow for monkey patching the DB connection string.
-from cmstestsuite.unit_tests.testdbgenerator import TestCaseWithDatabase
+from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms import config
 from cms.db import Contest, Executable, Participation, Statement, Submission, \
@@ -46,7 +46,7 @@ from cmscommon.digest import bytes_digest
 from cmscontrib.DumpExporter import DumpExporter
 
 
-class TestDumpExporter(TestCaseWithDatabase):
+class TestDumpExporter(DatabaseMixin, unittest.TestCase):
 
     def setUp(self):
         super(TestDumpExporter, self).setUp()

--- a/cmstestsuite/unit_tests/cmscontrib/DumpImporterTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/DumpImporterTest.py
@@ -35,7 +35,7 @@ import tempfile
 import unittest
 
 # Needs to be first to allow for monkey patching the DB connection string.
-from cmstestsuite.unit_tests.testdbgenerator import TestCaseWithDatabase
+from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms import config
 from cms.db import Contest, FSObject, Session, version
@@ -45,7 +45,7 @@ from cmscommon.digest import bytes_digest
 from cmscontrib.DumpImporter import DumpImporter
 
 
-class TestDumpImporter(TestCaseWithDatabase):
+class TestDumpImporter(DatabaseMixin, unittest.TestCase):
 
     GENERATED_FILE_CONTENT = b"content"
     NON_GENERATED_FILE_CONTENT = b"source"

--- a/cmstestsuite/unit_tests/cmscontrib/ImportContestTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/ImportContestTest.py
@@ -30,7 +30,7 @@ import six
 import unittest
 
 # Needs to be first to allow for monkey patching the DB connection string.
-from cmstestsuite.unit_tests.testdbgenerator import TestCaseWithDatabase
+from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Contest, SessionGen, Submission
 
@@ -88,7 +88,7 @@ def fake_loader_factory(contest, contest_has_changed=False,
     return FakeLoader
 
 
-class TestImportContest(TestCaseWithDatabase):
+class TestImportContest(DatabaseMixin, unittest.TestCase):
 
     def setUp(self):
         super(TestImportContest, self).setUp()

--- a/cmstestsuite/unit_tests/cmscontrib/ImportDatasetTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/ImportDatasetTest.py
@@ -29,7 +29,7 @@ from future.builtins import *  # noqa
 import unittest
 
 # Needs to be first to allow for monkey patching the DB connection string.
-from cmstestsuite.unit_tests.testdbgenerator import TestCaseWithDatabase
+from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Dataset, SessionGen
 
@@ -56,7 +56,7 @@ def fake_loader_factory(task, dataset):
     return FakeLoader
 
 
-class TestImportDataset(TestCaseWithDatabase):
+class TestImportDataset(DatabaseMixin, unittest.TestCase):
 
     def setUp(self):
         super(TestImportDataset, self).setUp()

--- a/cmstestsuite/unit_tests/cmscontrib/ImportTaskTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/ImportTaskTest.py
@@ -30,7 +30,7 @@ import six
 import unittest
 
 # Needs to be first to allow for monkey patching the DB connection string.
-from cmstestsuite.unit_tests.testdbgenerator import TestCaseWithDatabase
+from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import SessionGen, Submission, Task
 
@@ -54,7 +54,7 @@ def fake_loader_factory(task, task_has_changed=False):
     return FakeLoader
 
 
-class TestImportTask(TestCaseWithDatabase):
+class TestImportTask(DatabaseMixin, unittest.TestCase):
 
     def setUp(self):
         super(TestImportTask, self).setUp()

--- a/cmstestsuite/unit_tests/cmscontrib/ImportTeamTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/ImportTeamTest.py
@@ -29,7 +29,7 @@ from future.builtins import *  # noqa
 import unittest
 
 # Needs to be first to allow for monkey patching the DB connection string.
-from cmstestsuite.unit_tests.testdbgenerator import TestCaseWithDatabase
+from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import SessionGen, Team
 
@@ -53,7 +53,7 @@ def fake_loader_factory(team):
     return FakeLoader
 
 
-class TestImportTeam(TestCaseWithDatabase):
+class TestImportTeam(DatabaseMixin, unittest.TestCase):
 
     def setUp(self):
         super(TestImportTeam, self).setUp()

--- a/cmstestsuite/unit_tests/cmscontrib/ImportUserTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/ImportUserTest.py
@@ -30,7 +30,7 @@ import six
 import unittest
 
 # Needs to be first to allow for monkey patching the DB connection string.
-from cmstestsuite.unit_tests.testdbgenerator import TestCaseWithDatabase
+from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Participation, SessionGen, User
 
@@ -54,7 +54,7 @@ def fake_loader_factory(user):
     return FakeLoader
 
 
-class TestImportUser(TestCaseWithDatabase):
+class TestImportUser(DatabaseMixin, unittest.TestCase):
 
     def setUp(self):
         super(TestImportUser, self).setUp()

--- a/cmstestsuite/unit_tests/databasemixin.py
+++ b/cmstestsuite/unit_tests/databasemixin.py
@@ -18,11 +18,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Utilities to create objects in a testing DB.
+"""A unittest.TestCase mixin for tests interacting with the database.
 
-Apart from a base class for tests using a testing DB, this module
-offers a series of add_<object> functions to create the minimal object
-possible in the database.
+This mixin will connect to a different DB, recreating for each testing
+class; it will also create a session at each test setup.
+
+The mixin also offers a series of get_<object> (to build an object, not
+attached to any session) and add_<object> (to build and add the object
+to the default session) methods. Without arguments, these will create
+minimal objects with random values in the fields, and callers can
+specify as many fields as they like.minimal object possible in the
+database.
 
 When the object depends on a "parent" object, the caller can specify
 it, or leave it for the function to create. When there is a common
@@ -38,8 +44,6 @@ from __future__ import unicode_literals
 from future.builtins.disabled import *  # noqa
 from future.builtins import *  # noqa
 from six import itervalues
-
-import unittest
 
 from datetime import timedelta
 
@@ -60,11 +64,12 @@ from cms.db import Base, Contest, Dataset, Evaluation, Executable, File, \
 from cms.db.filecacher import DBBackend
 
 
-class TestCaseWithDatabase(unittest.TestCase):
-    """TestCase subclass starting with a clean testing database."""
+class DatabaseMixin(object):
+    """Mixin for tests with database access."""
 
     @classmethod
     def setUpClass(cls):
+        super(DatabaseMixin, cls).setUpClass()
         assert "fortesting" in str(cms.db.engine), \
             "Monkey patching of DB connection string failed"
         drop_db()
@@ -77,12 +82,15 @@ class TestCaseWithDatabase(unittest.TestCase):
         drop_db()
         cls.connection.close()
         cms.db.engine.dispose()
+        super(DatabaseMixin, cls).tearDownClass()
 
     def setUp(self):
+        super(DatabaseMixin, self).setUp()
         self.session = Session()
 
     def tearDown(self):
         self.session.rollback()
+        super(DatabaseMixin, self).tearDown()
 
     def delete_data(self):
         """Delete all the data in the DB.
@@ -141,9 +149,9 @@ class TestCaseWithDatabase(unittest.TestCase):
     @staticmethod
     def get_participation(user=None, contest=None, **kwargs):
         """Create a participation"""
-        user = user if user is not None else TestCaseWithDatabase.get_user()
+        user = user if user is not None else DatabaseMixin.get_user()
         contest = contest \
-            if contest is not None else TestCaseWithDatabase.get_contest()
+            if contest is not None else DatabaseMixin.get_contest()
         args = {
             "user": user,
             "contest": contest,
@@ -191,7 +199,7 @@ class TestCaseWithDatabase(unittest.TestCase):
     @staticmethod
     def get_dataset(task=None, **kwargs):
         """Create a dataset"""
-        task = task if task is not None else TestCaseWithDatabase.get_task()
+        task = task if task is not None else DatabaseMixin.get_task()
         args = {
             "task": task,
             "description": unique_unicode_id(),

--- a/cmstestsuite/unit_tests/databasemixin.py
+++ b/cmstestsuite/unit_tests/databasemixin.py
@@ -20,15 +20,14 @@
 
 """A unittest.TestCase mixin for tests interacting with the database.
 
-This mixin will connect to a different DB, recreating for each testing
-class; it will also create a session at each test setup.
+This mixin will connect to a different DB, recreating it for each
+testing class; it will also create a session at each test setup.
 
 The mixin also offers a series of get_<object> (to build an object, not
 attached to any session) and add_<object> (to build and add the object
 to the default session) methods. Without arguments, these will create
 minimal objects with random values in the fields, and callers can
-specify as many fields as they like.minimal object possible in the
-database.
+specify as many fields as they like.
 
 When the object depends on a "parent" object, the caller can specify
 it, or leave it for the function to create. When there is a common

--- a/cmstestsuite/unit_tests/filesystemmixin.py
+++ b/cmstestsuite/unit_tests/filesystemmixin.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A unittest.TestCase mixin for tests interacting with the filesystem.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *  # noqa
+from future.builtins import *  # noqa
+
+import io
+import os
+import shutil
+import tempfile
+
+
+class FileSystemMixin(object):
+    """Mixin for tests with filesystem access."""
+
+    def setUp(self):
+        super(FileSystemMixin, self).setUp()
+        self.base_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.base_dir)
+        super(FileSystemMixin, self).tearDown()
+
+    def get_path(self, inner_path):
+        "Return the full path for a given inner path within the temp dir."
+        return os.path.join(self.base_dir, inner_path)
+
+    def makedirs(self, inner_path):
+        """Create (possibly many) directories up to inner_path.
+
+        inner_path (str): path to create.
+
+        return (str): full path of the possibly new directory.
+
+        """
+        path = self.get_path(inner_path)
+        try:
+            os.makedirs(path)
+        except FileExistsError:
+            pass
+        return path
+
+    def write_file(self, inner_path, content):
+        """Write content and return the full path.
+
+        inner_path (str): path inside the temp dir to write to.
+        content (bytes): content to write.
+
+        return (str): full path of the file written.
+
+        """
+        path = self.get_path(inner_path)
+        with io.open(path, "wb") as f:
+            f.write(content)
+        return path

--- a/cmstestsuite/unit_tests/service/esoperations_test.py
+++ b/cmstestsuite/unit_tests/service/esoperations_test.py
@@ -32,14 +32,14 @@ from six import iterkeys, iteritems
 
 import unittest
 
-from cmstestsuite.unit_tests.testdbgenerator import TestCaseWithDatabase
+from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.io.priorityqueue import PriorityQueue
 from cms.service.esoperations import ESOperation, get_submissions_operations, \
     get_user_tests_operations
 
 
-class TestESOperations(TestCaseWithDatabase):
+class TestESOperations(DatabaseMixin, unittest.TestCase):
 
     def setUp(self):
         super(TestESOperations, self).setUp()

--- a/cmstestsuite/unit_tests/service/scoringoperations_test.py
+++ b/cmstestsuite/unit_tests/service/scoringoperations_test.py
@@ -32,12 +32,12 @@ from six import iterkeys, iteritems
 
 import unittest
 
-from cmstestsuite.unit_tests.testdbgenerator import TestCaseWithDatabase
+from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.service.scoringoperations import ScoringOperation, get_operations
 
 
-class TestScoringOperations(TestCaseWithDatabase):
+class TestScoringOperations(DatabaseMixin, unittest.TestCase):
 
     def setUp(self):
         super(TestScoringOperations, self).setUp()


### PR DESCRIPTION
It makes it difficult to call all the setups and teardowns correctly;
instead we can use mixins where the semantic of super calling is more
self-contained.

Moreover, add a filesystem test mixin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/895)
<!-- Reviewable:end -->
