### PR TITLE
TPS importer

### DIFF
--- a/cmscontrib/loaders/__init__.py
+++ b/cmscontrib/loaders/__init__.py
@@ -26,10 +26,14 @@ from six import itervalues, iteritems
 
 from .italy_yaml import YamlLoader
 from .polygon import PolygonTaskLoader, PolygonUserLoader, PolygonContestLoader
+from .tps import TpsTaskLoader
+
 
 LOADERS = dict(
     (loader_class.short_name, loader_class) for loader_class in [
-        YamlLoader, PolygonTaskLoader, PolygonUserLoader, PolygonContestLoader
+        YamlLoader,
+        PolygonTaskLoader, PolygonUserLoader, PolygonContestLoader,
+        TpsTaskLoader
     ]
 )
 

--- a/cmscontrib/loaders/tps.py
+++ b/cmscontrib/loaders/tps.py
@@ -31,6 +31,7 @@ import json
 import logging
 import os
 import re
+import subprocess
 
 from datetime import timedelta
 
@@ -239,8 +240,10 @@ class TpsTaskLoader(TaskLoader):
         if os.path.exists(checker_src):
             logger.info("Checker found, compiling")
             checker_exe = os.path.join(checker_dir, "checker")
-            os.system("g++ -x c++ -std=gnu++14 -O2 -static -o %s %s" %
-                      (checker_exe, checker_src))
+            subprocess.call([
+                "g++", "-x", "c++", "-std=gnu++14", "-O2", "-static",
+                "-o", checker_exe, checker_src
+            ])
             digest = self.file_cacher.put_file_from_path(
                 checker_exe,
                 "Manager for task %s" % name)
@@ -290,9 +293,10 @@ class TpsTaskLoader(TaskLoader):
         if os.path.exists(manager_src):
             logger.info("Manager found, compiling")
             manager_exe = os.path.join(graders_dir, "manager")
-            os.system("cat %s | \
-                            g++ -x c++ -O2 -static -o %s -" %
-                      (manager_src, manager_exe))
+            subprocess.call([
+                "g++", "-x", "c++", "-O2", "-static",
+                "-o", manager_exe, manager_src
+            ])
             digest = self.file_cacher.put_file_from_path(
                 manager_exe,
                 "Manager for task %s" % name)

--- a/cmscontrib/loaders/tps.py
+++ b/cmscontrib/loaders/tps.py
@@ -102,7 +102,6 @@ class TpsTaskLoader(TaskLoader):
                 [task_type_parameters[par_input],
                  task_type_parameters[par_output]],
                 evaluation_param,
-                task_type_parameters[par_user_managers]
             ]
 
         if task_type == 'Communication':
@@ -253,10 +252,9 @@ class TpsTaskLoader(TaskLoader):
             logger.info("Checker not found, using diff if necessary")
             evaluation_param = "diff"
 
+        # Note that the original TPS worked with custom task type Batch2017
+        # and Communication2017 instead of Batch and Communication.
         args["task_type"] = data['task_type']
-        if data['task_type'] != 'OutputOnly' \
-                and data['task_type'] != 'Notice':
-            args["task_type"] += '2017'
         args["task_type_parameters"] = \
             self._get_task_type_parameters(
                 data, data['task_type'], evaluation_param)
@@ -285,6 +283,9 @@ class TpsTaskLoader(TaskLoader):
             digest = self.file_cacher.put_file_from_path(
                 grader_src,
                 "Manager for task %s" % name)
+            if data['task_type'] == 'Communication' \
+                    and os.path.splitext(grader_name)[0] == 'grader':
+                grader_name = 'stub' + os.path.splitext(grader_name)[1]
             args["managers"][grader_name] = Manager(grader_name, digest)
 
         # Manager

