### PR TITLE
Trusted step (used for checkers)

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -117,7 +117,7 @@ class Config(object):
         self.sandbox_implementation = 'isolate'
 
         # Sandbox.
-        # Max size of each writable file during an evaluation step, in kiB.
+        # Max size of each writable file during an evaluation step, in KiB.
         self.max_file_size = 1048576
         # Max processes, CPU time (s), memory (KiB) for compilation runs.
         self.compilation_sandbox_max_processes = 1000

--- a/cms/conf.py
+++ b/cms/conf.py
@@ -117,11 +117,16 @@ class Config(object):
         self.sandbox_implementation = 'isolate'
 
         # Sandbox.
+        # Max size of each writable file during an evaluation step, in kiB.
         self.max_file_size = 1048576
         # Max processes, CPU time (s), memory (KiB) for compilation runs.
         self.compilation_sandbox_max_processes = 1000
         self.compilation_sandbox_max_time_s = 10.0
         self.compilation_sandbox_max_memory_kib = 512 * 1024  # 512 MiB
+        # Max processes, CPU time (s), memory (KiB) for trusted runs.
+        self.trusted_sandbox_max_processes = 1000
+        self.trusted_sandbox_max_time_s = 10.0
+        self.trusted_sandbox_max_memory_kib = 4 * 1024 * 1024  # 4 GiB
 
         # WebServers.
         self.secret_key_default = "8e045a51e4b102ea803c06f92841a1fb"

--- a/cms/grading/steps/__init__.py
+++ b/cms/grading/steps/__init__.py
@@ -32,7 +32,7 @@ from .evaluation import EVALUATION_MESSAGES, evaluation_step, \
     human_evaluation_message, is_evaluation_passed
 from .messages import HumanMessage, MessageCollection
 from .stats import execution_stats, merge_execution_stats
-from .trusted import extract_outcome_and_text
+from .trusted import extract_outcome_and_text, trusted_step
 from .whitediff import _WHITES, _white_diff, white_diff_step
 
 
@@ -48,7 +48,7 @@ __all__ = [
     # stats_test.py
     "execution_stats", "merge_execution_stats",
     # trusted.py
-    "extract_outcome_and_text",
+    "extract_outcome_and_text", "trusted_step",
     # whitediff.py
     "_WHITES", "_white_diff", "white_diff_step",
 ]

--- a/cms/grading/steps/compilation.py
+++ b/cms/grading/steps/compilation.py
@@ -37,7 +37,7 @@ import logging
 import os
 
 from .messages import HumanMessage, MessageCollection
-from .stats import execution_stats, merge_execution_stats
+from .utils import generic_step
 
 from cms import config
 from cms.grading.Sandbox import Sandbox
@@ -114,26 +114,12 @@ def compilation_step(sandbox, commands):
     sandbox.address_space = config.compilation_sandbox_max_memory_kib
 
     # Actually run the compilation commands, logging stdout and stderr.
-    logger.debug("Starting compilation step.")
-    stats = None
-    for step, command in enumerate(commands):
-        # Keep stdout and stderr of each compilation step
-        sandbox.stdout_file = "compiler_stdout_%d.txt" % step
-        sandbox.stderr_file = "compiler_stderr_%d.txt" % step
-
-        box_success = sandbox.execute_without_std(command, wait=True)
-        if not box_success:
-            logger.error("Compilation aborted because of "
-                         "sandbox error in `%s'.", sandbox.path)
-            return False, None, None, None
-
-        stats = merge_execution_stats(
-            stats, execution_stats(sandbox, collect_output=True),
-            concurrent=False)
-
-        # If some command in the sequence has failed, we terminate early.
-        if stats["exit_status"] != Sandbox.EXIT_OK:
-            break
+    stats = generic_step(sandbox, commands, "compilation", collect_output=True)
+    print(stats)
+    if stats is None:
+        logger.error("Sandbox failed during compilation. "
+                     "See previous logs for the reason.")
+        return False, None, None, None
 
     # For each possible exit status we return an appropriate result.
     exit_status = stats["exit_status"]

--- a/cms/grading/steps/compilation.py
+++ b/cms/grading/steps/compilation.py
@@ -113,9 +113,8 @@ def compilation_step(sandbox, commands):
     sandbox.wallclock_timeout = 2 * sandbox.timeout + 1
     sandbox.address_space = config.compilation_sandbox_max_memory_kib
 
-    # Actually run the compilation commands, logging stdout and stderr.
+    # Run the compilation commands, copying stdout and stderr to stats.
     stats = generic_step(sandbox, commands, "compilation", collect_output=True)
-    print(stats)
     if stats is None:
         logger.error("Sandbox failed during compilation. "
                      "See previous logs for the reason.")

--- a/cms/grading/steps/trusted.py
+++ b/cms/grading/steps/trusted.py
@@ -46,7 +46,10 @@ from future.builtins import *  # noqa
 import io
 import logging
 
+from cms import config
+from cms.grading.Sandbox import Sandbox
 from .evaluation import EVALUATION_MESSAGES
+from .utils import generic_step
 
 
 logger = logging.getLogger(__name__)
@@ -118,3 +121,62 @@ def extract_outcome_and_text(sandbox):
                            "'%s' is not recognized." % remaining)
 
     return outcome, [text]
