### PR TITLE
Fix isolate options

### DIFF
--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -1061,7 +1061,10 @@ class IsolateSandbox(SandboxBase):
         if self.stack_space is not None:
             res += ["--stack=%d" % self.stack_space]
         if self.address_space is not None:
-            res += ["--cg-mem=%d" % self.address_space]
+            if self.cgroup:
+                res += ["--cg-mem=%d" % self.address_space]
+            else:
+                res += ["--mem=%d" % self.address_space]
         if self.stdout_file is not None:
             res += ["--stdout=%s" % self.inner_absolute_path(self.stdout_file)]
         if self.max_processes is not None:

--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -1038,7 +1038,7 @@ class IsolateSandbox(SandboxBase):
         if self.box_id is not None:
             res += ["--box-id=%d" % self.box_id]
         if self.cgroup:
-            res += ["--cg"]
+            res += ["--cg", "--cg-timing"]
         if self.chdir is not None:
             res += ["--chdir=%s" % self.chdir]
         for in_name, out_name, options in self.dirs:


### PR DESCRIPTION
I reviewed how current CMS calls isolate and there are several problems with it:

(1) When using cgroups (which is currently the CMS default), --cg-timing is not specified, so the time limit does not work properly.

(2) When not using cgroups, memory limit is still passed as --cg-mem, which does not work.

(3) We do not set --quota, so unless root set up FS quotas for all UIDs used by isolate, the disk space consumed by the solution is not limited at all.

This pull request solves (1) and (2). I would like to know you opinion how to specify the quota: should I add a setting in the config file for that? Or a more general config setting for adding arbitrary isolate options (--extra-time could be handy, too)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/913)
<!-- Reviewable:end -->
