### PR TITLE
Make names in tests more deterministic

### DIFF
--- a/cmstestsuite/functionaltestframework.py
+++ b/cmstestsuite/functionaltestframework.py
@@ -121,18 +121,37 @@ class FunctionalTestFramework(object):
             self._cws_browser.login(lr)
         return self._cws_browser
 
-    def initialize_aws(self, rand):
-        """Create an admin and logs in
+    def initialize_aws(self):
+        """Create an admin.
 
-        rand (int): some random bit to add to the admin username.
+        The username will be admin, unless already used. In that case it will
+        be admin<suffix>, where <suffix> will be the first integer (from 0)
+        for which an admin with that name doesn't yet exists.
+
+        return (str): the suffix.
 
         """
         logger.info("Creating admin...")
-        self.admin_info["username"] = "admin%s" % rand
         self.admin_info["password"] = "adminpwd"
-        sh([sys.executable, "cmscontrib/AddAdmin.py",
-            "%(username)s" % self.admin_info,
-            "-p", "%(password)s" % self.admin_info])
+
+        suffix = ""
+        while True:
+            self.admin_info["username"] = "admin%s" % suffix
+            logger.info("Trying %(username)s" % self.admin_info)
+            try:
+                sh([sys.executable, "cmscontrib/AddAdmin.py",
+                    "%(username)s" % self.admin_info,
+                    "-p", "%(password)s" % self.admin_info],
+                   ignore_failure=False)
+            except TestException:
+                if suffix == "":
+                    suffix = "0"
+                else:
+                    suffix = str(int(suffix) + 1)
+            else:
+                break
+
+        return suffix
 
     def get_cms_config(self):
         if self._cms_config is None:

--- a/cmstestsuite/functionaltestframework.py
+++ b/cmstestsuite/functionaltestframework.py
@@ -126,7 +126,7 @@ class FunctionalTestFramework(object):
 
         The username will be admin, unless already used. In that case it will
         be admin<suffix>, where <suffix> will be the first integer (from 0)
-        for which an admin with that name doesn't yet exists.
+        for which an admin with that name doesn't yet exist.
 
         return (str): the suffix.
 
@@ -144,10 +144,7 @@ class FunctionalTestFramework(object):
                     "-p", "%(password)s" % self.admin_info],
                    ignore_failure=False)
             except TestException:
-                if suffix == "":
-                    suffix = "0"
-                else:
-                    suffix = str(int(suffix) + 1)
+                suffix = str(int(suffix or "1") + 1)
             else:
                 break
 

--- a/cmstestsuite/testrunner.py
+++ b/cmstestsuite/testrunner.py
@@ -31,7 +31,6 @@ import datetime
 import io
 import logging
 import os
-import random
 import subprocess
 
 from cmstestsuite import CONFIG
@@ -58,8 +57,10 @@ class TestRunner(object):
         # Map from task name to (task id, task_module).
         self.task_id_map = {}
 
-        # Random bit to append to object's names to avoid collisions.
-        self.rand = random.randint(0, 999999999)
+        # String to append to object's names to avoid collisions. Will be the
+        # first integer i for which admin<i> is not already registered, and we
+        # will hope that if the admin name doesn't clash, no other name will.
+        self.suffix = None
 
         self.num_users = 0
         self.workers = workers
@@ -70,7 +71,7 @@ class TestRunner(object):
             os.environ["PYTHONPATH"] = "%(TEST_DIR)s" % CONFIG
 
         self.start_generic_services()
-        self.framework.initialize_aws(self.rand)
+        self.suffix = self.framework.initialize_aws()
 
         if contest_id is None:
             self.contest_id = self.create_contest()
@@ -133,8 +134,8 @@ class TestRunner(object):
         start_time = datetime.datetime.utcnow()
         stop_time = start_time + datetime.timedelta(1, 0, 0)
         self.contest_id = self.framework.add_contest(
-            name="testcontest" + str(self.rand),
-            description="A test contest #%s." % self.rand,
+            name="testcontest" + self.suffix,
+            description="A test contest #%s." % self.suffix,
             languages=list(ALL_LANGUAGES),
             allow_password_authentication="checked",
             start=start_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
@@ -165,7 +166,7 @@ class TestRunner(object):
                 return 'th'
             return {1: 'st', 2: 'nd', 3: 'rd'}.get(x % 10, 'th')
 
-        username = "testrabbit_%d_%d" % (self.rand, self.num_users)
+        username = "testrabbit_%s_%d" % (self.suffix, self.num_users)
 
         # Find a user that may already exist (from a previous contest).
         users = self.framework.get_users(self.contest_id)
@@ -195,7 +196,7 @@ class TestRunner(object):
         return (int): task id of the new (or existing) task.
 
         """
-        name = task_module.task_info['name'] + str(self.rand)
+        name = task_module.task_info['name'] + self.suffix
 
         # Have we done this before? Pull it out of our cache if so.
         if name in self.task_id_map:

--- a/cmstestsuite/testrunner.py
+++ b/cmstestsuite/testrunner.py
@@ -57,7 +57,7 @@ class TestRunner(object):
         # Map from task name to (task id, task_module).
         self.task_id_map = {}
 
-        # String to append to object's names to avoid collisions. Will be the
+        # String to append to objects' names to avoid collisions. Will be the
         # first integer i for which admin<i> is not already registered, and we
         # will hope that if the admin name doesn't clash, no other name will.
         self.suffix = None
@@ -135,7 +135,7 @@ class TestRunner(object):
         stop_time = start_time + datetime.timedelta(1, 0, 0)
         self.contest_id = self.framework.add_contest(
             name="testcontest" + self.suffix,
-            description="A test contest #%s." % self.suffix,
+            description="A test contest #%s." % (self.suffix or "1"),
             languages=list(ALL_LANGUAGES),
             allow_password_authentication="checked",
             start=start_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
@@ -166,7 +166,7 @@ class TestRunner(object):
                 return 'th'
             return {1: 'st', 2: 'nd', 3: 'rd'}.get(x % 10, 'th')
 
-        username = "testrabbit_%s_%d" % (self.suffix, self.num_users)
+        username = "testrabbit_%s_%d" % (self.suffix or "1", self.num_users)
 
         # Find a user that may already exist (from a previous contest).
         users = self.framework.get_users(self.contest_id)
@@ -178,6 +178,7 @@ class TestRunner(object):
             "last_name": "Wabbit the %d%s" % (self.num_users,
                                               enumerify(self.num_users))
         }
+
         if username in users:
             self.user_id = users[username]['id']
             self.framework.add_existing_user(self.user_id, **user_create_args)


### PR DESCRIPTION
A common annoyance while developing and using functional tests to get
some sample data is that the names keep changing, and a browser cannot
remember the login, among other pains. Also it is impossible to
understand which one was the contest for the latest run.

With this change, the first run will have no suffix, the second will
have suffix "0", and so on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/942)
<!-- Reviewable:end -->