+
+
+def trusted_step(sandbox, commands):
+    """Execute some trusted commands in the sandbox.
+
+    Even if the commands are trusted, we use the sandbox to limit the resource
+    they use to avoid crashing a worker due to some configuration or
+    programming error.
+
+    sandbox (Sandbox): the sandbox we consider, already created.
+    commands ([[str]]): trusted commands to execute.
+
+    return ((bool, bool|None, dict|None)): a tuple with three items:
+        * success: True if the sandbox did not fail, in any command;
+        * execution_success: True if all commands terminated correctly,
+            without timeouts or other errors; None if success is False;
+        * stats: a dictionary with statistics about the execution, or None
+            if success is False.
+
+    """
+    # Set sandbox parameters suitable for trusted commands.
+    sandbox.preserve_env = True
+    sandbox.max_processes = config.trusted_sandbox_max_processes
+    sandbox.timeout = config.trusted_sandbox_max_time_s
+    sandbox.wallclock_timeout = 2 * sandbox.timeout + 1
+    sandbox.address_space = config.trusted_sandbox_max_memory_kib
+
+    # Actually run the commands, logging stdout and stderr.
+    stats = generic_step(sandbox, commands, "trusted")
+    if stats is None:
+        logger.error("Sandbox failed during trusted step. "
+                     "See previous logs for the reason.")
+        return False, None, None
+
+    exit_status = stats["exit_status"]
+
+    if exit_status == Sandbox.EXIT_OK:
+        # Sandbox ok, commands ok.
+        logger.debug("Trusted step ended successfully.")
+        return True, True, stats
+    elif exit_status in [
+            Sandbox.EXIT_NONZERO_RETURN,
+            Sandbox.EXIT_TIMEOUT,
+            Sandbox.EXIT_TIMEOUT_WALL,
+            Sandbox.EXIT_SIGNAL]:
+        # Sandbox ok, commands not ok.
+        logger.error("Trusted step ended with status '%s' (usually due to "
+                     "programming errors in a manager or configuration "
+                     "issues).", exit_status)
+        return True, False, stats
+    elif exit_status == Sandbox.EXIT_SANDBOX_ERROR:
+        # Sandbox not ok.
+        logger.error("Unexpected SANDBOX_ERROR exit status in trusted step.")
+        return False, None, None
+    else:
+        # Sandbox interface not ok, something really wrong happened.
+        logger.error("Unrecognized sandbox exit status '%s' in trusted step.",
+                     exit_status)
+        return False, None, None

--- a/cms/grading/steps/trusted.py
+++ b/cms/grading/steps/trusted.py
@@ -126,7 +126,7 @@ def extract_outcome_and_text(sandbox):
 def trusted_step(sandbox, commands):
     """Execute some trusted commands in the sandbox.
 
-    Even if the commands are trusted, we use the sandbox to limit the resource
+    Even if the commands are trusted, we use the sandbox to limit the resources
     they use to avoid crashing a worker due to some configuration or
     programming error.
 
@@ -148,7 +148,7 @@ def trusted_step(sandbox, commands):
     sandbox.wallclock_timeout = 2 * sandbox.timeout + 1
     sandbox.address_space = config.trusted_sandbox_max_memory_kib
 
-    # Actually run the commands, logging stdout and stderr.
+    # Run the trusted commands.
     stats = generic_step(sandbox, commands, "trusted")
     if stats is None:
         logger.error("Sandbox failed during trusted step. "

--- a/cms/grading/steps/utils.py
+++ b/cms/grading/steps/utils.py
@@ -24,7 +24,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""High level functions to perform standardized compilations."""
+"""Utilities for standardized runs (steps)."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -66,7 +66,7 @@ def _generic_execution(sandbox, command, exec_num, step_name,
     box_success = sandbox.execute_without_std(command, wait=True)
     if not box_success:
         logger.error("Step '%s' aborted because of sandbox error in '%s' on "
-                     "the %s-th command ('%s').",
+                     "the %d-th command ('%r').",
                      step_name, sandbox.path, exec_num + 1, command)
         return None
 
@@ -92,7 +92,7 @@ def generic_step(sandbox, commands, step_name, collect_output=False):
         error, or None in case of an unexpected sandbox error.
 
     """