--- a/cmscontrib/loaders/tps.py
+++ b/cmscontrib/loaders/tps.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Programming contest management system
+# Copyright © 2017 Kiarash Golezardi <kiarashgolezardi@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *  # noqa
+from future.builtins import *  # noqa
+
+import io
+import json
+import logging
+import os
+
+from datetime import timedelta
+
+from cms.db import Task, SubmissionFormatElement, Dataset, Manager, Testcase
+
+from .base_loader import TaskLoader
+
+
+logger = logging.getLogger(__name__)
+
+
+def make_timedelta(t):
+    return timedelta(seconds=t)
+
+
+class TpsTaskLoader(TaskLoader):
+    """Loader for TPS exported tasks.
+
+    """
+
+    short_name = 'tps_task'
+    description = 'TPS task format'
+
+    # FIXME: stay?
+    @staticmethod
+    def detect(path):
+        """See docstring in class Loader.
+
+        """
+        return os.path.exists(os.path.join(path, "problem.json"))
+
+    def task_has_changed(self):
+        """See docstring in class Loader.
+
+        """
+        return True
+
+    def _get_task_type_parameters(self, data, task_type, evaluation_param):
+        parameters_str = data['task_type_params']
+        if parameters_str is None or parameters_str == '':
+            parameters_str = '{}'
+        task_type_parameters = json.loads(parameters_str)
+        par_prefix = 'task_type_parameters_%s' % task_type
+        if task_type == 'Batch':
+            par_compilation = '%s_compilation' % par_prefix
+            par_input = '%s_io_0_inputfile' % par_prefix
+            par_output = '%s_io_1_outputfile' % par_prefix
+            if par_compilation not in task_type_parameters:
+                task_type_parameters[par_compilation] = 'alone'
+            if par_input not in task_type_parameters:
+                task_type_parameters[par_input] = ''
+            if par_output not in task_type_parameters:
+                task_type_parameters[par_output] = ''
+            return '["%s", ["%s", "%s"], "%s"]' % \
+                   (task_type_parameters[par_compilation],
+                    task_type_parameters[par_input],
+                    task_type_parameters[par_output],
+                    evaluation_param)
+        if task_type == 'Communication':
+            par_processes = '%s_num_processes' % par_prefix
+            if par_processes not in task_type_parameters:
+                task_type_parameters[par_processes] = 1
+            return '[%s]' % task_type_parameters[par_processes]
+        return '[%s]' % evaluation_param
+
+    def get_task(self, get_statement=True):
+        """See docstring in class Loader.
+
+        """
+
+        json_src = os.path.join(self.path, 'problem.json')
+        if not os.path.exists(json_src):
+            logger.critical('No task found.')
+            raise IOError('No task found at path %s' % json_src)
+        with io.open(json_src, 'rt', encoding='utf-8') as json_file:
+            data = json.load(json_file)
+
+        name = data['code']
+        logger.info("Loading parameters for task %s.", name)
+
+        args = {}
+
+        args["name"] = name
+        args["title"] = data['name']
+
+        # TODO: import statements
+
+        args["submission_format"] = [SubmissionFormatElement("%s.%%l" % name)]
+
+        # These options cannot be configured in the TPS format.
+        # Uncomment the following to set specific values for them.
+
+        # args['max_user_test_number'] = 10
+        # args['min_user_test_interval'] = make_timedelta(60)
+
+        # args['token_mode'] = 'infinite'
+        # args['token_max_number'] = 100
+        # args['token_min_interval'] = make_timedelta(60)
+        # args['token_gen_initial'] = 1
+        # args['token_gen_number'] = 1
+        # args['token_gen_interval'] = make_timedelta(1800)
+        # args['token_gen_max'] = 2
+
+        # TODO: additional cms config files
+
+        task = Task(**args)
+
+        args = dict()
+
+        args["task"] = task
+        args["description"] = "Default"
+        args["autojudge"] = True
+
+        args["time_limit"] = float(data['time_limit'])
+        args["memory_limit"] = int(data['memory_limit'])
+
+        args["managers"] = {}
+
+        # Checker
+        checker_dir = os.path.join(self.path, "checker")
+        checker_src = os.path.join(checker_dir, "checker.cpp")
+
+        if os.path.exists(checker_src):
+            logger.info("Checker found, compiling")
+            checker_exe = os.path.join(checker_dir, "checker")
+            os.system("cat %s | \
+                g++ -x c++ -O2 -static -o %s -" %
+                      (checker_src, checker_exe))
+            digest = self.file_cacher.put_file_from_path(
+                checker_exe,
+                "Manager for task %s" % name)
+            args["managers"]['checker'] = Manager("checker", digest)
+            evaluation_param = "comparator"
+        else:
+            logger.info("Checker not found, using diff if necessary")
+            evaluation_param = "diff"
+
+        args["task_type"] = data['task_type']
+        args["task_type_parameters"] = \
+            self._get_task_type_parameters(
+                data, data['task_type'], evaluation_param)
+
+        # Graders
+        graders_dir = os.path.join(self.path, 'graders')
+        graders_list = \
+            [filename
+             for filename in os.listdir(graders_dir)
+             if filename != 'manager.cpp']
+        for grader_name in graders_list:
+            grader_src = os.path.join(graders_dir, grader_name)
+            digest = self.file_cacher.put_file_from_path(
+                grader_src,
+                "Manager for task %s" % name)
+            args["managers"][grader_name] = Manager(grader_name, digest)
+
+        # Manager
+        manager_src = os.path.join(graders_dir, 'manager.cpp')
+
+        if os.path.exists(manager_src):
+            logger.info("Manager found, compiling")
+            manager_exe = os.path.join(graders_dir, "manager")
+            os.system("cat %s | \
+                            g++ -x c++ -O2 -static -o %s -" %
+                      (manager_src, manager_exe))
+            digest = self.file_cacher.put_file_from_path(
+                manager_exe,
+                "Manager for task %s" % name)
+            args["managers"] += [Manager("manager", digest)]
+
+        # Testcases
+        testcases_dir = os.path.join(self.path, 'tests')
+        testcase_codenames = [filename[:-3]
+                              for filename in os.listdir(testcases_dir)
+                              if filename[-3:] == '.in']
+
+        args["testcases"] = {}
+
+        for codename in testcase_codenames:
+            infile = os.path.join(testcases_dir, "%s.in" % codename)
+            outfile = os.path.join(testcases_dir, "%s.out" % codename)
+            if not os.path.exists(outfile):
+                logger.critical(
+                    'Could not find the output file for testcase %s', codename)
+                logger.critical('Aborting...')
+                exit()
+
+            input_digest = self.file_cacher.put_file_from_path(
+                infile,
+                "Input %s for task %s" % (codename, name))
+            output_digest = self.file_cacher.put_file_from_path(
+                outfile,
+                "Output %s for task %s" % (codename, name))
+            testcase = Testcase(codename, True,
+                                input_digest, output_digest)
+            args["testcases"][codename] = testcase
+
+        # Score Type
+        subtasks_dir = os.path.join(self.path, 'subtasks')
+        subtasks = os.listdir(subtasks_dir)
+
+        if len(subtasks) == 0:
+            number_tests = len(testcase_codenames)
+            args["score_type"] = "Sum"
+            args["score_type_parameters"] = str(100 / number_tests)
+        else:
+            args["score_type"] = "GroupMin"
+            # FIXME: create the score_type_parameters
+
+        dataset = Dataset(**args)
+        task.active_dataset = dataset
+
+        logger.info("Task parameters loaded.")
+
+        return task

