### PR TITLE
Extract max_number/min_interval checks for submissions/user tests

### DIFF
--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2010-2014 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
+# Copyright © 2010-2017 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
+# Copyright © 2012-2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
+# Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
+# Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
+# Copyright © 2015-2016 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
+# Copyright © 2016 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Submission-related handlers for CWS for a specific task.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *  # noqa
+from future.builtins import *  # noqa
+
+import logging
+
+from sqlalchemy import func, desc
+
+from cms.db import Submission, Task
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_submission_count(
+        sql_session, participation, contest=None, task=None, cls=Submission):
+    """Return the amount of submissions the contestant sent in.
+
+    Count the submissions (or user tests) for the given participation
+    on the given task or contest (that is, on all the contest's tasks).
+
+    sql_session (Session): the SQLAlchemy session to use.
+    participation (Participation): the participation to fetch data for.
+    contest (Contest|None): if given count on all the contest's tasks.
+    task (Task|None): if given count only on this task (trumps contest).
+    cls (Submission|UserTest): if the UserTest class is given, count
+        user tests rather than submissions.
+
+    return (int): the count.
+
+    """
+    q = sql_session.query(func.count(cls.id))
+    if task is not None:
+        if contest is not None and task.contest is not contest:
+            raise ValueError("contest and task don't match")
+        q = q.filter(cls.task == task)
+    elif contest is not None:
+        q = q.join(cls.task) \
+            .filter(Task.contest == contest)
+    else:
+        raise ValueError("need at least one of contest and task")
+    q = q.filter(cls.participation == participation)
+    return q.scalar()
+
+
+def check_max_number(
+        sql_session, max_number, participation, contest=None, task=None,
+        cls=Submission):
+    """Check whether user already sent in given number of submissions.
+
+    Verify whether the given participation did already hit the given
+    constraint on the maximum number of submissions (i.e., whether they
+    submitted at least as many submissions as the limit) and return the
+    *opposite*, that is, return whether they are allowed to send more.
+
+    sql_session (Session): the SQLAlchemy session to use.
+    max_number (int|None): the constraint; None means no constraint has
+        to be enforced and thus True is always returned.
+    participation (Participation): the participation to fetch data for.
+    contest (Contest|None): if given count on all the contest's tasks.
+    task (Task|None): if given count only on this task (trumps contest).
+    cls (Submission|UserTest): if the UserTest class is given, count
+        user tests rather than submissions.
+
+    return (bool): whether the contestant can submit more.
+
+    """
+    if max_number is None or participation.unrestricted:
+        return True
+    count = get_submission_count(
+        sql_session, participation, contest=contest, task=task, cls=cls)
+    if count >= max_number:
+        return False
+    return True
+
+
+def get_latest_submission(
+        sql_session, participation, contest=None, task=None, cls=Submission):
+    """Return the most recent submission the contestant sent in.
+
+    Retrieve the submission (or user test) with the latest timestamp
+    among the ones for the given participation on the given task or
+    contest (that is, on all the contest's tasks).
+
+    sql_session (Session): the SQLAlchemy session to use.
+    participation (Participation): the participation to fetch data for.
+    contest (Contest|None): if given look at all the contest's tasks.
+    task (Task|None): if given look only at this task (trumps contest).
+    cls (Submission|UserTest): if the UserTest class is given, fetch
+        user tests rather than submissions.
+
+    return (Submission|UserTest|None): the latest submission/user test,
+        if any.
+
+    """
+    q = sql_session.query(cls)
+    if task is not None:
+        if contest is not None and task.contest is not contest:
+            raise ValueError("contest and task don't match")
+        q = q.filter(cls.task == task)
+    elif contest is not None:
+        q = q.join(cls.task) \
+            .filter(Task.contest == contest)
+    else:
+        raise ValueError("need at least one of contest and task")
+    q = q.filter(cls.participation == participation) \
+        .order_by(desc(cls.timestamp))
+    return q.first()
+
+
+def check_min_interval(
+        sql_session, min_interval, timestamp, participation, contest=None,
+        task=None, cls=Submission):
+    """Check whether user sent in latest submission long enough ago.
+
+    Verify whether at least the given amount of time has passed since
+    the given participation last sent in a submission (or user test).
+
+    sql_session (Session): the SQLAlchemy session to use.
+    min_interval (timedelta|None): the constraint; None means no
+        constraint has to be enforced and thus True is always returned.
+    timestamp (datetime): the current timestamp.
+    participation (Participation): the participation to fetch data for.
+    contest (Contest|None): if given look at all the contest's tasks.
+    task (Task|None): if given look only at this task (trumps contest).
+    cls (Submission|UserTest): if the UserTest class is given, fetch
+        user tests rather than submissions.
+
+    return (bool): whether the contestant's "cool down" period has
+        expired and they can submit again.
+
+    """
+    if min_interval is None or participation.unrestricted:
+        return True
+    submission = get_latest_submission(
+        sql_session, participation, contest=contest, task=task, cls=cls)
+    if submission is not None \
+            and (timestamp - submission.timestamp < min_interval):
+        return False
+    return True

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -80,7 +80,7 @@ def _filter_submission_query(q, participation, contest, task, cls):
 
 def get_submission_count(
         sql_session, participation, contest=None, task=None, cls=Submission):
