### PR TITLE
Use MB instead of MiB throughout the code

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -117,7 +117,7 @@ class Config(object):
         self.sandbox_implementation = 'isolate'
 
         # Sandbox.
-        self.max_file_size = 1048576
+        self.max_file_size = 1000 * 1000 * 1000
 
         # WebServers.
         self.secret_key_default = "8e045a51e4b102ea803c06f92841a1fb"

--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -89,7 +89,7 @@ __all__ = [
 
 # Instantiate or import these objects.
 
-version = 30
+version = 31
 
 engine = create_engine(config.database, echo=config.database_debug,
                        pool_timeout=60, pool_recycle=120)

--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -1055,7 +1055,8 @@ class IsolateSandbox(SandboxBase):
         for var, value in iteritems(self.set_env):
             res += ["--env=%s=%s" % (var, value)]
         if self.fsize is not None:
-            res += ["--fsize=%d" % self.fsize]
+            # Isolate wants file sizes as KiB.
+            res += ["--fsize=%d" % (self.fsize // 1024)]
         if self.stdin_file is not None:
             res += ["--stdin=%s" % self.inner_absolute_path(self.stdin_file)]
         if self.stack_space is not None:

--- a/cms/grading/__init__.py
+++ b/cms/grading/__init__.py
@@ -270,7 +270,7 @@ def compilation_step(sandbox, commands):
     sandbox.max_processes = None
     sandbox.timeout = 10
     sandbox.wallclock_timeout = 20
-    sandbox.address_space = 512 * 1024
+    sandbox.address_space = 500 * 1000 * 1000
 
     # Actually run the compilation commands, logging stdout and stderr.
     logger.debug("Starting compilation step.")
@@ -397,7 +397,7 @@ def evaluation_step(sandbox, commands,
     sandbox (Sandbox): the sandbox we consider.
     commands ([[string]]): the actual evaluation lines.
     time_limit (float): time limit in seconds.
-    memory_limit (int): memory limit in MB.
+    memory_limit (int): memory limit in bytes.
     allow_dirs ([string]|None): if not None, a list of external
         directories to map inside the sandbox
     writable_files ([string]|None): if not None, a list of inner file
@@ -448,7 +448,7 @@ def evaluation_step_before_run(sandbox, command,
     else:
         sandbox.timeout = 0
         sandbox.wallclock_timeout = 0
-    sandbox.address_space = memory_limit * 1024
+    sandbox.address_space = memory_limit
     sandbox.fsize = config.max_file_size
 
     if stdin_redirect is not None:

--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -337,7 +337,7 @@ class Batch(TaskType):
                     job.user_output = sandbox.get_file_to_storage(
                         self._actual_output,
                         "Output file in job %s" % job.info,
-                        trunc_len=100 * 1024)
+                        trunc_len=100 * 1000)
 
                 # If just asked to execute, fill text and set dummy outcome.
                 if job.only_execution:

--- a/cms/grading/tasktypes/Communication.py
+++ b/cms/grading/tasktypes/Communication.py
@@ -258,7 +258,8 @@ class Communication(TaskType):
             # is the last command in commands, and that the previous
             # are "setup" that doesn't need tight control.
             if len(commands) > 1:
-                evaluation_step(sandbox_user[i], commands[:-1], 10, 256)
+                evaluation_step(sandbox_user[i], commands[:-1], 10,
+                                250 * 1000 * 1000)
             processes[i] = evaluation_step_before_run(
                 sandbox_user[i],
                 commands[-1],

--- a/cms/io/rpc.py
+++ b/cms/io/rpc.py
@@ -82,9 +82,9 @@ class RemoteServiceBase(object):
     will be fired.
 
     """
-    # Incoming messages larger than 1 MiB are dropped to avoid DOS
+    # Incoming messages larger than 1 MB are dropped to avoid DOS
     # attacks. XXX Check that this size is sensible.
-    MAX_MESSAGE_SIZE = 1024 * 1024
+    MAX_MESSAGE_SIZE = 1000 * 1000
 
     def __init__(self, remote_address):
         """Prepare to handle a connection with the given remote address.

--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -446,10 +446,11 @@ class BaseHandler(CommonRequestHandler):
             try:
                 value = int(value)
             except:
-                raise ValueError("Can't cast %s to float." % value)
+                raise ValueError("Can't cast %s to int." % value)
             if not 0 < value:
                 raise ValueError("Invalid memory limit.")
-            dest["memory_limit"] = value
+            # AWS displays the value in MB, but it is stored in bytes.
+            dest["memory_limit"] = value * 1000 * 1000
 
     def get_task_type(self, dest, name, params):
         """Parse the task type.

--- a/cms/server/admin/templates/add_dataset.html
+++ b/cms/server/admin/templates/add_dataset.html
@@ -61,10 +61,10 @@ You are cloning the dataset "{{ original_dataset.description }}".
     </tr>
     <tr>
       <td>
-        <span class="info" title="Total maximum memory usage for each evaluation, in MiB (2^20 bytes)."></span>
+        <span class="info" title="Total maximum memory usage for each evaluation, in MB (10^6 bytes)."></span>
         Memory limit
       </td>
-      <td><input type="text" name="memory_limit" value="{{ 512 if original_dataset is none else original_dataset.memory_limit or "" }}"/> MiB</td>
+      <td><input type="text" name="memory_limit" value="{{ 500 if original_dataset is none else original_dataset.memory_limit or "" }}"/> MB</td>
     </tr>
 
     <tr><td colspan=2><h2>Task type settings (<a href="http://cms.readthedocs.org/en/{{ rtd_version }}/Task%20types.html" target="_blank">documentation</a>)</h2></td></tr>

--- a/cms/server/admin/templates/submission.html
+++ b/cms/server/admin/templates/submission.html
@@ -146,7 +146,7 @@
       </tr>
       <tr>
         <td>Max memory used</td>
-        <td>{% if m is not none %}{{ m // (1024 ** 2) }} MiB{% else %}N/A{% endif %}</td>
+        <td>{% if m is not none %}{{ m // (1000 * 1000) }} MB{% else %}N/A{% endif %}</td>
       </tr>
       {% endif %}
       <tr>
@@ -232,7 +232,7 @@
             ({{ ev.execution_wall_clock_time }} s)
             {% endif %}
             {% if ev.execution_memory is not none %}
-            ({{ (ev.execution_memory // 1024) // 1024 }} MiB)
+            ({{ ev.execution_memory // (1000 * 1000) }} MB)
             {% endif %}
           </td>
           <td>{{ ev.evaluation_sandbox }}</td>

--- a/cms/server/admin/templates/task.html
+++ b/cms/server/admin/templates/task.html
@@ -337,10 +337,10 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
         </tr>
         <tr>
           <td>
-            <span class="info" title="Total maximum memory usage for each evaluation, in MiB (2^20 bytes)."></span>
+            <span class="info" title="Total maximum memory usage for each evaluation, in MB (10^6 bytes)."></span>
             Memory limit
           </td>
-          <td><input type="text" name="memory_limit_{{ dataset.id }}" value="{{ dataset.memory_limit if dataset.memory_limit is not none else "" }}"/> MiB</td>
+          <td><input type="text" name="memory_limit_{{ dataset.id }}" value="{{ dataset.memory_limit if dataset.memory_limit is not none else "" }}"/> MB</td>
         </tr>
 
         <tr><td colspan=2><h3>Task type settings (<a href="http://cms.readthedocs.org/en/{{ rtd_version }}/Task%20types.html" target="_blank">documentation</a>)</h3></td></tr>

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -217,7 +217,7 @@
             </td>
             <td>
     {% if t_iter.active_dataset.memory_limit is not none %}
-        {{ (t_iter.active_dataset.memory_limit * 1024 * 1024)|format_size }}
+        {{ t_iter.active_dataset.memory_limit|format_size }}
     {% else %}
         {% trans %}N/A{% endtrans %}
     {% endif %}

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -104,7 +104,7 @@
 {% if task.active_dataset.memory_limit is not none %}
         <tr>
             <th>{% trans %}Memory limit{% endtrans %}</th>
-            <td colspan="2">{{ (task.active_dataset.memory_limit * 1024 * 1024)|format_size }}</td>
+            <td colspan="2">{{ task.active_dataset.memory_limit|format_size }}</td>
         </tr>
 {% endif %}
 {% set compilation_commands = task_type.get_compilation_commands(task.submission_format|map(attribute="filename")|list) %}

--- a/cms/server/util.py
+++ b/cms/server/util.py
@@ -157,7 +157,7 @@ def file_handler_gen(BaseClass):
             """
             data = self.temp_file.read(FileCacher.CHUNK_SIZE)
             length = len(data)
-            self.size += length / (1024 * 1024)
+            self.size += length / (1000 * 1000)
             self.write(data)
             if length < FileCacher.CHUNK_SIZE:
                 self.temp_file.close()

--- a/cms/service/ResourceService.py
+++ b/cms/service/ResourceService.py
@@ -55,7 +55,7 @@ from cms.io import Service, rpc_method
 logger = logging.getLogger(__name__)
 
 
-B_TO_MB = 1024 * 1024
+B_TO_MB = 1000 * 1000
 
 MAX_RESOURCE_SECONDS = 11 * 60  # MAX time window for remote resource query
 

--- a/cmscontrib/loaders/italy_yaml.py
+++ b/cmscontrib/loaders/italy_yaml.py
@@ -446,7 +446,9 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
         args["autojudge"] = False
 
         load(conf, args, ["time_limit", "timeout"], conv=float)
-        load(conf, args, ["memory_limit", "memlimit"])
+        # The Italian YAML format specifies memory limits in MiB.
+        load(conf, args, ["memory_limit", "memlimit"],
+             conv=lambda mb: mb * 1024 * 1024)
 
         # Builds the parameters that depend on the task type
         args["managers"] = []

--- a/cmscontrib/loaders/polygon.py
+++ b/cmscontrib/loaders/polygon.py
@@ -183,7 +183,7 @@ class PolygonTaskLoader(TaskLoader):
             tl = float(testset.find('time-limit').text)
             ml = float(testset.find('memory-limit').text)
             args["time_limit"] = tl * 0.001
-            args["memory_limit"] = ml // (1024 * 1024)
+            args["memory_limit"] = ml
 
             args["managers"] = {}
             infile_param = judging.attrib['input-file']

--- a/cmscontrib/updaters/update_31.py
+++ b/cmscontrib/updaters/update_31.py
@@ -2,9 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Contest Management System - http://cms-dev.github.io/
-# Copyright © 2012-2013 Bernard Blackham <bernard@largestprime.net>
-# Copyright © 2014-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
-# Copyright © 2016 Masaki Hara <ackie.h.gmai@gmail.com>
+# Copyright © 2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -19,36 +17,41 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""A class to update a dump created by CMS.
+
+Used by ContestImporter and DumpUpdater.
+
+This updater changes the unit of the memory limit from MiB to bytes.
+
+"""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 from future.builtins.disabled import *  # noqa
 from future.builtins import *  # noqa
+from six import iteritems
 
-task_info = {
-    "name": "communication2",
-    "title": "Test Communication Task",
-    "official_language": "",
-    "submission_format_choice": "other",
-    "submission_format": "[\"user1.%l\", \"user2.%l\"]",
-    "time_limit_{{dataset_id}}": "1.0",
-    "memory_limit_{{dataset_id}}": "125",
-    "task_type_{{dataset_id}}": "Communication",
-    "TaskTypeOptions_{{dataset_id}}_Communication_num_processes": "2",
-    "score_type_{{dataset_id}}": "Sum",
-    "score_type_parameters_{{dataset_id}}": "50",
-}
+import logging
 
-managers = [
-    "stub.c",
-    "stub.cpp",
-    "stub.pas",
-    "stub.java",
-    "manager",
-]
 
-test_cases = [
-    ("1.in", "1.out", True),
-    ("2.in", "2.out", False),
-]
+logger = logging.getLogger(__name__)
+
+
+class Updater(object):
+
+    def __init__(self, data):
+        assert data["_version"] == 30
+        self.objs = data
+
+    def run(self):
+        for k, v in iteritems(self.objs):
+            if k.startswith("_"):
+                continue
+
+            if v["_class"] == "Dataset":
+                if v.get("memory_limit") is not None:
+                    v["memory_limit"] *= 1024 * 1024
+
+        return self.objs

--- a/cmstestsuite/code/oom-heap.c
+++ b/cmstestsuite/code/oom-heap.c
@@ -3,10 +3,10 @@
 int main() {
     int *big;
     int i;
-    big = malloc(128 * 1024 * 1024);
+    big = malloc(125 * 1000 * 1000);
     // If we don't do this cycle, the compiler is smart enough not to
     // map the array into resident memory.
-    for (i = 0; i < 128 * 1024 * 1024 / sizeof(int); i++) {
+    for (i = 0; i < 125 * 1000 * 1000 / sizeof(int); i++) {
       big[i] = 0;
     }
     scanf("%d", &big[10000]);

--- a/cmstestsuite/code/oom-heap.cpp
+++ b/cmstestsuite/code/oom-heap.cpp
@@ -2,10 +2,10 @@
 
 int main() {
     int *big;
-    big = new int[128 * 1024 * 1024 / sizeof(int)];
+    big = new int[125 * 1000 * 1000 / sizeof(int)];
     // If we don't do this cycle, the compiler is smart enough not to
     // map the array into resident memory.
-    for (int i = 0; i < 128 * 1024 * 1024 / sizeof(int); i++) {
+    for (int i = 0; i < 125 * 1000 * 1000 / sizeof(int); i++) {
       big[i] = 0;
     }
     std::cin >> big[10000];

--- a/cmstestsuite/code/oom-heap.cs
+++ b/cmstestsuite/code/oom-heap.cs
@@ -4,11 +4,11 @@ public static class Batchstdio
 {
     public static void Main()
     {
-        int[] big = new int[128 * 1024 * 1024 / 4];
-        
+        int[] big = new int[125 * 1000 * 1000 / 4];
+
         // If we don't do this cycle, the compiler is smart enough not to
         // map the array into resident memory.
-        for (int i = 0; i < 128 * 1024 * 1024 / sizeof(int); i++)
+        for (int i = 0; i < 125 * 1000 * 1000 / sizeof(int); i++)
         {
             big[i] = 0;
         }

--- a/cmstestsuite/code/oom-heap.hs
+++ b/cmstestsuite/code/oom-heap.hs
@@ -2,5 +2,5 @@ import Data.Array.IArray
 
 main = do
     n <- read `fmap` getLine
-    let a = array (0, 128 * 1024 * 1024) [(10000, n)] :: Array Int Int
+    let a = array (0, 125 * 1000 * 1000) [(10000, n)] :: Array Int Int
     putStrLn $ "correct " ++ (show $ a ! 10000)

--- a/cmstestsuite/code/oom-heap.java
+++ b/cmstestsuite/code/oom-heap.java
@@ -3,7 +3,7 @@ import java.util.Scanner;
 public class batchstdio {
 
     public static void main(String[] args) {
-    	int[] big = new int[128 * 1024 * 1024 / 4];
+        int[] big = new int[125 * 1000 * 1000 / 4];
         Scanner scanner = new Scanner(System.in);
         big[10000] = scanner.nextInt();
         System.out.println("correct "+big[10000]);

--- a/cmstestsuite/code/oom-heap.pas
+++ b/cmstestsuite/code/oom-heap.pas
@@ -4,7 +4,7 @@ var
    big: array of integer;
 
 begin
-    setlength(big, 128 * 1024 * 1024 div sizeof(integer));
+    setlength(big, 125 * 1000 * 1000 div sizeof(integer));
     readln(big[10000]);
     writeln('correct ', big[10000]);
 end.

--- a/cmstestsuite/code/oom-heap.php
+++ b/cmstestsuite/code/oom-heap.php
@@ -1,6 +1,6 @@
 <?php
-// PHP arrays are extremely greedy; 10M elements are enough to cross the 128MB limit.
-$n = range(0, 10 * 1024 * 1024);
+// PHP arrays are extremely greedy; 10M elements are enough to cross the 125MB limit.
+$n = range(0, 10 * 1000 * 1000);
 $n[10000] = intval(fgets(STDIN));
 echo "correct $n[10000]\n";
 ?>

--- a/cmstestsuite/code/oom-heap.py
+++ b/cmstestsuite/code/oom-heap.py
@@ -1,5 +1,5 @@
 import sys
 
-big = [0] * (128 * 1024 * 1024)
+big = [0] * (125 * 1000 * 1000)
 big[10000] = int(sys.stdin.readline().strip())
 sys.stdout.write("correct %d\n" % big[10000])

--- a/cmstestsuite/code/oom-heap.rs
+++ b/cmstestsuite/code/oom-heap.rs
@@ -2,7 +2,7 @@ use std::io;
 
 fn main()
 {
-    let mut v = vec![0; 128 * 1024 * 1024];
+    let mut v = vec![0; 125 * 1000 * 1000];
     let mut s = String::new();
     match io::stdin().read_line(&mut s)
     {

--- a/cmstestsuite/code/oom-static.c
+++ b/cmstestsuite/code/oom-static.c
@@ -1,12 +1,12 @@
 #include <stdio.h>
 
-int big[128 * 1024 * 1024 / sizeof(int)];
+int big[125 * 1000 * 1000 / sizeof(int)];
 
 int main() {
     int i;
     // If we don't do this cycle, the compiler is smart enough not to
     // map the array into resident memory.
-    for (i = 0; i < 128 * 1024 * 1024 / sizeof(int); i++) {
+    for (i = 0; i < 125 * 1000 * 1000 / sizeof(int); i++) {
       big[i] = 0;
     }
     scanf("%d", &big[10000]);

--- a/cmstestsuite/code/oom-static.cpp
+++ b/cmstestsuite/code/oom-static.cpp
@@ -1,11 +1,11 @@
 #include <iostream>
 
-int big[128 * 1024 * 1024 / sizeof(int)];
+int big[125 * 1000 * 1000 / sizeof(int)];
 
 int main() {
     // If we don't do this cycle, the compiler is smart enough not to
     // map the array into resident memory.
-    for (int i = 0; i < 128 * 1024 * 1024 / sizeof(int); i++) {
+    for (int i = 0; i < 125 * 1000 * 1000 / sizeof(int); i++) {
       big[i] = 0;
     }
     std::cin >> big[10000];

--- a/cmstestsuite/code/oom-static.pas
+++ b/cmstestsuite/code/oom-static.pas
@@ -1,11 +1,11 @@
 program correct;
 
 var
-   big: array[0..128 * 1024 * 1024 div sizeof(integer)] of integer;
+   big: array[0..125 * 1000 * 1000 div sizeof(integer)] of integer;
    i: longint;
 
 begin
-     for i := 1 to 128 * 1024 * 1024 div sizeof(integer) do
+     for i := 1 to 125 * 1000 * 1000 div sizeof(integer) do
        big[i] := 0;
     readln(big[10000]);
     writeln('correct ', big[10000]);

--- a/cmstestsuite/code/write-big-fileio.c
+++ b/cmstestsuite/code/write-big-fileio.c
@@ -14,13 +14,13 @@ int main() {
     FILE *in = fopen("input.txt", "r");
     fscanf(in, "%d", &n);
 
-    // Seek is done in two steps so there are no probles even when
+    // Seek is done in two steps so there are no problems even when
     // type off_t is 4 bytes long. In this part everything is done
     // calling directly syscalls because apparently libc does not
     // properly report EFBIG errors.
     int outfd = open("output.txt", O_WRONLY|O_CREAT|O_TRUNC, 0666);
-    lseek(outfd, 1024 * 1024 * 1024, SEEK_CUR);
-    lseek(outfd, 1024 * 1024 * 1024, SEEK_CUR);
+    lseek(outfd, 1000 * 1000 * 1000, SEEK_CUR);
+    lseek(outfd, 1000 * 1000 * 1000, SEEK_CUR);
     i = write(outfd, "\0", 1);
     close(outfd);
 

--- a/cmstestsuite/tasks/batch_50/__init__.py
+++ b/cmstestsuite/tasks/batch_50/__init__.py
@@ -31,7 +31,7 @@ task_info = {
     "submission_format_choice": "other",
     "submission_format": "[\"batch.%l\"]",
     "time_limit_{{dataset_id}}": "0.5",
-    "memory_limit_{{dataset_id}}": "128",
+    "memory_limit_{{dataset_id}}": "125",
     "task_type_{{dataset_id}}": "Batch",
     "TaskTypeOptions_{{dataset_id}}_Batch_compilation": "alone",
     "TaskTypeOptions_{{dataset_id}}_Batch_io_0_inputfile": "",

--- a/cmstestsuite/tasks/batch_fileio/__init__.py
+++ b/cmstestsuite/tasks/batch_fileio/__init__.py
@@ -32,7 +32,7 @@ task_info = {
     "submission_format_choice": "other",
     "submission_format": "[\"batchfileio.%l\"]",
     "time_limit_{{dataset_id}}": "0.5",
-    "memory_limit_{{dataset_id}}": "128",
+    "memory_limit_{{dataset_id}}": "125",
     "task_type_{{dataset_id}}": "Batch",
     "TaskTypeOptions_{{dataset_id}}_Batch_compilation": "alone",
     "TaskTypeOptions_{{dataset_id}}_Batch_io_0_inputfile": "input.txt",

--- a/cmstestsuite/tasks/batch_fileio_managed/__init__.py
+++ b/cmstestsuite/tasks/batch_fileio_managed/__init__.py
@@ -32,7 +32,7 @@ task_info = {
     "submission_format_choice": "other",
     "submission_format": "[\"batchfileiomanaged.%l\"]",
     "time_limit_{{dataset_id}}": "0.5",
-    "memory_limit_{{dataset_id}}": "128",
+    "memory_limit_{{dataset_id}}": "125",
     "task_type_{{dataset_id}}": "Batch",
     "TaskTypeOptions_{{dataset_id}}_Batch_compilation": "grader",
     "TaskTypeOptions_{{dataset_id}}_Batch_io_0_inputfile": "input.txt",

--- a/cmstestsuite/tasks/batch_stdio/__init__.py
+++ b/cmstestsuite/tasks/batch_stdio/__init__.py
@@ -32,7 +32,7 @@ task_info = {
     "submission_format_choice": "other",
     "submission_format": "[\"batchstdio.%l\"]",
     "time_limit_{{dataset_id}}": "0.5",
-    "memory_limit_{{dataset_id}}": "128",
+    "memory_limit_{{dataset_id}}": "125",
     "task_type_{{dataset_id}}": "Batch",
     "TaskTypeOptions_{{dataset_id}}_Batch_compilation": "alone",
     "TaskTypeOptions_{{dataset_id}}_Batch_io_0_inputfile": "",

--- a/cmstestsuite/tasks/communication/__init__.py
+++ b/cmstestsuite/tasks/communication/__init__.py
@@ -32,7 +32,7 @@ task_info = {
     "submission_format_choice": "other",
     "submission_format": "[\"communication.%l\"]",
     "time_limit_{{dataset_id}}": "1.0",
-    "memory_limit_{{dataset_id}}": "128",
+    "memory_limit_{{dataset_id}}": "125",
     "task_type_{{dataset_id}}": "Communication",
     "TaskTypeOptions_{{dataset_id}}_Communication_num_processes": "1",
     "score_type_{{dataset_id}}": "Sum",

--- a/cmstestsuite/tasks/outputonly/__init__.py
+++ b/cmstestsuite/tasks/outputonly/__init__.py
@@ -31,7 +31,7 @@ task_info = {
     "submission_format_choice": "other",
     "submission_format": "[\"output_000.txt\", \"output_001.txt\"]",
     "time_limit_{{dataset_id}}": "0.5",
-    "memory_limit_{{dataset_id}}": "128",
+    "memory_limit_{{dataset_id}}": "125",
     "task_type_{{dataset_id}}": "OutputOnly",
     "TaskTypeOptions_{{dataset_id}}_OutputOnly_output_eval": "diff",
     "score_type_{{dataset_id}}": "Sum",

--- a/cmstestsuite/tasks/outputonly_comparator/__init__.py
+++ b/cmstestsuite/tasks/outputonly_comparator/__init__.py
@@ -31,7 +31,7 @@ task_info = {
     "submission_format_choice": "other",
     "submission_format": "[\"output_000.txt\", \"output_001.txt\"]",
     "time_limit_{{dataset_id}}": "0.5",
-    "memory_limit_{{dataset_id}}": "128",
+    "memory_limit_{{dataset_id}}": "125",
     "task_type_{{dataset_id}}": "OutputOnly",
     "TaskTypeOptions_{{dataset_id}}_OutputOnly_output_eval": "comparator",
     "score_type_{{dataset_id}}": "Sum",

--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -66,8 +66,8 @@
     "_section": "Sandbox",
 
     "_help": "Do not allow contestants' solutions to write files bigger",
-    "_help": "than this size (expressed in KB; defaults to 1 GB).",
-    "max_file_size": 1048576,
+    "_help": "than this size (expressed in bytes; defaults to 1 GB).",
+    "max_file_size": 1000000000,
 
 
 


### PR DESCRIPTION
In general, prefer powers of 10 over powers of 2.

Moreover store the memory limit in bytes, rather than in MiB, to avoid any ambiguity.

This removes the inconsistencies of having the memory limit displayed in MiB in AWS and in MB in CWS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/918)
<!-- Reviewable:end -->