--- a/cmscontrib/loaders/tps.py
+++ b/cmscontrib/loaders/tps.py
@@ -4,6 +4,7 @@
 # Programming contest management system
 # Copyright © 2017 Kiarash Golezardi <kiarashgolezardi@gmail.com>
 # Copyright © 2017 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
+# Copyright © 2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -33,8 +34,7 @@ import re
 
 from datetime import timedelta
 
-from cms.db import Task, SubmissionFormatElement, Dataset, Manager, \
-    Testcase, Attachment, Statement
+from cms.db import Task, Dataset, Manager, Testcase, Attachment, Statement
 
 from .base_loader import TaskLoader
 
@@ -183,13 +183,11 @@ class TpsTaskLoader(TaskLoader):
         if data["task_type"] == 'OutputOnly':
             args["submission_format"] = list()
             for codename in testcase_codenames:
-                args["submission_format"].append(
-                    SubmissionFormatElement("%s.out" % codename))
+                args["submission_format"].append("%s.out" % codename)
         elif data["task_type"] == 'Notice':
             args["submission_format"] = list()
         else:
-            args["submission_format"] = [
-                SubmissionFormatElement("%s.%%l" % name)]
+            args["submission_format"] = ["%s.%%l" % name]
 
         # These options cannot be configured in the TPS format.
         # Uncomment the following to set specific values for them.

--- a/cmscontrib/loaders/tps.py
+++ b/cmscontrib/loaders/tps.py
@@ -96,23 +96,24 @@ class TpsTaskLoader(TaskLoader):
                 if not os.path.exists(pas_grader):
                     user_managers = '[\\"grader.%l\\"]'
                 task_type_parameters[par_user_managers] = user_managers
-            return '["%s", ["%s", "%s"], "%s", "%s"]' % \
-                   (task_type_parameters[par_compilation],
-                    task_type_parameters[par_input],
-                    task_type_parameters[par_output],
-                    evaluation_param,
-                    task_type_parameters[par_user_managers])
+            return [
+                task_type_parameters[par_compilation],
+                [task_type_parameters[par_input],
+                 task_type_parameters[par_output]],
+                evaluation_param,
+                task_type_parameters[par_user_managers]
+            ]
 
         if task_type == 'Communication':
             par_processes = '%s_num_processes' % par_prefix
             if par_processes not in task_type_parameters:
                 task_type_parameters[par_processes] = 1
