### PR TITLE
Compilation command improvements

### DIFF
--- a/cms/grading/languages/c++11_g++.py
+++ b/cms/grading/languages/c++11_g++.py
@@ -65,7 +65,7 @@ class Cpp11Gpp(CompiledLanguage):
         command = ["/usr/bin/g++"]
         if for_evaluation:
             command += ["-DEVAL"]
-        command += ["-std=c++11", "-O2", "-pipe", "-static",
+        command += ["-std=gnu++11", "-O2", "-pipe", "-static",
                     "-s", "-o", executable_filename]
         command += source_filenames
         return [command]

--- a/cms/grading/languages/c11_gcc.py
+++ b/cms/grading/languages/c11_gcc.py
@@ -65,7 +65,7 @@ class C11Gcc(CompiledLanguage):
         command = ["/usr/bin/gcc"]
         if for_evaluation:
             command += ["-DEVAL"]
-        command += ["-std=c11", "-O2", "-pipe", "-static",
+        command += ["-std=gnu11", "-O2", "-pipe", "-static",
                     "-s", "-o", executable_filename]
         command += source_filenames
         command += ["-lm"]

--- a/cms/grading/languages/pascal_fpc.py
+++ b/cms/grading/languages/pascal_fpc.py
@@ -65,6 +65,6 @@ class PascalFpc(CompiledLanguage):
         command = ["/usr/bin/fpc"]
         if for_evaluation:
             command += ["-dEVAL"]
-        command += ["-XS", "-O2", "-o%s" % executable_filename]
+        command += ["-O2", "-XSs", "-o%s" % executable_filename]
         command += [source_filenames[0]]
         return [command]


### PR DESCRIPTION
- C11/C++11:
  - Enable GNU extensions (default GCC mode).
- Pascal:
  - Reorder flags to follow (preprocessor, compiler, linker) order.
  - Enable symbol stripping.
- Java:
  - Replace `mv` calls with direct output names.
  - Use `/bin/sh` instead of `/bin/bash` for portability.
  - Drop unneeded full paths inside shell commands.
  - Define `eval` system property for evaluation, similar to `-DEVAL`. Can be read with `Boolean.getBoolean("eval")` in the code. Possible alternative name: `cms.eval`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/899)
<!-- Reviewable:end -->