-    logger.debug("Starting step '%s' in sandbox '%s' (%s commands).",
+    logger.debug("Starting step '%s' in sandbox '%s' (%d commands).",
                  step_name, sandbox.path, len(commands))
     stats = None
     for exec_num, command in enumerate(commands):

--- a/cms/grading/steps/utils.py
+++ b/cms/grading/steps/utils.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2010-2015 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
+# Copyright © 2010-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
+# Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
+# Copyright © 2013-2014 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
+# Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
+# Copyright © 2016 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""High level functions to perform standardized compilations."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *  # noqa
+from future.builtins import *  # noqa
+
+import logging
+
+from .stats import execution_stats, merge_execution_stats
+
+from cms.grading.Sandbox import Sandbox
+
+
+logger = logging.getLogger(__name__)
+
+
+def _generic_execution(sandbox, command, exec_num, step_name,
+                       collect_output=False):
+    """A single command execution of a multi-command step.
+
+    sandbox (Sandbox): the sandbox to use, already created and configured.
+    command ([str]): command to execute.
+    exec_num (int): 0-based index of the execution, to be used not to
+        overwrite the output files.
+    step_name (str): name of the step, also used as a prefix for the stdout
+        and stderr files.
+    collect_output (bool): if True, stats will contain stdout and stderr of the
+        command (regardless, they are redirected to file inside the sandbox).
+
+    return (dict|None): execution statistics, including standard output and
+        error, or None in case of an unexpected sandbox error.
+
+    """
+    sandbox.stdout_file = "%s_stdout_%d.txt" % (step_name, exec_num)
+    sandbox.stderr_file = "%s_stderr_%d.txt" % (step_name, exec_num)
+
+    box_success = sandbox.execute_without_std(command, wait=True)
+    if not box_success:
+        logger.error("Step '%s' aborted because of sandbox error in '%s' on "
+                     "the %s-th command ('%s').",
+                     step_name, sandbox.path, exec_num + 1, command)
+        return None
+
+    return execution_stats(sandbox, collect_output=collect_output)
+
+
+def generic_step(sandbox, commands, step_name, collect_output=False):
+    """Execute some commands in the sandbox.
+
+    Execute the commands sequentially in the (already created and configured)
+    sandbox.
+
+    Terminate early after a command if the sandbox fails, or the command does
+    not terminate normally and with exit code 0.
+
+    sandbox (Sandbox): the sandbox we consider, already created.
+    commands ([[str]]): compilation commands to execute.
+    step_name (str): used for logging and as a prefix to the output files
+    collect_output (bool): if True, stats will contain stdout and stderr of the
+        commands (regardless, they are redirected to file inside the sandbox).
+
+    return (dict|None): execution statistics, including standard output and
+        error, or None in case of an unexpected sandbox error.
+
+    """
+    logger.debug("Starting step '%s' in sandbox '%s' (%s commands).",
+                 step_name, sandbox.path, len(commands))
+    stats = None
+    for exec_num, command in enumerate(commands):
+        this_stats = _generic_execution(sandbox, command, exec_num, step_name,
+                                        collect_output=collect_output)
+        # Sandbox error, return immediately.
+        if this_stats is None:
+            return None
+
+        stats = merge_execution_stats(stats, this_stats, concurrent=False)
+        # Command error, also return immediately, but returning the stats.
+        if stats["exit_status"] != Sandbox.EXIT_OK:
+            break
+
+    return stats

--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -34,8 +34,8 @@ import os
 import shutil
 
 from cms.grading.steps import compilation_step, evaluation_step, \
-    human_evaluation_message, is_evaluation_passed, extract_outcome_and_text, \
-    white_diff_step
+    extract_outcome_and_text, human_evaluation_message, is_evaluation_passed,\
+    trusted_step, white_diff_step
 from cms.grading.languagemanager import LANGUAGES, get_language
 from cms.grading.ParameterTypes import ParameterTypeCollection, \
     ParameterTypeChoice, ParameterTypeString
@@ -355,7 +355,6 @@ class Batch(TaskType):
                         multithreaded=True,
                         name="check")
                     job.sandboxes.append(checkbox.path)
-                    checkbox.max_processes = 1000
 
                     checker_success, outcome, text = self._eval_output(
                         checkbox, job, sandbox.get_root_path())
@@ -431,8 +430,8 @@ class Batch(TaskType):
             self._actual_input,
             Batch.CORRECT_OUTPUT_FILENAME,
             self._actual_output]
-        success, _ = evaluation_step(sandbox, [command])
-        if not success:
+        box_success, success, stats = trusted_step(sandbox, [command])
+        if not box_success or not success:
             return False, None, []
 
         try:

--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -430,7 +430,7 @@ class Batch(TaskType):
             self._actual_input,
             Batch.CORRECT_OUTPUT_FILENAME,
             self._actual_output]
-        box_success, success, stats = trusted_step(sandbox, [command])
+        box_success, success, unused_stats = trusted_step(sandbox, [command])
         if not box_success or not success:
             return False, None, []
 

--- a/cms/grading/tasktypes/OutputOnly.py
+++ b/cms/grading/tasktypes/OutputOnly.py
@@ -205,7 +205,7 @@ class OutputOnly(TaskType):
             OutputOnly.INPUT_FILENAME,
             OutputOnly.CORRECT_OUTPUT_FILENAME,
             OutputOnly.OUTPUT_FILENAME]
-        box_success, success, stats = trusted_step(sandbox, [command])
+        box_success, success, unused_stats = trusted_step(sandbox, [command])
         if not box_success or not success:
             return False, None, []
 

--- a/cms/grading/tasktypes/OutputOnly.py
+++ b/cms/grading/tasktypes/OutputOnly.py
@@ -36,8 +36,8 @@ import logging
 from cms.grading.TaskType import TaskType, \
     create_sandbox, delete_sandbox
 from cms.grading.ParameterTypes import ParameterTypeChoice
-from cms.grading.steps import white_diff_step, evaluation_step, \
-    extract_outcome_and_text
+from cms.grading.steps import extract_outcome_and_text, trusted_step,\
+    white_diff_step
 
 
 logger = logging.getLogger(__name__)
@@ -205,8 +205,8 @@ class OutputOnly(TaskType):
             OutputOnly.INPUT_FILENAME,
             OutputOnly.CORRECT_OUTPUT_FILENAME,
             OutputOnly.OUTPUT_FILENAME]
-        success, _ = evaluation_step(sandbox, [command])
-        if not success:
+        box_success, success, stats = trusted_step(sandbox, [command])
+        if not box_success or not success:
             return False, None, []
 
         try:

--- a/cmstestsuite/unit_tests/grading/steps/compilation_test.py
+++ b/cmstestsuite/unit_tests/grading/steps/compilation_test.py
@@ -37,9 +37,6 @@ from cmstestsuite.unit_tests.grading.steps.fakeisolatesandbox \
 from cmstestsuite.unit_tests.grading.steps.stats_test import get_stats
 
 