-            return '[%s]' % task_type_parameters[par_processes]
+            return [task_type_parameters[par_processes]]
 
         if task_type == 'TwoSteps' or task_type == 'OutputOnly':
-            return '["%s"]' % evaluation_param
+            return [evaluation_param]
 
-        return ""
+        return []
 
     def get_task(self, get_statement=True):
         """See docstring in class Loader.
@@ -148,7 +149,7 @@ class TpsTaskLoader(TaskLoader):
                 for statement in statements:
                     language = statement[:-4]
                     if language == "en_US":
-                        args["primary_statements"] = '["en_US"]'
+                        args["primary_statements"] = ["en_US"]
                     digest = self.file_cacher.put_file_from_path(
                         os.path.join(statements_dir, statement),
                         "Statement for task %s (lang: %s)" %
@@ -330,7 +331,7 @@ class TpsTaskLoader(TaskLoader):
         if len(subtasks) == 0:
             number_tests = max(len(testcase_codenames), 1)
             args["score_type"] = "Sum"
-            args["score_type_parameters"] = str(100 / number_tests)
+            args["score_type_parameters"] = 100 / number_tests
         else:
             args["score_type"] = "GroupMin"
             parsed_data = []
@@ -354,7 +355,7 @@ class TpsTaskLoader(TaskLoader):
                         parsed_data.append([score, testcases, optional_name])
                     else:
                         parsed_data.append([score, testcases])
-            args["score_type_parameters"] = json.dumps(parsed_data)
+            args["score_type_parameters"] = parsed_data
 
         dataset = Dataset(**args)
         task.active_dataset = dataset

--- a/cmscontrib/loaders/tps.py
+++ b/cmscontrib/loaders/tps.py
@@ -184,7 +184,7 @@ class TpsTaskLoader(TaskLoader):
             args["submission_format"] = list()
             for codename in testcase_codenames:
                 args["submission_format"].append(
-                    SubmissionFormatElement("output_%s.txt" % codename))
+                    SubmissionFormatElement("%s.out" % codename))
         elif data["task_type"] == 'Notice':
             args["submission_format"] = list()
         else:
@@ -205,7 +205,10 @@ class TpsTaskLoader(TaskLoader):
         # args['token_gen_interval'] = make_timedelta(1800)
         # args['token_gen_max'] = 2
 
-        args['score_precision'] = 2
+        if "score_precision" in data:
+            args['score_precision'] = int(data["score_precision"])
+        else:
+            args['score_precision'] = 2
         args['max_submission_number'] = 50
         args['max_user_test_number'] = 50
         if data["task_type"] == 'OutputOnly':
@@ -237,7 +240,7 @@ class TpsTaskLoader(TaskLoader):
         if os.path.exists(checker_src):
             logger.info("Checker found, compiling")
             checker_exe = os.path.join(checker_dir, "checker")
-            os.system("g++ -x c++ -O2 -static -o %s %s" %
+            os.system("g++ -x c++ -std=gnu++14 -O2 -static -o %s %s" %
                       (checker_exe, checker_src))
             digest = self.file_cacher.put_file_from_path(
                 checker_exe,
@@ -264,7 +267,7 @@ class TpsTaskLoader(TaskLoader):
             pas_manager_path = os.path.join(graders_dir, pas_manager)
             if not os.path.exists(pas_manager_path):
                 digest = self.file_cacher.put_file_content(
-                    '', 'Pascal manager for task %s' % name)
+                    ''.encode('utf-8'), 'Pascal manager for task %s' % name)
                 args["managers"][pas_manager] = Manager(pas_manager, digest)
 
         if not os.path.exists(graders_dir):


### PR DESCRIPTION
Supersedes #852. FYI @wil93.
Tried on two tasks kindly provided by @akmohtashami and it imports correctly.

Main changes introduced by me:
- fixed pep8 & change of names within the existing commits (this required the extraction of the long "task_type_parameter_<name>" strings, the other changes are trivial);
- included at the end the update from the removal of submission format element.

Note for reviewer (@lerks): more subtle code style decisions should belong to TPS author, IMHO. 

The last remaining issue is that the importer wants to use the task types Batch2017 and Communication2017, which is not very future-proof. I guess the question for @akmohtashami is whether the tasks exported from TPS explicitly require these task types, or they can work with the regular version too. In the latter case I'd remove the 2017 suffix, in the former we need to find a solution to ensure compatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/935)
<!-- Reviewable:end -->