-    """Return the amount of submissions the contestant sent in.
+    """Return the number of submissions the contestant sent in.
 
     Count the submissions (or user tests) for the given participation
     on the given task or contest (that is, on all the contest's tasks).

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -26,7 +26,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Submission-related handlers for CWS for a specific task.
+"""Submission-related helpers for CWS.
 
 """
 

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -126,9 +126,7 @@ def check_max_number(
         return True
     count = get_submission_count(
         sql_session, participation, contest=contest, task=task, cls=cls)
-    if count >= max_number:
-        return False
-    return True
+    return count < max_number
 
 
 def get_latest_submission(
@@ -182,7 +180,5 @@ def check_min_interval(
         return True
     submission = get_latest_submission(
         sql_session, participation, contest=contest, task=task, cls=cls)
-    if submission is not None \
-            and (timestamp - submission.timestamp < min_interval):
-        return False
-    return True
+    return submission is None \
+           or (timestamp - submission.timestamp >= min_interval)

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -89,8 +89,8 @@ def get_submission_count(
     participation (Participation): the participation to fetch data for.
     contest (Contest|None): if given count on all the contest's tasks.
     task (Task|None): if given count only on this task (trumps contest).
-    cls (Submission|UserTest): if the UserTest class is given, count
-        user tests rather than submissions.
+    cls (type): if the UserTest class is given, count user tests rather
+        than submissions.
 
     return (int): the count.
 
@@ -116,8 +116,8 @@ def check_max_number(
     participation (Participation): the participation to fetch data for.
     contest (Contest|None): if given count on all the contest's tasks.
     task (Task|None): if given count only on this task (trumps contest).
-    cls (Submission|UserTest): if the UserTest class is given, count
-        user tests rather than submissions.
+    cls (type): if the UserTest class is given, count user tests rather
+        than submissions.
 
     return (bool): whether the contestant can submit more.
 
@@ -143,8 +143,8 @@ def get_latest_submission(
     participation (Participation): the participation to fetch data for.
     contest (Contest|None): if given look at all the contest's tasks.
     task (Task|None): if given look only at this task (trumps contest).
-    cls (Submission|UserTest): if the UserTest class is given, fetch
-        user tests rather than submissions.
+    cls (type): if the UserTest class is given, fetch user tests rather
+        than submissions.
 
     return (Submission|UserTest|None): the latest submission/user test,
         if any.
@@ -171,8 +171,8 @@ def check_min_interval(
     participation (Participation): the participation to fetch data for.
     contest (Contest|None): if given look at all the contest's tasks.
     task (Task|None): if given look only at this task (trumps contest).
-    cls (Submission|UserTest): if the UserTest class is given, fetch
-        user tests rather than submissions.
+    cls (type): if the UserTest class is given, fetch user tests rather
+        than submissions.
 
     return (bool): whether the contestant's "cool down" period has
         expired and they can submit again.

--- a/cmstestsuite/unit_tests/server/contest/submission_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission_test.py
@@ -59,14 +59,14 @@ class TestGetSubmissionCount(DatabaseMixin, unittest.TestCase):
         with self.assertRaises(ValueError):
             self.call()
         # If both, the task's contest cannot be None.
-        self.other_task = self.add_task()
+        other_task = self.add_task()
         with self.assertRaises(ValueError):
-            self.call(contest=self.contest, task=self.other_task)
+            self.call(contest=self.contest, task=other_task)
         # And cannot be another contest.
-        self.other_contest = self.add_contest()
-        self.other_task.contest = self.other_contest
+        other_contest = self.add_contest()
+        other_task.contest = other_contest
         with self.assertRaises(ValueError):
-            self.call(contest=self.contest, task=self.other_task)
+            self.call(contest=self.contest, task=other_task)
 
     def test_count_task(self):
         # No submissions.
@@ -111,8 +111,8 @@ class TestGetSubmissionCount(DatabaseMixin, unittest.TestCase):
         self.assertEqual(self.call(contest=self.contest), 3)
 
         # Doesn't mix submissions for different contests.
-        self.other_contest = self.add_contest()
-        self.assertEqual(self.call(contest=self.other_contest), 0)
+        other_contest = self.add_contest()
+        self.assertEqual(self.call(contest=other_contest), 0)
 
         # Doesn't mix submissions with user tests.
         self.assertEqual(self.call(contest=self.contest, cls=UserTest), 0)
@@ -221,14 +221,14 @@ class TestGetLastSubmission(DatabaseMixin, unittest.TestCase):
         with self.assertRaises(ValueError):
             self.call()
         # If both, the task's contest cannot be None.
-        self.other_task = self.add_task()
+        other_task = self.add_task()
         with self.assertRaises(ValueError):
-            self.call(contest=self.contest, task=self.other_task)
+            self.call(contest=self.contest, task=other_task)
         # And cannot be another contest.
-        self.other_contest = self.add_contest()
-        self.other_task.contest = self.other_contest
+        other_contest = self.add_contest()
+        other_task.contest = other_contest
         with self.assertRaises(ValueError):
-            self.call(contest=self.contest, task=self.other_task)
+            self.call(contest=self.contest, task=other_task)
 
     def test_retrieve_task(self):
         # No submissions.
@@ -275,8 +275,8 @@ class TestGetLastSubmission(DatabaseMixin, unittest.TestCase):
         self.assertIs(self.call(contest=self.contest), s2)
 
         # Doesn't mix submissions for different contests.
-        self.other_contest = self.add_contest()
-        self.assertIsNone(self.call(contest=self.other_contest))
+        other_contest = self.add_contest()
+        self.assertIsNone(self.call(contest=other_contest))
 
         # Doesn't mix submissions with user tests.
         self.assertIsNone(self.call(contest=self.contest, cls=UserTest))

--- a/cmstestsuite/unit_tests/server/contest/submission_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission_test.py
@@ -51,8 +51,10 @@ class TestGetSubmissionCount(DatabaseMixin, unittest.TestCase):
         self.task2 = self.add_task(contest=self.contest)
         self.participation = self.add_participation(contest=self.contest)
 
-    def call(self, **kwargs):
-        return get_submission_count(self.session, self.participation, **kwargs)
+    def call(self, participation=None, **kwargs):
+        if participation is None:
+            participation = self.participation
+        return get_submission_count(self.session, participation, **kwargs)
 
     def test_bad_arguments(self):
         # Needs at least one of contest or task.
@@ -84,6 +86,11 @@ class TestGetSubmissionCount(DatabaseMixin, unittest.TestCase):
         # Doesn't mix submissions for different tasks.
         self.assertEqual(self.call(task=self.task2), 0)
 
+        # Doesn't mix submissions for different users.
+        other_participation = self.add_participation(contest=self.contest)
+        self.assertEqual(self.call(participation=other_participation,
+                                   task=self.task1), 0)
+
         # Doesn't mix submissions with user tests.
         self.assertEqual(self.call(task=self.task1, cls=UserTest), 0)
 
@@ -113,6 +120,11 @@ class TestGetSubmissionCount(DatabaseMixin, unittest.TestCase):
         # Doesn't mix submissions for different contests.
         other_contest = self.add_contest()
         self.assertEqual(self.call(contest=other_contest), 0)
+
+        # Doesn't mix submissions for different users.
+        other_participation = self.add_participation(contest=self.contest)
+        self.assertEqual(self.call(participation=other_participation,
+                                   contest=self.contest), 0)
 
         # Doesn't mix submissions with user tests.
         self.assertEqual(self.call(contest=self.contest, cls=UserTest), 0)
@@ -213,8 +225,10 @@ class TestGetLastSubmission(DatabaseMixin, unittest.TestCase):
     def at(self, seconds):
         return self.timestamp + timedelta(seconds=seconds)
 
-    def call(self, **kwargs):
-        return get_latest_submission(self.session, self.participation, **kwargs)
+    def call(self, participation=None, **kwargs):
+        if participation is None:
+            participation = self.participation
+        return get_latest_submission(self.session, participation, **kwargs)
 
     def test_bad_arguments(self):
         # Needs at least one of contest or task.
@@ -252,6 +266,11 @@ class TestGetLastSubmission(DatabaseMixin, unittest.TestCase):
         # Doesn't mix submissions for different tasks.
         self.assertIsNone(self.call(task=self.task2))
 
+        # Doesn't mix submissions for different users.
+        other_participation = self.add_participation(contest=self.contest)
+        self.assertIsNone(self.call(participation=other_participation,
+                                    task=self.task1))
+
         # Doesn't mix submissions with user tests.
         self.assertIsNone(self.call(task=self.task1, cls=UserTest))
 
@@ -277,6 +296,11 @@ class TestGetLastSubmission(DatabaseMixin, unittest.TestCase):
         # Doesn't mix submissions for different contests.
         other_contest = self.add_contest()
         self.assertIsNone(self.call(contest=other_contest))
+
+        # Doesn't mix submissions for different users.
+        other_participation = self.add_participation(contest=self.contest)
+        self.assertIsNone(self.call(participation=other_participation,
+                                    contest=self.contest))
 
         # Doesn't mix submissions with user tests.
         self.assertIsNone(self.call(contest=self.contest, cls=UserTest))

--- a/cmstestsuite/unit_tests/server/contest/submission_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission_test.py
@@ -212,10 +212,10 @@ class TestCheckMaxNumber(DatabaseMixin, unittest.TestCase):
         self.get_submission_count.assert_not_called()
 
 
-class TestGetLastSubmission(DatabaseMixin, unittest.TestCase):
+class TestGetLatestSubmission(DatabaseMixin, unittest.TestCase):
 
     def setUp(self):
-        super(TestGetLastSubmission, self).setUp()
+        super(TestGetLatestSubmission, self).setUp()
         self.contest = self.add_contest()
         self.task1 = self.add_task(contest=self.contest)
         self.task2 = self.add_task(contest=self.contest)
@@ -336,8 +336,8 @@ class TestCheckMinInterval(DatabaseMixin, unittest.TestCase):
     def setUp(self):
         super(TestCheckMinInterval, self).setUp()
 
-        patcher = patch("cms.server.contest.submission.get_last_submission")
-        self.get_last_submission = patcher.start()
+        patcher = patch("cms.server.contest.submission.get_latest_submission")
+        self.get_latest_submission = patcher.start()
         self.addCleanup(patcher.stop)
         self.calls = list()
 
@@ -365,7 +365,7 @@ class TestCheckMinInterval(DatabaseMixin, unittest.TestCase):
     def test_no_limit(self):
         s = self.add_submission(timestamp=self.at(5), task=self.task,
                                 participation=self.participation)
-        self.get_last_submission.return_value = s
+        self.get_latest_submission.return_value = s
         # Test different arguments to ensure they don't cause issues.
         self.assertTrue(self.call(None, 0))
         self.assertTrue(self.call(None, 1, contest=self.contest))
@@ -373,41 +373,41 @@ class TestCheckMinInterval(DatabaseMixin, unittest.TestCase):
         self.assertTrue(self.call(
             None, 3, contest=self.contest, task=self.task))
         # Having calls signals an inefficiency.
-        self.get_last_submission.assert_not_called()
+        self.get_latest_submission.assert_not_called()
 
     def test_limit(self):
         s = self.add_submission(timestamp=self.at(5), task=self.task,
                                 participation=self.participation)
-        self.get_last_submission.return_value = s
+        self.get_latest_submission.return_value = s
         # Test different arguments to ensure they are passed to the call.
         self.assertFalse(self.call(1, 4, contest=self.contest))
         self.assertFalse(self.call(3, 6, task=self.task, cls=UserTest))
         self.assertTrue(self.call(4, 11, contest=self.contest, task=self.task))
         # Arguments should have been passed unchanged.
-        self.get_last_submission.assert_has_calls(self.calls)
+        self.get_latest_submission.assert_has_calls(self.calls)
 
     def test_limit_no_submissions(self):
-        self.get_last_submission.return_value = None
+        self.get_latest_submission.return_value = None
         # Test different arguments to ensure they are passed to the call.
         self.assertTrue(self.call(1, 4, contest=self.contest, cls=UserTest))
         self.assertTrue(self.call(3, 6, task=self.task))
         self.assertTrue(self.call(4, 11, contest=self.contest, task=self.task))
         # Arguments should have been passed unchanged.
-        self.get_last_submission.assert_has_calls(self.calls)
+        self.get_latest_submission.assert_has_calls(self.calls)
 
     def test_limit_unrestricted(self):
         # Unrestricted users have no limit enforced.
         self.participation.unrestricted = True
         s = self.add_submission(timestamp=self.at(5), task=self.task,
                                 participation=self.participation)
-        self.get_last_submission.return_value = s
+        self.get_latest_submission.return_value = s
         # Test different arguments to ensure they don't cause issues.
         self.assertTrue(self.call(1, 4, contest=self.contest))
         self.assertTrue(self.call(3, 6, task=self.task))
         self.assertTrue(self.call(
             4, 11, contest=self.contest, task=self.task, cls=UserTest))
         # Having calls signals an inefficiency.
-        self.get_last_submission.assert_not_called()
+        self.get_latest_submission.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/cmstestsuite/unit_tests/server/contest/submission_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission_test.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for submission functions.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *
+from future.builtins import *
+
+import unittest
+from datetime import timedelta
+
+from mock import call, patch
+
+# Needs to be first to allow for monkey patching the DB connection string.
+from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
+
+from cms.db import Submission, UserTest
+from cms.server.contest.submission import get_submission_count, \
+    check_max_number, get_latest_submission, check_min_interval
+from cmscommon.datetime import make_datetime
+
+
+class TestGetSubmissionCount(DatabaseMixin, unittest.TestCase):
+
+    def setUp(self):
+        super(TestGetSubmissionCount, self).setUp()
+        self.contest = self.add_contest()
+        self.task1 = self.add_task(contest=self.contest)
+        self.task2 = self.add_task(contest=self.contest)
+        self.participation = self.add_participation(contest=self.contest)
+
+    def call(self, **kwargs):
+        return get_submission_count(self.session, self.participation, **kwargs)
+
+    def test_bad_arguments(self):
+        # Needs at least one of contest or task.
+        with self.assertRaises(ValueError):
+            self.call()
+        # If both, the task's contest cannot be None.
+        self.other_task = self.add_task()
+        with self.assertRaises(ValueError):
+            self.call(contest=self.contest, task=self.other_task)
+        # And cannot be another contest.
+        self.other_contest = self.add_contest()
+        self.other_task.contest = self.other_contest
+        with self.assertRaises(ValueError):
+            self.call(contest=self.contest, task=self.other_task)
+
+    def test_count_task(self):
+        # No submissions.
+        self.assertEqual(self.call(task=self.task1), 0)
+
+        # One submission.
+        s = self.add_submission(task=self.task1,
+                                participation=self.participation)
+        self.assertEqual(self.call(task=self.task1), 1)
+
+        # More than one submission.
+        self.add_submission(task=self.task1, participation=self.participation)
+        self.assertEqual(self.call(task=self.task1), 2)
+
+        # Doesn't mix submissions for different tasks.
+        self.assertEqual(self.call(task=self.task2), 0)
+
+        # Doesn't mix submissions with user tests.
+        self.assertEqual(self.call(task=self.task1, cls=UserTest), 0)
+
+        # Isn't influenced by submission results.
+        d1 = self.add_dataset(task=self.task1)
+        d2 = self.add_dataset(task=self.task1)
+        self.add_submission_result(submission=s, dataset=d1)
+        self.add_submission_result(submission=s, dataset=d2)
+        self.assertEqual(self.call(task=self.task1), 2)
+
+    def test_count_contest(self):
+        # No submissions.
+        self.assertEqual(self.call(contest=self.contest), 0)
+
+        # One submission.
+        self.add_submission(task=self.task1, participation=self.participation)
+        self.assertEqual(self.call(contest=self.contest), 1)
+
+        # Another one, on a different task.
+        self.add_submission(task=self.task2, participation=self.participation)
+        self.assertEqual(self.call(contest=self.contest), 2)
+
+        # Back to the first task.
+        self.add_submission(task=self.task1, participation=self.participation)
+        self.assertEqual(self.call(contest=self.contest), 3)
+
+        # Doesn't mix submissions for different contests.
+        self.other_contest = self.add_contest()
+        self.assertEqual(self.call(contest=self.other_contest), 0)
+
+        # Doesn't mix submissions with user tests.
+        self.assertEqual(self.call(contest=self.contest, cls=UserTest), 0)
+
+    def test_user_tests(self):
+        # No user tests.
+        self.assertEqual(self.call(contest=self.contest, cls=UserTest), 0)
+        self.assertEqual(self.call(task=self.task1, cls=UserTest), 0)
+        self.assertEqual(self.call(task=self.task2, cls=UserTest), 0)
+
+        # One user test.
+        self.add_user_test(task=self.task1, participation=self.participation)
+        self.assertEqual(self.call(contest=self.contest, cls=UserTest), 1)
+        self.assertEqual(self.call(task=self.task1, cls=UserTest), 1)
+        self.assertEqual(self.call(task=self.task2, cls=UserTest), 0)
+
+        # Another user test, on a different task.
+        self.add_user_test(task=self.task2, participation=self.participation)
+        self.assertEqual(self.call(contest=self.contest, cls=UserTest), 2)
+        self.assertEqual(self.call(task=self.task1, cls=UserTest), 1)
+        self.assertEqual(self.call(task=self.task2, cls=UserTest), 1)
+
+        # Doesn't mix user tests with submissions.
+        self.assertEqual(self.call(contest=self.contest), 0)
+        self.assertEqual(self.call(task=self.task1), 0)
+        self.assertEqual(self.call(task=self.task2), 0)
+
+
+class TestCheckMaxNumber(DatabaseMixin, unittest.TestCase):
+
+    def setUp(self):
+        super(TestCheckMaxNumber, self).setUp()
+
+        patcher = patch("cms.server.contest.submission.get_submission_count")
+        self.get_submission_count = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.calls = list()
+
+        self.contest = self.add_contest()
+        self.task = self.add_task(contest=self.contest)
+        self.participation = self.add_participation(unrestricted=False,
+                                                    contest=self.contest)
+
+    def call(self, max_number, **kwargs):
+        res = check_max_number(
+            self.session, max_number, self.participation, **kwargs)
+        kwargs.setdefault("contest", None)
+        kwargs.setdefault("task", None)
+        kwargs.setdefault("cls", Submission)
+        self.calls.append(call(self.session, self.participation, **kwargs))
+        return res
+
+    def test_no_limit(self):
+        self.get_submission_count.return_value = 5
+        # Test different arguments to ensure they don't cause issues.
+        self.assertTrue(self.call(None))
+        self.assertTrue(self.call(None, contest=self.contest))
+        self.assertTrue(self.call(None, task=self.task))
+        self.assertTrue(self.call(None, contest=self.contest, task=self.task))
+        # Having calls signals an inefficiency.
+        self.get_submission_count.assert_not_called()
+
+    def test_limit(self):
+        self.get_submission_count.return_value = 5
+        # Test different arguments to ensure they are passed to the call.
+        self.assertFalse(self.call(0, contest=self.contest))
+        self.assertFalse(self.call(3, task=self.task))
+        self.assertFalse(self.call(5, contest=self.contest, task=self.task))
+        self.assertTrue(self.call(6, contest=self.contest, cls=UserTest))
+        self.assertTrue(self.call(9, task=self.task, cls=UserTest))
+        # Arguments should have been passed unchanged.
+        self.get_submission_count.assert_has_calls(self.calls)
+
+    def test_limit_unrestricted(self):
+        # Unrestricted users have no limit enforced.
+        self.participation.unrestricted = True
+        self.get_submission_count.return_value = 5
+        # Test different arguments to ensure they don't cause issues.
+        self.assertTrue(self.call(0, contest=self.contest))
+        self.assertTrue(self.call(3, task=self.task))
+        self.assertTrue(self.call(5, contest=self.contest, task=self.task))
+        self.assertTrue(self.call(6, contest=self.contest, cls=UserTest))
+        self.assertTrue(self.call(9, task=self.task, cls=UserTest))
+        # Having calls signals an inefficiency.
+        self.get_submission_count.assert_not_called()
+
+
+class TestGetLastSubmission(DatabaseMixin, unittest.TestCase):
+
+    def setUp(self):
+        super(TestGetLastSubmission, self).setUp()
+        self.contest = self.add_contest()
+        self.task1 = self.add_task(contest=self.contest)
+        self.task2 = self.add_task(contest=self.contest)
+        self.participation = self.add_participation(contest=self.contest)
+        self.timestamp = make_datetime()
+
+    def at(self, seconds):
+        return self.timestamp + timedelta(seconds=seconds)
+
+    def call(self, **kwargs):
+        return get_latest_submission(self.session, self.participation, **kwargs)
+
+    def test_bad_arguments(self):
+        # Needs at least one of contest or task.
+        with self.assertRaises(ValueError):
+            self.call()
+        # If both, the task's contest cannot be None.
+        self.other_task = self.add_task()
+        with self.assertRaises(ValueError):
+            self.call(contest=self.contest, task=self.other_task)
+        # And cannot be another contest.
+        self.other_contest = self.add_contest()
+        self.other_task.contest = self.other_contest
+        with self.assertRaises(ValueError):
+            self.call(contest=self.contest, task=self.other_task)
+
+    def test_retrieve_task(self):
+        # No submissions.
+        self.assertIsNone(self.call(task=self.task1))
+
+        # One submission.
+        s1 = self.add_submission(timestamp=self.at(0), task=self.task1,
+                                 participation=self.participation)
+        self.assertIs(self.call(task=self.task1), s1)
+
+        # More than one submission.
+        s2 = self.add_submission(timestamp=self.at(2), task=self.task1,
+                                 participation=self.participation)
+        self.assertIs(self.call(task=self.task1), s2)
+
+        # They are sorted by timestamp, not by insertion order (i.e., by id).
+        self.add_submission(timestamp=self.at(1), task=self.task1,
+                            participation=self.participation)
+        self.assertIs(self.call(task=self.task1), s2)
+
+        # Doesn't mix submissions for different tasks.
+        self.assertIsNone(self.call(task=self.task2))
+
+        # Doesn't mix submissions with user tests.
+        self.assertIsNone(self.call(task=self.task1, cls=UserTest))
+
+    def test_retrieve_contest(self):
+        # No submissions.
+        self.assertIsNone(self.call(contest=self.contest))
+
+        # One submission.
+        s1 = self.add_submission(timestamp=self.at(2), task=self.task1,
+                                 participation=self.participation)
+        self.assertIs(self.call(contest=self.contest), s1)
+
+        # Another one, on a different task.
+        s2 = self.add_submission(timestamp=self.at(3), task=self.task2,
+                                 participation=self.participation)
+        self.assertIs(self.call(contest=self.contest), s2)
+
+        # Back to the first task, but at an earlier time.
+        self.add_submission(timestamp=self.at(1), task=self.task1,
+                            participation=self.participation)
+        self.assertIs(self.call(contest=self.contest), s2)
+
+        # Doesn't mix submissions for different contests.
+        self.other_contest = self.add_contest()
+        self.assertIsNone(self.call(contest=self.other_contest))
+
+        # Doesn't mix submissions with user tests.
+        self.assertIsNone(self.call(contest=self.contest, cls=UserTest))
+
+    def test_user_tests(self):
+        # No user tests.
+        self.assertIsNone(self.call(contest=self.contest, cls=UserTest))
+        self.assertIsNone(self.call(task=self.task1, cls=UserTest))
+        self.assertIsNone(self.call(task=self.task2, cls=UserTest))
+
+        # One user test.
+        s1 = self.add_user_test(timestamp=self.at(1), task=self.task1,
+                                participation=self.participation)
+        self.assertIs(self.call(contest=self.contest, cls=UserTest), s1)
+        self.assertIs(self.call(task=self.task1, cls=UserTest), s1)
+        self.assertIsNone(self.call(task=self.task2, cls=UserTest))
+
+        # Another user test, on a different task.
+        s2 = self.add_user_test(timestamp=self.at(2), task=self.task2,
+                                participation=self.participation)
+        self.assertIs(self.call(contest=self.contest, cls=UserTest), s2)
+        self.assertIs(self.call(task=self.task1, cls=UserTest), s1)
+        self.assertIs(self.call(task=self.task2, cls=UserTest), s2)
+
+        # Doesn't mix user tests with submissions.
+        self.assertIsNone(self.call(contest=self.contest))
+        self.assertIsNone(self.call(task=self.task1))
+        self.assertIsNone(self.call(task=self.task2))
+
+
+class TestCheckMinInterval(DatabaseMixin, unittest.TestCase):
+
+    def setUp(self):
+        super(TestCheckMinInterval, self).setUp()
+
+        patcher = patch("cms.server.contest.submission.get_last_submission")
+        self.get_last_submission = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.calls = list()
+
+        self.contest = self.add_contest()
+        self.task = self.add_task(contest=self.contest)
+        self.participation = self.add_participation(unrestricted=False,
+                                                    contest=self.contest)
+
+        self.timestamp = make_datetime()
+
+    def at(self, seconds):
+        return self.timestamp + timedelta(seconds=seconds)
+
+    def call(self, min_interval, timestamp, **kwargs):
+        res = check_min_interval(
+            self.session,
+            None if min_interval is None else timedelta(seconds=min_interval),
+            self.at(timestamp), self.participation, **kwargs)
+        kwargs.setdefault("contest", None)
+        kwargs.setdefault("task", None)
+        kwargs.setdefault("cls", Submission)
+        self.calls.append(call(self.session, self.participation, **kwargs))
+        return res
+
+    def test_no_limit(self):
+        s = self.add_submission(timestamp=self.at(5), task=self.task,
+                                participation=self.participation)
+        self.get_last_submission.return_value = s
+        # Test different arguments to ensure they don't cause issues.
+        self.assertTrue(self.call(None, 0))
+        self.assertTrue(self.call(None, 1, contest=self.contest))
+        self.assertTrue(self.call(None, 2, task=self.task))
+        self.assertTrue(self.call(
+            None, 3, contest=self.contest, task=self.task))
+        # Having calls signals an inefficiency.
+        self.get_last_submission.assert_not_called()
+
+    def test_limit(self):
+        s = self.add_submission(timestamp=self.at(5), task=self.task,
+                                participation=self.participation)
+        self.get_last_submission.return_value = s
+        # Test different arguments to ensure they are passed to the call.
+        self.assertFalse(self.call(1, 4, contest=self.contest))
+        self.assertFalse(self.call(3, 6, task=self.task, cls=UserTest))
+        self.assertTrue(self.call(4, 11, contest=self.contest, task=self.task))
+        # Arguments should have been passed unchanged.
+        self.get_last_submission.assert_has_calls(self.calls)
+
+    def test_limit_no_submissions(self):
+        self.get_last_submission.return_value = None
+        # Test different arguments to ensure they are passed to the call.
+        self.assertTrue(self.call(1, 4, contest=self.contest, cls=UserTest))
+        self.assertTrue(self.call(3, 6, task=self.task))
+        self.assertTrue(self.call(4, 11, contest=self.contest, task=self.task))
+        # Arguments should have been passed unchanged.
+        self.get_last_submission.assert_has_calls(self.calls)
+
+    def test_limit_unrestricted(self):
+        # Unrestricted users have no limit enforced.
+        self.participation.unrestricted = True
+        s = self.add_submission(timestamp=self.at(5), task=self.task,
+                                participation=self.participation)
+        self.get_last_submission.return_value = s
+        # Test different arguments to ensure they don't cause issues.
+        self.assertTrue(self.call(1, 4, contest=self.contest))
+        self.assertTrue(self.call(3, 6, task=self.task))
+        self.assertTrue(self.call(
+            4, 11, contest=self.contest, task=self.task, cls=UserTest))
+        # Having calls signals an inefficiency.
+        self.get_last_submission.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
And add tests.

Before, the code would always fetch once the latest submission for the
task, even if it wasn't needed at all (for min_interval check or for
allow_partial_submission fill-in). Now it is retrieved on demand, thus
in total either 0, 1 or 2 times. I believe that the average will be less
than 1 and that thus the net result will be an improvement. Also the
code is clearer now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/932)
<!-- Reviewable:end -->