-INVALID_UTF8 = b"\xc3\x28"
-
-
 ONE_COMMAND = [["test", "command"]]
 TWO_COMMANDS = [["test", "command", "1"], ["command", "2"]]
 
@@ -64,11 +61,11 @@ class TestCompilationStep(unittest.TestCase):
         expected_stats = get_stats(
             0.1, 0.5, 1000 * 1024, Sandbox.EXIT_OK, stdout="o", stderr="你好")
         with patch("cms.grading.steps.compilation.generic_step",
-                   return_value=expected_stats) as m:
+                   return_value=expected_stats) as mock_generic_step:
             success, compilation_success, text, stats = compilation_step(
                 self.sandbox, ONE_COMMAND)
 
-        m.assert_called_once_with(
+        mock_generic_step.assert_called_once_with(
             self.sandbox, ONE_COMMAND, "compilation", collect_output=True)
         self.assertLoggedError(False)
         self.assertTrue(success)
@@ -166,11 +163,11 @@ class TestCompilationStep(unittest.TestCase):
         expected_stats = get_stats(
             0.1, 0.5, 1000 * 1024, Sandbox.EXIT_OK, stdout="o", stderr="你好")
         with patch("cms.grading.steps.compilation.generic_step",
-                   return_value=expected_stats) as m:
+                   return_value=expected_stats) as mock_generic_step:
             success, compilation_success, text, stats = compilation_step(
                 self.sandbox, TWO_COMMANDS)
 
-        m.assert_called_once_with(
+        mock_generic_step.assert_called_once_with(
             self.sandbox, TWO_COMMANDS, "compilation", collect_output=True)
         self.assertLoggedError(False)
         self.assertTrue(success)

--- a/cmstestsuite/unit_tests/grading/steps/fakeisolatesandbox.py
+++ b/cmstestsuite/unit_tests/grading/steps/fakeisolatesandbox.py
@@ -51,7 +51,8 @@ class FakeIsolateSandbox(IsolateSandbox):
         self._fake_files[path] = content
 
     def fake_execute_data(self, success, stdout, stderr,
-                          time, wall_time, memory, exit_status, signal=None):
+                          time, wall_time, memory, exit_status,
+                          signal=None, message=None):
         """Set the fake data for the corresponding execution.
 
         Can be called multiple times, and this allows the system under test
@@ -64,6 +65,7 @@ class FakeIsolateSandbox(IsolateSandbox):
         memory (int): memory used in KiB.
         exit_status (str): isolate's two-letter exit status.
         signal (int|None): terminating signal if not None
+        message (str|None): message from isolate
 
         """
         data = {}
@@ -85,6 +87,8 @@ class FakeIsolateSandbox(IsolateSandbox):
             logs.append("status:%s" % exit_status)
         if signal is not None:
             logs.append("exitsig:%s" % signal)
+        if message is not None:
+            logs.append("message:%s" % message)
         data["log"] = "\n".join(logs).encode("utf-8")
 
         self._fake_execute_data.append(data)

--- a/cmstestsuite/unit_tests/grading/steps/trusted_test.py
+++ b/cmstestsuite/unit_tests/grading/steps/trusted_test.py
@@ -64,11 +64,11 @@ class TestTrustedStep(unittest.TestCase):
         expected_stats = get_stats(
             0.1, 0.5, 1000 * 1024, Sandbox.EXIT_OK, stdout="o", stderr="你好")
         with patch("cms.grading.steps.trusted.generic_step",
-                   return_value=expected_stats) as m:
+                   return_value=expected_stats) as mock_generic_step:
             success, trusted_success, stats = trusted_step(
                 self.sandbox, ONE_COMMAND)
 
-        m.assert_called_once_with(
+        mock_generic_step.assert_called_once_with(
             self.sandbox, ONE_COMMAND, "trusted")
         self.assertLoggedError(False)
         self.assertTrue(success)
@@ -157,12 +157,12 @@ class TestTrustedStep(unittest.TestCase):
         expected_stats = get_stats(
             0.1, 0.5, 1000 * 1024, Sandbox.EXIT_OK, stdout="o", stderr="你好")
         with patch("cms.grading.steps.trusted.generic_step",
-                   return_value=expected_stats) as m:
+                   return_value=expected_stats) as mock_generic_step:
             success, trusted_success, stats = trusted_step(
                 self.sandbox, TWO_COMMANDS)
 
         self.assertLoggedError(False)
-        m.assert_called_once_with(
+        mock_generic_step.assert_called_once_with(
             self.sandbox, TWO_COMMANDS, "trusted")
         self.assertTrue(success)
         self.assertTrue(trusted_success)

--- a/cmstestsuite/unit_tests/grading/steps/trusted_test.py
+++ b/cmstestsuite/unit_tests/grading/steps/trusted_test.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests for the compilation step."""
+"""Tests for the trusted step."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -31,7 +31,7 @@ import unittest
 from mock import patch
 
 from cms.grading.Sandbox import Sandbox
-from cms.grading.steps import COMPILATION_MESSAGES, compilation_step
+from cms.grading.steps import trusted_step
 from cmstestsuite.unit_tests.grading.steps.fakeisolatesandbox \
     import FakeIsolateSandbox
 from cmstestsuite.unit_tests.grading.steps.stats_test import get_stats
@@ -44,13 +44,13 @@ ONE_COMMAND = [["test", "command"]]
 TWO_COMMANDS = [["test", "command", "1"], ["command", "2"]]
 
 
-class TestCompilationStep(unittest.TestCase):
+class TestTrustedStep(unittest.TestCase):
 
     def setUp(self):
-        super(TestCompilationStep, self).setUp()
+        super(TestTrustedStep, self).setUp()
         self.sandbox = FakeIsolateSandbox(True, None)
 
-        patcher = patch("cms.grading.steps.compilation.logger.error")
+        patcher = patch("cms.grading.steps.trusted.logger.error")
         self.mock_logger_error = patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -63,119 +63,109 @@ class TestCompilationStep(unittest.TestCase):
     def test_single_command_success(self):
         expected_stats = get_stats(
             0.1, 0.5, 1000 * 1024, Sandbox.EXIT_OK, stdout="o", stderr="你好")
-        with patch("cms.grading.steps.compilation.generic_step",
+        with patch("cms.grading.steps.trusted.generic_step",
                    return_value=expected_stats) as m:
-            success, compilation_success, text, stats = compilation_step(
+            success, trusted_success, stats = trusted_step(
                 self.sandbox, ONE_COMMAND)
 
         m.assert_called_once_with(
-            self.sandbox, ONE_COMMAND, "compilation", collect_output=True)
+            self.sandbox, ONE_COMMAND, "trusted")
         self.assertLoggedError(False)
         self.assertTrue(success)
-        self.assertTrue(compilation_success)
-        self.assertEqual(text, [COMPILATION_MESSAGES.get("success").message])
+        self.assertTrue(trusted_success)
         self.assertEqual(stats, expected_stats)
 
-    def test_single_command_compilation_failed_nonzero_return(self):
-        # This case is a "success" for the sandbox (it's the user's fault),
-        # but compilation is unsuccessful (no executable).
+    def test_single_commands_trusted_failed_nonzero_return(self):
         expected_stats = get_stats(
             0.1, 0.5, 1000 * 1024, Sandbox.EXIT_NONZERO_RETURN,
             stdout="o", stderr="e")
-        with patch("cms.grading.steps.compilation.generic_step",
+        with patch("cms.grading.steps.trusted.generic_step",
                    return_value=expected_stats):
-            success, compilation_success, text, stats = compilation_step(
+            success, trusted_success, stats = trusted_step(
                 self.sandbox, ONE_COMMAND)
 
-        # User's fault, no error needs to be logged.
-        self.assertLoggedError(False)
+        # Trusted steps should always succeed, if not, should notify the admin.
+        self.assertLoggedError()
         self.assertTrue(success)
-        self.assertFalse(compilation_success)
-        self.assertEqual(text, [COMPILATION_MESSAGES.get("fail").message])
+        self.assertFalse(trusted_success)
         self.assertEqual(stats, expected_stats)
 
-    def test_single_command_compilation_failed_timeout(self):
+    def test_single_commands_trusted_failed_timeout(self):
         # This case is a "success" for the sandbox (it's the user's fault),
-        # but compilation is unsuccessful (no executable).
+        # but trusted is unsuccessful (no executable).
         expected_stats = get_stats(
             0.1, 0.5, 1000 * 1024, Sandbox.EXIT_TIMEOUT,
             stdout="o", stderr="e")
-        with patch("cms.grading.steps.compilation.generic_step",
+        with patch("cms.grading.steps.trusted.generic_step",
                    return_value=expected_stats):
-            success, compilation_success, text, stats = compilation_step(
+            success, trusted_success, stats = trusted_step(
                 self.sandbox, ONE_COMMAND)
 
-        # User's fault, no error needs to be logged.
-        self.assertLoggedError(False)
+        # Trusted steps should always succeed, if not, should notify the admin.
+        self.assertLoggedError()
         self.assertTrue(success)
-        self.assertFalse(compilation_success)
-        self.assertEqual(text, [COMPILATION_MESSAGES.get("timeout").message])
+        self.assertFalse(trusted_success)
         self.assertEqual(stats, expected_stats)
 
-    def test_single_command_compilation_failed_timeout_wall(self):
+    def test_single_commands_trusted_failed_timeout_wall(self):
         # This case is a "success" for the sandbox (it's the user's fault),
-        # but compilation is unsuccessful (no executable).
+        # but trusted is unsuccessful (no executable).
         expected_stats = get_stats(
             0.1, 0.5, 1000 * 1024, Sandbox.EXIT_TIMEOUT_WALL,
             stdout="o", stderr="e")
-        with patch("cms.grading.steps.compilation.generic_step",
+        with patch("cms.grading.steps.trusted.generic_step",
                    return_value=expected_stats):
-            success, compilation_success, text, stats = compilation_step(
+            success, trusted_success, stats = trusted_step(
                 self.sandbox, ONE_COMMAND)
 
-        # User's fault, no error needs to be logged.
-        self.assertLoggedError(False)
+        # Trusted steps should always succeed, if not, should notify the admin.
+        self.assertLoggedError()
         self.assertTrue(success)
-        self.assertFalse(compilation_success)
-        self.assertEqual(text, [COMPILATION_MESSAGES.get("timeout").message])
+        self.assertFalse(trusted_success)
         self.assertEqual(stats, expected_stats)
 
-    def test_single_command_compilation_failed_signal(self):
+    def test_single_commands_trusted_failed_signal(self):
         # This case is a "success" for the sandbox (it's the user's fault),
-        # but compilation is unsuccessful (no executable).
+        # but trusted is unsuccessful (no executable).
         expected_stats = get_stats(
             0.1, 0.5, 1000 * 1024, Sandbox.EXIT_SIGNAL, signal=11,
             stdout="o", stderr="e")
-        with patch("cms.grading.steps.compilation.generic_step",
+        with patch("cms.grading.steps.trusted.generic_step",
                    return_value=expected_stats):
-            success, compilation_success, text, stats = compilation_step(
+            success, trusted_success, stats = trusted_step(
                 self.sandbox, ONE_COMMAND)
 
-        # User's fault, no error needs to be logged.
-        self.assertLoggedError(False)
+        # Trusted steps should always succeed, if not, should notify the admin.
+        self.assertLoggedError()
         self.assertTrue(success)
-        self.assertFalse(compilation_success)
-        self.assertEqual(text,
-                         [COMPILATION_MESSAGES.get("signal").message, "11"])
+        self.assertFalse(trusted_success)
         self.assertEqual(stats, expected_stats)
 
-    def test_single_command_sandbox_failed(self):
-        with patch("cms.grading.steps.compilation.generic_step",
+    def test_single_commands_sandbox_failed(self):
+        with patch("cms.grading.steps.trusted.generic_step",
                    return_value=None):
-            success, compilation_success, text, stats = compilation_step(
+            success, trusted_success, stats = trusted_step(
                 self.sandbox, ONE_COMMAND)
 
         # Sandbox should never fail. If it does, should notify the admin.
         self.assertLoggedError()
         self.assertFalse(success)
-        self.assertIsNone(compilation_success)
-        self.assertIsNone(text)
+        self.assertIsNone(trusted_success)
         self.assertIsNone(stats)
 
     def test_multiple_commands_success(self):
         expected_stats = get_stats(
             0.1, 0.5, 1000 * 1024, Sandbox.EXIT_OK, stdout="o", stderr="你好")
-        with patch("cms.grading.steps.compilation.generic_step",
+        with patch("cms.grading.steps.trusted.generic_step",
                    return_value=expected_stats) as m:
-            success, compilation_success, text, stats = compilation_step(
+            success, trusted_success, stats = trusted_step(
                 self.sandbox, TWO_COMMANDS)
 
-        m.assert_called_once_with(
-            self.sandbox, TWO_COMMANDS, "compilation", collect_output=True)
         self.assertLoggedError(False)
+        m.assert_called_once_with(
+            self.sandbox, TWO_COMMANDS, "trusted")
         self.assertTrue(success)
-        self.assertTrue(compilation_success)
-        self.assertEqual(text, [COMPILATION_MESSAGES.get("success").message])
+        self.assertTrue(trusted_success)
         self.assertEqual(stats, expected_stats)
 
 

--- a/cmstestsuite/unit_tests/grading/steps/utils_test.py
+++ b/cmstestsuite/unit_tests/grading/steps/utils_test.py
@@ -94,6 +94,16 @@ class TestGenericStep(unittest.TestCase):
         self.assertEqual(stats, get_stats(0.1, 0.5, 1000 * 1024,
                                           Sandbox.EXIT_TIMEOUT))
 
+    def test_single_command_failed_timeout_wall(self):
+        self.sandbox.fake_execute_data(
+            True, b"o", b"e", 0.1, 0.5, 1000, "TO",
+            message="Time limit exceeded (wall clock)")
+
+        stats = generic_step(self.sandbox, ONE_COMMAND, "name")
+
+        self.assertEqual(stats, get_stats(0.1, 0.5, 1000 * 1024,
+                                          Sandbox.EXIT_TIMEOUT_WALL))
+
     def test_single_command_failed_signal(self):
         self.sandbox.fake_execute_data(
             True, b"o", b"e", 0.1, 0.5, 1000, "SG", signal=11)

--- a/cmstestsuite/unit_tests/grading/steps/utils_test.py
+++ b/cmstestsuite/unit_tests/grading/steps/utils_test.py
@@ -39,6 +39,10 @@ from cmstestsuite.unit_tests.grading.steps.stats_test import get_stats
 INVALID_UTF8 = b"\xc3\x28"
 
 
+ONE_COMMAND = [["test", "command"]]
+TWO_COMMANDS = [["test", "command", "1"], ["command", "2"]]
+
+
 class TestGenericStep(unittest.TestCase):
 
     def setUp(self):
@@ -49,7 +53,7 @@ class TestGenericStep(unittest.TestCase):
         self.sandbox.fake_execute_data(
             True, b"o", "你好".encode("utf-8"), 0.1, 0.5, 1000, "OK")
 
-        stats = generic_step(self.sandbox, [["test", "command"]], "name",
+        stats = generic_step(self.sandbox, ONE_COMMAND, "name",
                              collect_output=True)
 
         # Stdout and stderr are encoded in UTF-8.
@@ -64,7 +68,7 @@ class TestGenericStep(unittest.TestCase):
         self.sandbox.fake_execute_data(
             True, b"o", "你好".encode("utf-8"), 0.1, 0.5, 1000, "OK")
 
-        stats = generic_step(self.sandbox, [["test", "command"]], "name",
+        stats = generic_step(self.sandbox, ONE_COMMAND, "name",
                              collect_output=False)
 
         # No output collected on stats.
@@ -77,7 +81,7 @@ class TestGenericStep(unittest.TestCase):
     def test_single_command_nonzero_return(self):
         self.sandbox.fake_execute_data(True, b"o", b"e", 0.1, 0.5, 1000, "RE")
 
-        stats = generic_step(self.sandbox, [["test", "command"]], "name")
+        stats = generic_step(self.sandbox, ONE_COMMAND, "name")
 
         self.assertEqual(stats, get_stats(0.1, 0.5, 1000 * 1024,
                                           Sandbox.EXIT_NONZERO_RETURN))
@@ -85,7 +89,7 @@ class TestGenericStep(unittest.TestCase):
     def test_single_command_failed_timeout(self):
         self.sandbox.fake_execute_data(True, b"o", b"e", 0.1, 0.5, 1000, "TO")
 
-        stats = generic_step(self.sandbox, [["test", "command"]], "name")
+        stats = generic_step(self.sandbox, ONE_COMMAND, "name")
 
         self.assertEqual(stats, get_stats(0.1, 0.5, 1000 * 1024,
                                           Sandbox.EXIT_TIMEOUT))
@@ -94,7 +98,7 @@ class TestGenericStep(unittest.TestCase):
         self.sandbox.fake_execute_data(
             True, b"o", b"e", 0.1, 0.5, 1000, "SG", signal=11)
 
-        stats = generic_step(self.sandbox, [["test", "command"]], "name")
+        stats = generic_step(self.sandbox, ONE_COMMAND, "name")
 
         self.assertEqual(stats, get_stats(0.1, 0.5, 1000 * 1024,
                                           Sandbox.EXIT_SIGNAL, signal=11))
@@ -103,7 +107,7 @@ class TestGenericStep(unittest.TestCase):
         self.sandbox.fake_execute_data(
             False, b"o", b"e", 0.1, 0.5, 1000, "XX")
 
-        stats = generic_step(self.sandbox, [["test", "command"]], "name")
+        stats = generic_step(self.sandbox, ONE_COMMAND, "name")
 
         self.assertIsNone(stats)
 
@@ -113,7 +117,7 @@ class TestGenericStep(unittest.TestCase):
         self.sandbox.fake_execute_data(
             True, b"o2", b"e2", 1.0, 5.0, 10000, "OK")
 
-        stats = generic_step(self.sandbox, [["c1"], ["c2"]], "name",
+        stats = generic_step(self.sandbox, TWO_COMMANDS, "name",
                              collect_output=True)
 
         # 2 commands executed, with exec_num 0 and 1
@@ -132,7 +136,7 @@ class TestGenericStep(unittest.TestCase):
         self.sandbox.fake_execute_data(
             True, b"o2", b"e2", 1.0, 5.0, 10000, "OK")
 
-        stats = generic_step(self.sandbox, [["c1"], ["c2"]], "name",
+        stats = generic_step(self.sandbox, TWO_COMMANDS, "name",
                              collect_output=True)
 
         # 1 command executed (generic terminates early), with exec_num 0.
@@ -148,7 +152,7 @@ class TestGenericStep(unittest.TestCase):
         self.sandbox.fake_execute_data(
             True, b"o2", b"e2", 1.0, 5.0, 10000, "OK")
 
-        stats = generic_step(self.sandbox, [["c1"], ["c2"]], "name")
+        stats = generic_step(self.sandbox, TWO_COMMANDS, "name")
 
         # 1 command executed (generic terminates early), with exec_num 0.
         self.assertEquals(self.sandbox.exec_num, 0)
@@ -161,7 +165,7 @@ class TestGenericStep(unittest.TestCase):
             b"e" + INVALID_UTF8 + b"2",
             0.1, 0.5, 1000, "OK")
 
-        stats = generic_step(self.sandbox, [["test", "command"]], "name",
+        stats = generic_step(self.sandbox, ONE_COMMAND, "name",
                              collect_output=True)
 
         # UTF-8 invalid parts are replaced with funny question marks (\uFFFD).

--- a/cmstestsuite/unit_tests/grading/steps/utils_test.py
+++ b/cmstestsuite/unit_tests/grading/steps/utils_test.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the step utils."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *  # noqa
+from future.builtins import *  # noqa
+from six import assertRegex
+
+import unittest
+
+from cms.grading.Sandbox import Sandbox
+from cms.grading.steps.utils import generic_step
+from cmstestsuite.unit_tests.grading.steps.fakeisolatesandbox \
+    import FakeIsolateSandbox
+from cmstestsuite.unit_tests.grading.steps.stats_test import get_stats
+
+
+INVALID_UTF8 = b"\xc3\x28"
+
+
+class TestGenericStep(unittest.TestCase):
+
+    def setUp(self):
+        super(TestGenericStep, self).setUp()
+        self.sandbox = FakeIsolateSandbox(True, None)
+
+    def test_single_command_success(self):
+        self.sandbox.fake_execute_data(
+            True, b"o", "你好".encode("utf-8"), 0.1, 0.5, 1000, "OK")
+
+        stats = generic_step(self.sandbox, [["test", "command"]], "name",
+                             collect_output=True)
+
+        # Stdout and stderr are encoded in UTF-8.
+        self.assertEqual(
+            stats, get_stats(0.1, 0.5, 1000 * 1024, Sandbox.EXIT_OK,
+                             stdout="o", stderr="你好"))
+        # Generic step always redirects stdout and stderr.
+        self.assertEqual(self.sandbox.stdout_file, "name_stdout_0.txt")
+        self.assertEqual(self.sandbox.stderr_file, "name_stderr_0.txt")
+
+    def test_single_command_success_no_collect_output(self):
+        self.sandbox.fake_execute_data(
+            True, b"o", "你好".encode("utf-8"), 0.1, 0.5, 1000, "OK")
+
+        stats = generic_step(self.sandbox, [["test", "command"]], "name",
+                             collect_output=False)
+
+        # No output collected on stats.
+        self.assertEqual(
+            stats, get_stats(0.1, 0.5, 1000 * 1024, Sandbox.EXIT_OK))
+        # Generic step always redirects stdout and stderr.
+        self.assertEqual(self.sandbox.stdout_file, "name_stdout_0.txt")
+        self.assertEqual(self.sandbox.stderr_file, "name_stderr_0.txt")
+
+    def test_single_command_nonzero_return(self):
+        self.sandbox.fake_execute_data(True, b"o", b"e", 0.1, 0.5, 1000, "RE")
+
+        stats = generic_step(self.sandbox, [["test", "command"]], "name")
+
+        self.assertEqual(stats, get_stats(0.1, 0.5, 1000 * 1024,
+                                          Sandbox.EXIT_NONZERO_RETURN))
+
+    def test_single_command_failed_timeout(self):
+        self.sandbox.fake_execute_data(True, b"o", b"e", 0.1, 0.5, 1000, "TO")
+
+        stats = generic_step(self.sandbox, [["test", "command"]], "name")
+
+        self.assertEqual(stats, get_stats(0.1, 0.5, 1000 * 1024,
+                                          Sandbox.EXIT_TIMEOUT))
+
+    def test_single_command_failed_signal(self):
+        self.sandbox.fake_execute_data(
+            True, b"o", b"e", 0.1, 0.5, 1000, "SG", signal=11)
+
+        stats = generic_step(self.sandbox, [["test", "command"]], "name")
+
+        self.assertEqual(stats, get_stats(0.1, 0.5, 1000 * 1024,
+                                          Sandbox.EXIT_SIGNAL, signal=11))
+
+    def test_single_command_sandbox_failed(self):
+        self.sandbox.fake_execute_data(
+            False, b"o", b"e", 0.1, 0.5, 1000, "XX")
+
+        stats = generic_step(self.sandbox, [["test", "command"]], "name")
+
+        self.assertIsNone(stats)
+
+    def test_multiple_commands_success(self):
+        self.sandbox.fake_execute_data(
+            True, b"o1", b"e1", 0.1, 0.5, 1000, "OK")
+        self.sandbox.fake_execute_data(
+            True, b"o2", b"e2", 1.0, 5.0, 10000, "OK")
+
+        stats = generic_step(self.sandbox, [["c1"], ["c2"]], "name",
+                             collect_output=True)
+
+        # 2 commands executed, with exec_num 0 and 1
+        self.assertEquals(self.sandbox.exec_num, 1)
+        # Stats are the combination of the two.
+        self.assertEqual(stats, get_stats(1.1,  # sum
+                                          5.5,  # sum
+                                          10000 * 1024,  # max
+                                          Sandbox.EXIT_OK,
+                                          stdout="o1\n===\no2",
+                                          stderr="e1\n===\ne2"))
+
+    def test_multiple_commands_failure_terminates_early(self):
+        self.sandbox.fake_execute_data(
+            True, b"o1", b"e1", 0.1, 0.5, 1000, "RE")
+        self.sandbox.fake_execute_data(
+            True, b"o2", b"e2", 1.0, 5.0, 10000, "OK")
+
+        stats = generic_step(self.sandbox, [["c1"], ["c2"]], "name",
+                             collect_output=True)
+
+        # 1 command executed (generic terminates early), with exec_num 0.
+        self.assertEquals(self.sandbox.exec_num, 0)
+        # Stats are only for the first command.
+        self.assertEqual(stats, get_stats(
+            0.1, 0.5, 1000 * 1024, Sandbox.EXIT_NONZERO_RETURN,
+            stdout="o1", stderr="e1"))
+
+    def test_multiple_commands_sandbox_failure_terminates_early(self):
+        self.sandbox.fake_execute_data(
+            False, b"o1", b"e1", 0.1, 0.5, 1000, "XX")
+        self.sandbox.fake_execute_data(
+            True, b"o2", b"e2", 1.0, 5.0, 10000, "OK")
+
+        stats = generic_step(self.sandbox, [["c1"], ["c2"]], "name")
+
+        # 1 command executed (generic terminates early), with exec_num 0.
+        self.assertEquals(self.sandbox.exec_num, 0)
+        self.assertIsNone(stats)
+
+    def test_invalid_utf8_in_output(self):
+        self.sandbox.fake_execute_data(
+            True,
+            b"o" + INVALID_UTF8 + b"1",
+            b"e" + INVALID_UTF8 + b"2",
+            0.1, 0.5, 1000, "OK")
+
+        stats = generic_step(self.sandbox, [["test", "command"]], "name",
+                             collect_output=True)
+
+        # UTF-8 invalid parts are replaced with funny question marks (\uFFFD).
+        assertRegex(self, stats["stdout"], "^o.*1$")
+        assertRegex(self, stats["stderr"], "^e.*2$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Factored out the execution of multiple sequential commands to a "generic_step". Consequently, all tests that applied to compilation_step were moved to generic_step, and now tests for compilation_ and trusted_step have a mock for generic_step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/943)
<!-- Reviewable:end -->
