### PR TITLE
Refactor the workflow to process and validate submitted files in CWS

### DIFF
--- a/cms/grading/language.py
+++ b/cms/grading/language.py
@@ -150,6 +150,19 @@ class Language(with_metaclass(ABCMeta, object)):
         """
         pass
 
+    # It's sometimes handy to use Language objects in sets or as dict
+    # keys. Since they have no state (they are just collections of
+    # constants and static methods) and are designed to be used as
+    # singletons, it's very easy to make them hashable.
+
+    @classmethod
+    def __eq__(cls, other):
+        return type(other) is cls
+
+    @classmethod
+    def __hash__(cls):
+        return hash(cls)
+
 
 class CompiledLanguage(Language):
     """A language where the compilation step produces an executable."""

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -53,8 +53,9 @@ from cms.db import File, Submission, SubmissionResult
 from cms.grading.languagemanager import get_language
 from cms.server import multi_contest
 from cms.server.contest.submission import get_submission_count, \
-    check_max_number, get_latest_submission, check_min_interval
-from cmscommon.archive import Archive
+    check_max_number, check_min_interval, InvalidArchive, \
+    extract_files_from_tornado, InvalidFilesOrLanguages, \
+    match_files_and_languages, fetch_file_digests_from_previous_submission
 from cms.server.contest.tokening import UnacceptableToken, TokenAlreadyPlayed, \
     accept_token, tokens_available
 from cmscommon.crypto import encrypt_number
@@ -137,112 +138,42 @@ class SubmitHandler(ContestHandler):
         # Required files from the user.
         required = set(task.submission_format)
 
-        # Ensure that the user did not submit multiple files with the
-        # same name.
-        if any(len(filename) != 1
-               for filename in itervalues(self.request.files)):
+        try:
+            given_files = extract_files_from_tornado(self.request.files)
+        except InvalidArchive:
+            self._send_error(
+                self._("Invalid archive format!"),
+                self._("The submitted archive could not be opened."))
+            return
+
+        try:
+            given_languages = {self.get_argument("language")}
+        except tornado.web.MissingArgumentError:
+            given_languages = None
+
+        try:
+            files, language = match_files_and_languages(
+                given_files, given_languages, required, contest.languages)
+        except InvalidFilesOrLanguages:
             self._send_error(
                 self._("Invalid submission format!"),
                 self._("Please select the correct files."))
             return
 
-        # If the user submitted an archive, extract it and use content
-        # as request.files. But only valid for "output only" (i.e.,
-        # not for submissions requiring a programming language
-        # identification).
-        if len(self.request.files) == 1 and \
-                next(iterkeys(self.request.files)) == "submission":
-            if any(filename.endswith(".%l") for filename in required):
+        file_digests = dict()
+        missing = required.difference(iterkeys(files))
+        if len(missing) > 0:
+            if task.active_dataset.task_type_object.ALLOW_PARTIAL_SUBMISSION:
+                file_digests = fetch_file_digests_from_previous_submission(
+                    self.sql_session, participation, task, language, missing)
+            else:
                 self._send_error(
                     self._("Invalid submission format!"),
-                    self._("Please select the correct files."),
-                    task)
-                return
-            archive_data = self.request.files["submission"][0]
-            del self.request.files["submission"]
-
-            # Create the archive.
-            archive = Archive.from_raw_data(archive_data["body"])
-
-            if archive is None:
-                self._send_error(
-                    self._("Invalid archive format!"),
-                    self._("The submitted archive could not be opened."))
-                return
-
-            # Extract the archive.
-            unpacked_dir = archive.unpack()
-            for name in archive.namelist():
-                filename = os.path.basename(name)
-                with io.open(os.path.join(unpacked_dir, filename), "rb") as f:
-                    body = f.read()
-                self.request.files[filename] = [{
-                    'filename': filename,
-                    'body': body
-                }]
-
-            archive.cleanup()
-
-        # This ensure that the user sent one file for every name in
-        # submission format and no more. Less is acceptable if task
-        # type says so.
-        task_type = task.active_dataset.task_type_object
-        provided = set(iterkeys(self.request.files))
-        if not (required == provided or (task_type.ALLOW_PARTIAL_SUBMISSION
-                                         and required.issuperset(provided))):
-            self._send_error(
-                self._("Invalid submission format!"),
-                self._("Please select the correct files."))
-            return
-
-        # Add submitted files. After this, files is a dictionary indexed
-        # by *our* filenames (something like "output01.txt" or
-        # "taskname.%l", and whose value is a couple
-        # (user_assigned_filename, content).
-        files = {}
-        for uploaded, data in iteritems(self.request.files):
-            files[uploaded] = (data[0]["filename"], data[0]["body"])
-
-        # Read the submission language provided in the request; we
-        # integrate it with the language fetched from the previous
-        # submission (if we use it) and later make sure it is
-        # recognized and allowed.
-        submission_lang = self.get_argument("language", None)
-        need_lang = any(our_filename.find(".%l") != -1
-                        for our_filename in files)
-
-        # If we allow partial submissions, we implicitly recover the
-        # non-submitted files from the previous submission (if it has
-        # the same programming language of the current one), and put
-        # them in file_digests (since they are already in FS).
-        file_digests = {}
-        if task_type.ALLOW_PARTIAL_SUBMISSION:
-            last_submission_t = get_latest_submission(
-                self.sql_session, participation, task=task)
-            if last_submission_t is not None \
-                    and (submission_lang is None
-                         or submission_lang == last_submission_t.language):
-                submission_lang = last_submission_t.language
-                for filename in required.difference(provided):
-                    if filename in last_submission_t.files:
-                        file_digests[filename] = \
-                            last_submission_t.files[filename].digest
-
-        # Throw an error if task needs a language, but we don't have
-        # it or it is not allowed / recognized.
-        if need_lang:
-            error = None
-            if submission_lang is None:
-                error = self._("Cannot recognize the submission language.")
-            elif submission_lang not in contest.languages:
-                error = self._("Language %s not allowed in this contest.") \
-                    % submission_lang
-            if error is not None:
-                self._send_error(self._("Invalid submission!"), error)
+                    self._("Please select the correct files."))
                 return
 
         # Check if submitted files are small enough.
-        if any([len(f[1]) > config.max_submission_length
+        if any([len(f) > config.max_submission_length
                 for f in itervalues(files)]):
             self._send_error(
                 self._("Submission too big!"),
@@ -279,7 +210,7 @@ class SubmitHandler(ContestHandler):
         try:
             for filename in files:
                 digest = self.service.file_cacher.put_file_content(
-                    files[filename][1],
+                    files[filename],
                     "Submission file %s sent by %s at %d." % (
                         filename, participation.user.username,
                         make_timestamp(self.timestamp)))
@@ -302,7 +233,7 @@ class SubmitHandler(ContestHandler):
         official = self.r_params["actual_phase"] == 0
 
         submission = Submission(self.timestamp,
-                                submission_lang,
+                                language.name if language is not None else None,
                                 task=task,
                                 participation=participation,
                                 official=official)

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -136,7 +136,7 @@ class SubmitHandler(ContestHandler):
             return
 
         # Required files from the user.
-        required = set(task.submission_format)
+        required_codenames = set(task.submission_format)
 
         try:
             given_files = extract_files_from_tornado(self.request.files)
@@ -153,7 +153,8 @@ class SubmitHandler(ContestHandler):
 
         try:
             files, language = match_files_and_languages(
-                given_files, given_languages, required, contest.languages)
+                given_files, given_languages, required_codenames,
+                contest.languages)
         except InvalidFilesOrLanguages:
             self._send_error(
                 self._("Invalid submission format!"),
@@ -161,11 +162,12 @@ class SubmitHandler(ContestHandler):
             return
 
         file_digests = dict()
-        missing = required.difference(iterkeys(files))
-        if len(missing) > 0:
+        missing_codenames = required_codenames.difference(iterkeys(files))
+        if len(missing_codenames) > 0:
             if task.active_dataset.task_type_object.ALLOW_PARTIAL_SUBMISSION:
                 file_digests = fetch_file_digests_from_previous_submission(
-                    self.sql_session, participation, task, language, missing)
+                    self.sql_session, participation, task, language,
+                    missing_codenames)
             else:
                 self._send_error(
                     self._("Invalid submission format!"),

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -147,14 +147,9 @@ class SubmitHandler(ContestHandler):
             return
 
         try:
-            given_languages = {self.get_argument("language")}
-        except tornado.web.MissingArgumentError:
-            given_languages = None
-
-        try:
             files, language = match_files_and_languages(
-                given_files, given_languages, required_codenames,
-                contest.languages)
+                given_files, self.get_argument("language", None),
+                required_codenames, contest.languages)
         except InvalidFilesOrLanguages:
             self._send_error(
                 self._("Invalid submission format!"),

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -54,7 +54,7 @@ from cms.grading.languagemanager import get_language
 from cms.server import multi_contest
 from cms.server.contest.submission import get_submission_count, \
     check_max_number, check_min_interval, InvalidArchive, \
-    extract_files_from_tornado, InvalidFilesOrLanguages, \
+    extract_files_from_tornado, InvalidFilesOrLanguage, \
     match_files_and_languages, fetch_file_digests_from_previous_submission
 from cms.server.contest.tokening import UnacceptableToken, TokenAlreadyPlayed, \
     accept_token, tokens_available
@@ -150,7 +150,7 @@ class SubmitHandler(ContestHandler):
             files, language = match_files_and_languages(
                 given_files, self.get_argument("language", None),
                 required_codenames, contest.languages)
-        except InvalidFilesOrLanguages:
+        except InvalidFilesOrLanguage:
             self._send_error(
                 self._("Invalid submission format!"),
                 self._("Please select the correct files."))

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -35,7 +35,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from future.builtins.disabled import *  # noqa
 from future.builtins import *  # noqa
-from six import iterkeys, itervalues, iteritems
+from six import iterkeys, iteritems
 
 import io
 import logging
@@ -50,8 +50,9 @@ from cms.db import UserTest, UserTestFile, UserTestManager, UserTestResult
 from cms.grading.languagemanager import get_language
 from cms.server import multi_contest
 from cms.server.contest.submission import get_submission_count, \
-    check_max_number, get_latest_submission, check_min_interval
-from cmscommon.archive import Archive
+    check_max_number, check_min_interval, InvalidArchive, \
+    extract_files_from_tornado, InvalidFilesOrLanguages, \
+    match_files_and_languages, fetch_file_digests_from_previous_submission
 from cmscommon.crypto import encrypt_number
 from cmscommon.datetime import make_timestamp
 from cmscommon.mimetypes import get_type_for_file_name
@@ -204,117 +205,50 @@ class UserTestHandler(ContestHandler):
                        task_type.get_user_managers() +
                        ["input"])
 
-        # Ensure that the user did not submit multiple files with the
-        # same name.
-        if any(len(filename) != 1
-               for filename in itervalues(self.request.files)):
+        try:
+            given_files = extract_files_from_tornado(self.request.files)
+        except InvalidArchive:
+            self._send_error(
+                self._("Invalid archive format!"),
+                self._("The submitted archive could not be opened."))
+            return
+
+        try:
+            given_languages = {self.get_argument("language")}
+        except tornado.web.MissingArgumentError:
+            given_languages = None
+
+        try:
+            files, language = match_files_and_languages(
+                given_files, given_languages, required, contest.languages)
+        except InvalidFilesOrLanguages:
             self._send_error(
                 self._("Invalid test format!"),
                 self._("Please select the correct files."))
             return
 
-        # If the user submitted an archive, extract it and use content
-        # as request.files. But only valid for "output only" (i.e.,
-        # not for submissions requiring a programming language
-        # identification).
-        if len(self.request.files) == 1 and \
-                next(iterkeys(self.request.files)) == "submission":
-            if any(filename.endswith(".%l") for filename in required):
+        file_digests = dict()
+        missing = required.difference(iterkeys(files))
+        if len(missing) > 0:
+            if task.active_dataset.task_type_object.ALLOW_PARTIAL_SUBMISSION:
+                file_digests = fetch_file_digests_from_previous_submission(
+                    self.sql_session, participation, task, language, missing,
+                    cls=UserTest)
+            else:
                 self._send_error(
                     self._("Invalid test format!"),
-                    self._("Please select the correct files."),
-                    task)
+                    self._("Please select the correct files."))
                 return
-            archive_data = self.request.files["submission"][0]
-            del self.request.files["submission"]
-
-            # Create the archive.
-            archive = Archive.from_raw_data(archive_data["body"])
-
-            if archive is None:
-                self._send_error(
-                    self._("Invalid archive format!"),
-                    self._("The submitted archive could not be opened."))
-                return
-
-            # Extract the archive.
-            unpacked_dir = archive.unpack()
-            for name in archive.namelist():
-                filename = os.path.basename(name)
-                with io.open(os.path.join(unpacked_dir, filename), "rb") as f:
-                    body = f.read()
-                self.request.files[filename] = [{
-                    'filename': filename,
-                    'body': body
-                }]
-
-            archive.cleanup()
-
-        # This ensure that the user sent one file for every name in
-        # submission format and no more. Less is acceptable if task
-        # type says so.
-        provided = set(iterkeys(self.request.files))
-        if not (required == provided or (task_type.ALLOW_PARTIAL_SUBMISSION
-                                         and required.issuperset(provided))):
-            self._send_error(
-                self._("Invalid test format!"),
-                self._("Please select the correct files."))
-            return
-
-        # Add submitted files. After this, files is a dictionary indexed
-        # by *our* filenames (something like "output01.txt" or
-        # "taskname.%l", and whose value is a couple
-        # (user_assigned_filename, content).
-        files = {}
-        for uploaded, data in iteritems(self.request.files):
-            files[uploaded] = (data[0]["filename"], data[0]["body"])
-
-        # Read the submission language provided in the request; we
-        # integrate it with the language fetched from the previous
-        # submission (if we use it) and later make sure it is
-        # recognized and allowed.
-        submission_lang = self.get_argument("language", None)
-        need_lang = any(our_filename.find(".%l") != -1
-                        for our_filename in files)
-
-        # If we allow partial submissions, implicitly we recover the
-        # non-submitted files from the previous user test. And put them
-        # in file_digests (i.e. like they have already been sent to FS).
-        file_digests = {}
-        if task_type.ALLOW_PARTIAL_SUBMISSION:
-            last_user_test_t = get_latest_submission(
-                self.sql_session, participation, task=task, cls=UserTest)
-            if last_user_test_t is not None \
-                    and (submission_lang is None
-                         or submission_lang == last_user_test_t.language):
-                submission_lang = last_user_test_t.language
-                for filename in required.difference(provided):
-                    if filename in last_user_test_t.files:
-                        file_digests[filename] = \
-                            last_user_test_t.files[filename].digest
-
-        # Throw an error if task needs a language, but we don't have
-        # it or it is not allowed / recognized.
-        if need_lang:
-            error = None
-            if submission_lang is None:
-                error = self._("Cannot recognize the user test language.")
-            elif submission_lang not in contest.languages:
-                error = self._("Language %s not allowed in this contest.") \
-                    % submission_lang
-        if error is not None:
-            self._send_error(self._("Invalid test!"), error)
-            return
 
         # Check if submitted files are small enough.
-        if any([len(f[1]) > config.max_submission_length
+        if any([len(f) > config.max_submission_length
                 for n, f in iteritems(files) if n != "input"]):
             self._send_error(
                 self._("Test too big!"),
                 self._("Each source file must be at most %d bytes long.") %
                 config.max_submission_length)
             return
-        if len(files["input"][1]) > config.max_input_length:
+        if len(files["input"]) > config.max_input_length:
             self._send_error(
                 self._("Input too big!"),
                 self._("The input file must be at most %d bytes long.") %
@@ -350,7 +284,7 @@ class UserTestHandler(ContestHandler):
         try:
             for filename in files:
                 digest = self.service.file_cacher.put_file_content(
-                    files[filename][1],
+                    files[filename],
                     "Test file %s sent by %s at %d." % (
                         filename, participation.user.username,
                         make_timestamp(self.timestamp)))
@@ -368,7 +302,7 @@ class UserTestHandler(ContestHandler):
         logger.info("All files stored for test sent by %s",
                     participation.user.username)
         user_test = UserTest(self.timestamp,
-                             submission_lang,
+                             language.name if language is not None else None,
                              file_digests["input"],
                              participation=participation,
                              task=task)
@@ -379,8 +313,8 @@ class UserTestHandler(ContestHandler):
                 UserTestFile(filename, digest, user_test=user_test))
         for filename in task_type.get_user_managers():
             digest = file_digests[filename]
-            if submission_lang is not None:
-                extension = get_language(submission_lang).source_extension
+            if language is not None:
+                extension = language.source_extension
                 filename = filename.replace(".%l", extension)
             self.sql_session.add(
                 UserTestManager(filename, digest, user_test=user_test))

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -214,14 +214,9 @@ class UserTestHandler(ContestHandler):
             return
 
         try:
-            given_languages = {self.get_argument("language")}
-        except tornado.web.MissingArgumentError:
-            given_languages = None
-
-        try:
             files, language = match_files_and_languages(
-                given_files, given_languages, required_codenames,
-                contest.languages)
+                given_files, self.get_argument("language", None),
+                required_codenames, contest.languages)
         except InvalidFilesOrLanguages:
             self._send_error(
                 self._("Invalid test format!"),

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -201,9 +201,9 @@ class UserTestHandler(ContestHandler):
             return
 
         # Required files from the user.
-        required = set(task.submission_format +
-                       task_type.get_user_managers() +
-                       ["input"])
+        required_codenames = set(task.submission_format +
+                                 task_type.get_user_managers() +
+                                 ["input"])
 
         try:
             given_files = extract_files_from_tornado(self.request.files)
@@ -220,7 +220,8 @@ class UserTestHandler(ContestHandler):
 
         try:
             files, language = match_files_and_languages(
-                given_files, given_languages, required, contest.languages)
+                given_files, given_languages, required_codenames,
+                contest.languages)
         except InvalidFilesOrLanguages:
             self._send_error(
                 self._("Invalid test format!"),
@@ -228,12 +229,12 @@ class UserTestHandler(ContestHandler):
             return
 
         file_digests = dict()
-        missing = required.difference(iterkeys(files))
-        if len(missing) > 0:
+        missing_codenames = required_codenames.difference(iterkeys(files))
+        if len(missing_codenames) > 0:
             if task.active_dataset.task_type_object.ALLOW_PARTIAL_SUBMISSION:
                 file_digests = fetch_file_digests_from_previous_submission(
-                    self.sql_session, participation, task, language, missing,
-                    cls=UserTest)
+                    self.sql_session, participation, task, language,
+                    missing_codenames, cls=UserTest)
             else:
                 self._send_error(
                     self._("Invalid test format!"),

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -51,7 +51,7 @@ from cms.grading.languagemanager import get_language
 from cms.server import multi_contest
 from cms.server.contest.submission import get_submission_count, \
     check_max_number, check_min_interval, InvalidArchive, \
-    extract_files_from_tornado, InvalidFilesOrLanguages, \
+    extract_files_from_tornado, InvalidFilesOrLanguage, \
     match_files_and_languages, fetch_file_digests_from_previous_submission
 from cmscommon.crypto import encrypt_number
 from cmscommon.datetime import make_timestamp
@@ -217,7 +217,7 @@ class UserTestHandler(ContestHandler):
             files, language = match_files_and_languages(
                 given_files, self.get_argument("language", None),
                 required_codenames, contest.languages)
-        except InvalidFilesOrLanguages:
+        except InvalidFilesOrLanguage:
             self._send_error(
                 self._("Invalid test format!"),
                 self._("Please select the correct files."))

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -280,7 +280,7 @@ class InvalidFiles(Exception):
     pass
 
 
-def match_file(codename, filename, language, submission_format):
+def _match_file(codename, filename, language, submission_format):
     """Figure out what element of the submission format a file is for.
 
     Return our best guess for which element of the submission format
@@ -341,7 +341,7 @@ def match_file(codename, filename, language, submission_format):
     return candidate_elements.pop()
 
 
-def match_files(given_files, language, submission_format):
+def _match_files(given_files, language, submission_format):
     """Fit the given files into the given submission format.
 
     Figure out, for all of the given files, which element of the
@@ -362,7 +362,7 @@ def match_files(given_files, language, submission_format):
     files = dict()
 
     for codename, filename, content in given_files:
-        codename = match_file(codename, filename, language, submission_format)
+        codename = _match_file(codename, filename, language, submission_format)
         if codename in files:
             raise InvalidFiles(
                 "two files match the same element %r of the submission format"
@@ -467,7 +467,7 @@ def match_files_and_languages(given_files, given_language_name,
     for language in candidate_languages:
         try:
             matched_files_by_language[language] = \
-                match_files(given_files, language, submission_format)
+                _match_files(given_files, language, submission_format)
         except InvalidFiles as err:
             invalidity_reasons.append("%r: %s" % (
                 language.name if language is not None else None, err))

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -36,12 +36,19 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from future.builtins.disabled import *  # noqa
 from future.builtins import *  # noqa
+from six import iterkeys, iteritems
 
+import io
 import logging
+import os.path
+from collections import namedtuple
 
+from patoolib.util import PatoolError
 from sqlalchemy import func, desc
 
-from cms.db import Submission, Task
+from cms.db import Submission, Task, UserTest
+from cms.grading.languagemanager import LANGUAGES, get_language
+from cmscommon.archive import Archive
 
 
 logger = logging.getLogger(__name__)
@@ -180,5 +187,353 @@ def check_min_interval(
         return True
     submission = get_latest_submission(
         sql_session, participation, contest=contest, task=task, cls=cls)
-    return submission is None \
-           or (timestamp - submission.timestamp >= min_interval)
+    return (submission is None
+            or timestamp - submission.timestamp >= min_interval)
+
+
+# Represents a file received through HTTP from an HTML form: codename
+# is the name of the form field (in our case it's the filename-with-%l)
+# and filename is the name of the file had on the user's system.
+ReceivedFile = namedtuple("ReceivedFile", ["codename", "filename", "content"])
+
+
+class InvalidArchive(Exception):
+    """Raised when the archive submitted by the user cannot be opened."""
+
+    pass
+
+
+def extract_files_from_archive(data):
+    """Return the files contained in the given archive.
+
+    Given the binary data of an archive in any of the formats supported
+    by patool, extract its contents and return them in our format. The
+    archive's contents must be a valid directory structure (i.e., its
+    contents cannot have conflicting/duplicated paths) but the structure
+    will be ignored and the files will be returned with their basename.
+
+    data (bytes): the encoded contents of the archive.
+
+    return ([ReceivedFile]): the files contained in the archive.
+
+    raise (InvalidArchive): if the data doesn't seem to encode an
+        archive, its contents are invalid, or other issues.
+
+    """
+    archive = Archive.from_raw_data(data)
+
+    if archive is None:
+        raise InvalidArchive()
+
+    result = list()
+
+    try:
+        unpacked_dir = archive.unpack()
+        for name in archive.namelist():
+            with io.open(os.path.join(unpacked_dir, name), "rb") as f:
+                result.append(
+                    ReceivedFile(None, os.path.basename(name), f.read()))
+
+    except (PatoolError, EnvironmentError):
+        raise InvalidArchive()
+
+    finally:
+        archive.cleanup()
+
+    return result
+
+
+def extract_files_from_tornado(tornado_files):
+    """Transform some files as received by Tornado into our format.
+
+    Given the files as provided by Tornado on the HTTPServerRequest's
+    files attribute, produce a result in our own format. Also, if the
+    files look like they consist of just a compressed archive, extract
+    it and return its contents instead.
+
+    tornado_files ({str: [tornado.httputil.HTTPFile]}): a bunch of
+        files, in Tornado's format.
+
+    return ([ReceivedFile]): the same bunch of files, in our format
+        (except if it was an archive: then it's the archive's contents).
+
+    raise (InvalidArchive): if there are issues extracting the archive.
+
+    """
+    if len(tornado_files) == 1 and "submission" in tornado_files \
+            and len(tornado_files["submission"]) == 1:
+        return extract_files_from_archive(tornado_files["submission"][0].body)
+
+    else:
+        result = list()
+        for codename, files in iteritems(tornado_files):
+            for f in files:
+                result.append(ReceivedFile(codename, f.filename, f.body))
+
+    return result
+
+
+class InvalidFiles(Exception):
+    """Raised when the submitted files can't be matched to the format."""
+
+    pass
+
+
+def match_file(codename, filename, language, submission_format):
+    """Figure out what element of the submission format a file is for.
+
+    Return our best guess for which element of the submission format
+    the submitted file was meant for. A match occurs when:
+    - the codename matches exactly and if it ends in ".%l" the filename
+      (if given) ends in any of the extensions of the language;
+    - the codename isn't given and the filename matches element of the
+      submission format when we replace its trailing ".%l" (if any) with
+      one of the source extensions of the language.
+
+    codename (str|None): the filename-with-%l, if provided.
+    filename (str|None): the name the contestant gave to the file, if
+        provided.
+    language (Language|None): the language to match against.
+    submission_format ({str}): the task's submission format.
+
+    return (str): the element of the submission format matched by the
+        file.
+
+    raise (InvalidFiles): if there's the slightest uncertainty or
+        ambiguity.
+
+    """
+    if codename is None and filename is None:
+        raise InvalidFiles("need at least one of codename and filename")
+
+    candidate_elements = set()
+    if codename is None:
+        for element in submission_format:
+            if element.endswith(".%l"):
+                if language is None:
+                    raise ValueError(
+                        "language not given when submission format requires it")
+                base = element.rpartition(".")[0]
+                for ext in language.source_extensions:
+                    if filename == base + ext:
+                        candidate_elements.add(element)
+            elif filename == element:
+                candidate_elements.add(element)
+    elif any(element == codename for element in submission_format):
+        if filename is None or not codename.endswith(".%l"):
+            candidate_elements.add(codename)
+        elif language is None:
+            raise ValueError(
+                "language not given when submission format requires it")
+        elif any(filename.endswith(ext) for ext in language.source_extensions):
+            candidate_elements.add(codename)
+
+    if len(candidate_elements) == 0:
+        raise InvalidFiles(
+            "file %r/%r doesn't match any of elements of the submission format"
+            % (codename, filename))
+    elif len(candidate_elements) > 1:
+        raise InvalidFiles(
+            "file %r/%r matches more than one element of the submission format"
+            % (codename, filename))
+
+    return next(iter(candidate_elements))
+
+
+def match_files(given_files, language, submission_format):
+    """Fit the given files into the given submission format.
+
+    Figure out, for all of the given files, which element of the
+    submission format they are for.
+
+    given_files ([ReceivedFile]): the files, as received from the user.
+    language (Language|None): the language to match against.
+    submission_format ({str}): the set of filenames-with-%l that the
+        contestants are required to submit.
+
+    return ({str: bytes}): the mapping from filenames-with-%l to
+        contents.
+
+    raise (InvalidFiles): if there's the slightest uncertainty or
+        ambiguity.
+
+    """
+    files = dict()
+
+    for codename, filename, content in given_files:
+        codename = match_file(codename, filename, language, submission_format)
+        if codename in files:
+            raise InvalidFiles(
+                "fwo files match the same element %r of the submission format"
+                % codename)
+        files[codename] = content
+
+    return files
+
+
+class InvalidFilesOrLanguages(Exception):
+    """Raised when the submitted files or given languages don't make sense."""
+
+    pass
+
+
+def match_files_and_languages(given_files, given_language_names,
+                              submission_format, allowed_language_names):
+    """Figure out what the given files are and which language they're in.
+
+    Take a set of files and a set of languages that these files are
+    claimed to be in and try to make sense of it. That is, the provided
+    information may come from sloppy, untrusted or adversarial sources
+    and this function's duty is to parse and validate it to ensure it
+    conforms to the expected format for a submission. Such a format is
+    given as a set of desired codenames (i.e., filenames with language
+    specific extensions replaced by %l) and a set of allowed languages
+    (if such a limitation is in place). The function tries to be lenient
+    as long as it believes the contestant's intentions are clear.
+
+    The function first figures out which set of candidate languages the
+    submission could be in, then tries to match the data against all of
+    them. If exactly one matches then that match is returned. The
+    languages that are considered are the ones provided by the user (if
+    they exist and are allowed) or, if not provided, all languages
+    (restricted to the allowed ones). If the submission format contains
+    no element ending in ".%l" then the None language is always used
+    (the rest of the arguments still needs to make sense though).
+    Matching a language is done using the match_files function.
+
+    given_files ([ReceivedFile]): the submitted files.
+    given_language_names ({str}|None): a set of languages, for example
+        provided by the contestant, which contains the language the
+        submitted files are in; ideally this would be a singleton (None
+        means this information isn't available and we should guess it).
+    submission_format ({str}): the codenames that the submitted files
+        should be matched to.
+    allowed_language_names ([str]|None): the languages that the result
+        is allowed to have (None means no limitation).
+
+    return ({str: bytes}, Language|None): the mapping from codenames to
+        content, and the language of the submission.
+
+    raise (InvalidFilesOrLanguages): if issues arise when finding a
+        match.
+
+    """
+    if len(given_files) == 0:
+        raise InvalidFilesOrLanguages("no files given")
+
+    if given_language_names is None:
+        if allowed_language_names is not None:
+            candidate_languages = set()
+            for language_name in allowed_language_names:
+                try:
+                    language = get_language(language_name)
+                except KeyError:
+                    pass
+                else:
+                    candidate_languages.add(language)
+        else:
+            candidate_languages = set(LANGUAGES)
+    elif len(given_language_names) == 0:
+        raise InvalidFilesOrLanguages("no language given")
+    else:
+        candidate_languages = set()
+        for language_name in given_language_names:
+            try:
+                language = get_language(language_name)
+            except KeyError:
+                raise InvalidFilesOrLanguages(
+                    "the given language %r isn't a language" % language_name)
+            else:
+                candidate_languages.add(language)
+        if allowed_language_names is not None:
+            forbidden_language_names = \
+                {language.name for language in candidate_languages} \
+                .difference(allowed_language_names)
+            if len(forbidden_language_names) > 0:
+                raise InvalidFilesOrLanguages(
+                    "some given languages %r aren't allowed"
+                    % forbidden_language_names)
+
+    if not any(element.endswith(".%l") for element in submission_format):
+        candidate_languages = {None}
+
+    matched_files_by_language = dict()
+    invalidity_reasons = list()
+    for language in candidate_languages:
+        try:
+            matched_files_by_language[language] = \
+                match_files(given_files, language, submission_format)
+        except InvalidFiles as err:
+            invalidity_reasons.append("%r: %s" % (
+                language.name if language is not None else None, err))
+
+    if len(matched_files_by_language) == 0:
+        raise InvalidFilesOrLanguages(
+            "there isn't any language that matches all the files:\n%s"
+            % (";\n".join(invalidity_reasons)))
+    elif len(matched_files_by_language) > 1:
+        raise InvalidFilesOrLanguages(
+            "there is more than one language that matches all the files: %r"
+            % set(iterkeys(matched_files_by_language)))
+
+    language, files = next(iteritems(matched_files_by_language))
+
+    return files, language
+
+
+def fetch_file_digests_from_previous_submission(
+        sql_session, participation, task, language, codenames, cls=Submission):
+    """Retrieve digests of files with given codenames from latest submission.
+
+    Get the most recent submission of the given contestant on the given
+    task and, if it is of the given language, return the digests of its
+    files that correspond to the given codenames. In case of UserTests
+    lookup also among the user-provided managers.
+
+    sql_session (Session): the SQLAlchemy session to use.
+    participation (Participation): the participation whose submissions
+        should be considered.
+    task (Task): the task whose submissions should be considered.
+    language (Language|None): the language the submission has to be in
+        for the lookup to be allowed.
+    codenames ({str}): the filenames-with-%l that need to be retrieved.
+    cls (type): if the UserTest class is given, lookup user tests rather
+        than submissions.
+
+    return ({str: str}): for every codename, the digest of the file of
+        that codename in the previous submission; if the previous
+        submission didn't have that file it won't be included in the
+        result; if there is no previous submission or if it isn't in the
+        desired language, return an empty result.
+
+    """
+    # FIXME Instead of taking the latest submission *if* it is of the
+    # right language, take the latest *among* those of that language.
+    latest_submission = get_latest_submission(
+        sql_session, participation, task=task, cls=cls)
+
+    language_name = language.name if language is not None else None
+    if latest_submission is None or language_name != latest_submission.language:
+        return dict()
+
+    digests = dict()
+    for codename in codenames:
+        if codename in latest_submission.files:
+            digests[codename] = latest_submission.files[codename].digest
+        elif cls is UserTest:
+            if codename == "input":
+                digests["input"] = latest_submission.input
+            else:
+                if codename.endswith(".%l"):
+                    if language is None:
+                        raise ValueError("language not given when submission "
+                                         "format requires it")
+                    filename = \
+                        codename.rpartition(".")[0] + language.source_extension
+                else:
+                    filename = codename
+                if filename in latest_submission.managers:
+                    digests[codename] = \
+                        latest_submission.managers[filename].digest
+
+    return digests

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -449,7 +449,9 @@ def match_files_and_languages(given_files, given_language_name,
     # If a language is needed but the caller didn't provide any we try
     # to auto-detect it by guessing among all allowed languages.
     else:
-        if allowed_language_names is not None:
+        if allowed_language_names is None:
+            candidate_languages = set(LANGUAGES)
+        else:
             candidate_languages = set()
             for language_name in allowed_language_names:
                 try:
@@ -458,8 +460,6 @@ def match_files_and_languages(given_files, given_language_name,
                     pass
                 else:
                     candidate_languages.add(language)
-        else:
-            candidate_languages = set(LANGUAGES)
 
     matched_files_by_language = dict()
     invalidity_reasons = list()

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -320,7 +320,7 @@ def match_file(codename, filename, language, submission_format):
                         candidate_elements.add(element)
             elif filename == element:
                 candidate_elements.add(element)
-    elif any(element == codename for element in submission_format):
+    elif codename in submission_format:
         if filename is None or not codename.endswith(".%l"):
             candidate_elements.add(codename)
         elif language is None:

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -267,12 +267,10 @@ def extract_files_from_tornado(tornado_files):
             and len(tornado_files["submission"]) == 1:
         return extract_files_from_archive(tornado_files["submission"][0].body)
 
-    else:
-        result = list()
-        for codename, files in iteritems(tornado_files):
-            for f in files:
-                result.append(ReceivedFile(codename, f.filename, f.body))
-
+    result = list()
+    for codename, files in iteritems(tornado_files):
+        for f in files:
+            result.append(ReceivedFile(codename, f.filename, f.body))
     return result
 
 

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -372,7 +372,7 @@ def match_files(given_files, language, submission_format):
     return files
 
 
-class InvalidFilesOrLanguages(Exception):
+class InvalidFilesOrLanguage(Exception):
     """Raised when the submitted files or given languages don't make sense."""
 
     pass
@@ -420,14 +420,14 @@ def match_files_and_languages(given_files, given_language_name,
 
     """
     if len(given_files) == 0:
-        raise InvalidFilesOrLanguages("no files given")
+        raise InvalidFilesOrLanguage("no files given")
 
     # If the submission format is language-agnostic the only "language"
     # that makes sense is None, and if the caller thought differently we
     # let them know.
     if not any(element.endswith(".%l") for element in submission_format):
         if given_language_name is not None:
-            raise InvalidFilesOrLanguages(
+            raise InvalidFilesOrLanguage(
                 "a language %r is given when not needed" % given_language_name)
         candidate_languages = {None}
 
@@ -437,12 +437,12 @@ def match_files_and_languages(given_files, given_language_name,
         try:
             language = get_language(given_language_name)
         except KeyError:
-            raise InvalidFilesOrLanguages(
+            raise InvalidFilesOrLanguage(
                 "the given language %r isn't a language" % given_language_name)
 
         if allowed_language_names is not None \
                 and language.name not in allowed_language_names:
-            raise InvalidFilesOrLanguages(
+            raise InvalidFilesOrLanguage(
                 "the given language %r isn't allowed" % given_language_name)
 
         candidate_languages = {language}
@@ -473,11 +473,11 @@ def match_files_and_languages(given_files, given_language_name,
                 language.name if language is not None else None, err))
 
     if len(matched_files_by_language) == 0:
-        raise InvalidFilesOrLanguages(
+        raise InvalidFilesOrLanguage(
             "there isn't any language that matches all the files:\n%s"
             % (";\n".join(invalidity_reasons)))
     elif len(matched_files_by_language) > 1:
-        raise InvalidFilesOrLanguages(
+        raise InvalidFilesOrLanguage(
             "there is more than one language that matches all the files: %r"
             % set(iterkeys(matched_files_by_language)))
 

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -338,7 +338,7 @@ def match_file(codename, filename, language, submission_format):
             "file %r/%r matches more than one element of the submission format"
             % (codename, filename))
 
-    return next(iter(candidate_elements))
+    return candidate_elements.pop()
 
 
 def match_files(given_files, language, submission_format):

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -228,12 +228,13 @@ def extract_files_from_archive(data):
     result = list()
 
     try:
-        unpacked_dir = archive.unpack()
+        archive.unpack()
         for name in archive.namelist():
-            with io.open(os.path.join(unpacked_dir, name), "rb") as f:
+            with archive.read(name) as f:
                 result.append(
                     ReceivedFile(None, os.path.basename(name), f.read()))
 
+    # When dropping py2, replace EnvironmentError by OSError.
     except (PatoolError, EnvironmentError):
         raise InvalidArchive()
 

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -190,9 +190,11 @@ def check_min_interval(
             or timestamp - submission.timestamp >= min_interval)
 
 
-# Represents a file received through HTTP from an HTML form: codename
-# is the name of the form field (in our case it's the filename-with-%l)
-# and filename is the name of the file had on the user's system.
+# Represents a file received through HTTP from an HTML form.
+# codename (str|None): the name of the form field (in our case it's the
+#   filename-with-%l).
+# filename (str|None): the name the file had on the user's system.
+# content (bytes): the data of the file.
 ReceivedFile = namedtuple("ReceivedFile", ["codename", "filename", "content"])
 
 
@@ -211,9 +213,10 @@ def extract_files_from_archive(data):
     contents cannot have conflicting/duplicated paths) but the structure
     will be ignored and the files will be returned with their basename.
 
-    data (bytes): the encoded contents of the archive.
+    data (bytes): the raw contents of the archive.
 
-    return ([ReceivedFile]): the files contained in the archive.
+    return ([ReceivedFile]): the files contained in the archive, with
+        their filename filled in but their codename set to None.
 
     raise (InvalidArchive): if the data doesn't seem to encode an
         archive, its contents are invalid, or other issues.
@@ -284,11 +287,11 @@ def match_file(codename, filename, language, submission_format):
 
     Return our best guess for which element of the submission format
     the submitted file was meant for. A match occurs when:
+    - the codename isn't given and the filename matches an element of
+      the submission format when we replace the latter's trailing ".%l"
+      (if any) with one of the source extensions of the language;
     - the codename matches exactly and if it ends in ".%l" the filename
-      (if given) ends in any of the extensions of the language;
-    - the codename isn't given and the filename matches element of the
-      submission format when we replace its trailing ".%l" (if any) with
-      one of the source extensions of the language.
+      (if given) ends in any of the extensions of the language.
 
     codename (str|None): the filename-with-%l, if provided.
     filename (str|None): the name the contestant gave to the file, if

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -38,7 +38,6 @@ from future.builtins.disabled import *  # noqa
 from future.builtins import *  # noqa
 from six import iterkeys, iteritems
 
-import io
 import logging
 import os.path
 from collections import namedtuple

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -314,7 +314,7 @@ def match_file(codename, filename, language, submission_format):
                 if language is None:
                     raise ValueError(
                         "language not given when submission format requires it")
-                base = element.rpartition(".")[0]
+                base = os.path.splitext(element)[0]
                 for ext in language.source_extensions:
                     if filename == base + ext:
                         candidate_elements.add(element)

--- a/cms/server/contest/submission.py
+++ b/cms/server/contest/submission.py
@@ -365,7 +365,7 @@ def match_files(given_files, language, submission_format):
         codename = match_file(codename, filename, language, submission_format)
         if codename in files:
             raise InvalidFiles(
-                "fwo files match the same element %r of the submission format"
+                "two files match the same element %r of the submission format"
                 % codename)
         files[codename] = content
 

--- a/cmstestsuite/unit_tests/databasemixin.py
+++ b/cmstestsuite/unit_tests/databasemixin.py
@@ -60,7 +60,7 @@ from cmstestsuite.unit_tests.testidgenerator import unique_long_id, \
 from cms.db import Announcement, Base, Contest, Dataset, Evaluation, \
     Executable, File, Message, Participation, Question, Session, Statement, \
     Submission, SubmissionResult, Task, Team, Testcase, User, UserTest, \
-    UserTestResult, drop_db, init_db, Token
+    UserTestResult, drop_db, init_db, Token, UserTestFile, UserTestManager
 from cms.db.filecacher import DBBackend
 
 
@@ -419,6 +419,34 @@ class DatabaseMixin(object):
         user_test = UserTest(**args)
         self.session.add(user_test)
         return user_test
+
+    def add_user_test_file(self, user_test=None, **kwargs):
+        """Create a user test file and add it to the session"""
+        if user_test is None:
+            user_test = self.add_user_test()
+        args = {
+            "user_test": user_test,
+            "filename": unique_unicode_id(),
+            "digest": unique_digest(),
+        }
+        args.update(kwargs)
+        user_test_file = UserTestFile(**args)
+        self.session.add(user_test_file)
+        return user_test_file
+
+    def add_user_test_manager(self, user_test=None, **kwargs):
+        """Create a user test manager and add it to the session"""
+        if user_test is None:
+            user_test = self.add_user_test()
+        args = {
+            "user_test": user_test,
+            "filename": unique_unicode_id(),
+            "digest": unique_digest(),
+        }
+        args.update(kwargs)
+        user_test_manager = UserTestManager(**args)
+        self.session.add(user_test_manager)
+        return user_test_manager
 
     def add_user_test_result(self, user_test=None, dataset=None, **kwargs):
         """Add a user test result."""

--- a/cmstestsuite/unit_tests/server/contest/submission_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission_test.py
@@ -611,6 +611,8 @@ def make_language(name, source_extensions):
 C_LANG = make_language("C", [".c"])
 # Has many extensions.
 CPP_LANG = make_language("C++", [".cpp", ".cxx", ".cc"])
+# Has an extension that doesn't begin with a period.
+PASCAL_LANG = make_language("Pascal", [".pas", "lib.pas"])
 # Have the same extensions.
 PY2_LANG = make_language("Py2", [".py"])
 PY3_LANG = make_language("Py3", [".py"])
@@ -759,6 +761,24 @@ class TestMatchFilesAndLanguages(unittest.TestCase):
             match_files_and_languages(
                 [ReceivedFile("foo.%l", "foo.cpp", FOO_CONTENT)],
                 {"C"}, {"foo.%l"}, None)
+
+    def test_extension_without_leading_period(self):
+        self.languages.update({PASCAL_LANG})
+
+        # Check that the *whole* trailing `.%l` string is replaced with
+        # the extension, not just the `%l` part, and also check that the
+        # function doesn't split the extension on the filename.
+        files, language = match_files_and_languages(
+            [ReceivedFile(None, "foolib.pas", FOO_CONTENT)],
+            None, {"foo.%l"}, None)
+        self.assertEqual(files, {"foo.%l": FOO_CONTENT})
+        self.assertIs(language, PASCAL_LANG)
+
+        # This must of course hold also when it would cause ambiguities.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile(None, "foolib.pas", FOO_CONTENT)],
+                None, {"foo.%l", "foolib.%l"}, None)
 
     def test_duplicate_files(self):
         self.languages.update({C_LANG})

--- a/cmstestsuite/unit_tests/server/contest/submission_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission_test.py
@@ -612,7 +612,7 @@ C_LANG = make_language("C", [".c"])
 # Has many extensions.
 CPP_LANG = make_language("C++", [".cpp", ".cxx", ".cc"])
 # Has an extension that doesn't begin with a period.
-PASCAL_LANG = make_language("Pascal", [".pas", "lib.pas"])
+PASCAL_LANG = make_language("Pascal", ["lib.pas"])
 # Have the same extensions.
 PY2_LANG = make_language("Py2", [".py"])
 PY3_LANG = make_language("Py3", [".py"])
@@ -774,11 +774,14 @@ class TestMatchFilesAndLanguages(unittest.TestCase):
         self.assertEqual(files, {"foo.%l": FOO_CONTENT})
         self.assertIs(language, PASCAL_LANG)
 
-        # This must of course hold also when it would cause ambiguities.
-        with self.assertRaises(InvalidFilesOrLanguages):
-            match_files_and_languages(
-                [ReceivedFile(None, "foolib.pas", FOO_CONTENT)],
-                None, {"foo.%l", "foolib.%l"}, None)
+        # This must also hold when the filename isn't matched against
+        # the submission format (because the codename is used for that)
+        # but just its extension is checked.
+        files, language = match_files_and_languages(
+            [ReceivedFile("foo.%l", "foolib.pas", FOO_CONTENT)],
+            None, {"foo.%l"}, None)
+        self.assertEqual(files, {"foo.%l": FOO_CONTENT})
+        self.assertIs(language, PASCAL_LANG)
 
     def test_duplicate_files(self):
         self.languages.update({C_LANG})

--- a/cmstestsuite/unit_tests/server/contest/submission_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission_test.py
@@ -27,19 +27,29 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from future.builtins.disabled import *
 from future.builtins import *
+import six
+from six import iteritems
 
+import io
+import tarfile
 import unittest
+import zipfile
+from collections import namedtuple
 from datetime import timedelta
 
-from mock import call, patch
+from mock import call, patch, MagicMock
 
 # Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Submission, UserTest
 from cms.server.contest.submission import get_submission_count, \
-    check_max_number, get_latest_submission, check_min_interval
+    check_max_number, get_latest_submission, check_min_interval, \
+    ReceivedFile, InvalidArchive, extract_files_from_archive, \
+    extract_files_from_tornado, InvalidFilesOrLanguages, \
+    match_files_and_languages, fetch_file_digests_from_previous_submission
 from cmscommon.datetime import make_datetime
+from cmstestsuite.unit_tests.testidgenerator import unique_digest
 
 
 class TestGetSubmissionCount(DatabaseMixin, unittest.TestCase):
@@ -408,6 +418,781 @@ class TestCheckMinInterval(DatabaseMixin, unittest.TestCase):
             4, 11, contest=self.contest, task=self.task, cls=UserTest))
         # Having calls signals an inefficiency.
         self.get_latest_submission.assert_not_called()
+
+
+# These tests are, to some extent, tests for the Archive class as well.
+class TestExtractFilesFromArchive(unittest.TestCase):
+
+    def test_zip(self):
+        archive_data = io.BytesIO()
+        with zipfile.ZipFile(archive_data, "w",
+                             compression=zipfile.ZIP_DEFLATED) as f:
+            f.writestr("foo.c", b"some content")
+            f.writestr("foo", b"some other content")
+            f.writestr("foo.%l", b"more content")
+        six.assertCountEqual(
+            self, extract_files_from_archive(archive_data.getvalue()), [
+                ReceivedFile(None, "foo.c", b"some content"),
+                ReceivedFile(None, "foo", b"some other content"),
+                ReceivedFile(None, "foo.%l", b"more content")])
+
+    def test_tar_gz(self):
+        files = [ReceivedFile(None, "foo.c", b"some content"),
+                 ReceivedFile(None, "foo", b"some other content"),
+                 ReceivedFile(None, "foo.%l", b"more content")]
+        archive_data = io.BytesIO()
+        with tarfile.open(fileobj=archive_data, mode="w:gz") as f:
+            for _, filename, content in files:
+                fileobj = io.BytesIO(content)
+                tarinfo = tarfile.TarInfo(filename)
+                tarinfo.size = len(content)
+                f.addfile(tarinfo, fileobj)
+        six.assertCountEqual(
+            self, extract_files_from_archive(archive_data.getvalue()), files)
+
+    def test_failure(self):
+        with self.assertRaises(InvalidArchive):
+            extract_files_from_archive(b"this is not a valid archive")
+
+    # Make sure we ignore the directory structure and only use the
+    # trailing component (i.e., the basename) in the return value, even
+    # if it leads to duplicated filenames.
+    def test_directories(self):
+        archive_data = io.BytesIO()
+        with zipfile.ZipFile(archive_data, "w",
+                             compression=zipfile.ZIP_DEFLATED) as f:
+            f.writestr("toplevel", b"some content")
+            f.writestr("nested/once", b"some other content")
+            f.writestr("two/levels/deep", b"more content")
+            f.writestr("many/levels/deep", b"moar content")
+        six.assertCountEqual(
+            self, extract_files_from_archive(archive_data.getvalue()),
+            [ReceivedFile(None, "toplevel", b"some content"),
+             ReceivedFile(None, "once", b"some other content"),
+             ReceivedFile(None, "deep", b"more content"),
+             ReceivedFile(None, "deep", b"moar content")])
+
+    # This is an expected and most likely unproblematic behavior.
+    def test_filename_with_null(self):
+        archive_data = io.BytesIO()
+        with zipfile.ZipFile(archive_data, "w") as f:
+            f.writestr("foo\0bar", b"some content")
+        six.assertCountEqual(
+            self, extract_files_from_archive(archive_data.getvalue()),
+            [ReceivedFile(None, "foo", b"some content")])
+
+    # This is a quite unexpected behavior: luckily in practice it should
+    # have no effect as the elements of the submission format aren't
+    # allowed to be empty and thus the submission would be rejected
+    # anyways. It also shouldn't leak any private information.
+    # This actually only happens when patool uses 7z (which happens if
+    # it is found installed). Otherwise it falls back on Python's
+    # zipfile module which outright fails.
+    @unittest.expectedFailure
+    def test_empty_filename(self):
+        archive_data = io.BytesIO()
+        with zipfile.ZipFile(archive_data, "w") as f:
+            # Need ZipInfo because of "bug" in writestr.
+            f.writestr(zipfile.ZipInfo(""), b"some content")
+        res = extract_files_from_archive(archive_data.getvalue())
+        self.assertEqual(len(res), 1)
+        f = res[0]
+        self.assertIsNone(f.codename)
+        # The extracted file is named like the temporary file where the
+        # archive's contents were copied to, plus a trailing tilde.
+        six.assertRegex(self, f.filename, "tmp[a-z0-9_]+~")
+        self.assertEqual(f.content, b"some content")
+
+    # This is a (probably expected and) desirable behavior.
+    def test_multiple_slashes_are_compressed(self):
+        archive_data = io.BytesIO()
+        with zipfile.ZipFile(archive_data, "w") as f:
+            f.writestr("foo//bar", b"some content")
+        six.assertCountEqual(
+            self, extract_files_from_archive(archive_data.getvalue()),
+            [ReceivedFile(None, "bar", b"some content")])
+
+    # This should check that the extracted files cannot "escape" from
+    # the temporary directory where they are being extracted to.
+    def test_weird_filenames(self):
+        filenames = ["../foo/bar", "/foo/bar"]
+        for filename in filenames:
+            archive_data = io.BytesIO()
+            with zipfile.ZipFile(archive_data, "w") as f:
+                f.writestr(filename, b"some content")
+            six.assertCountEqual(
+                self, extract_files_from_archive(archive_data.getvalue()),
+                [ReceivedFile(None, "bar", b"some content")])
+
+    # This is an unnecessary limitation due to the fact that patool does
+    # extract files to the actual filesystem. We could avoid it by using
+    # zipfile, tarfile, etc. directly but it would be too burdensome to
+    # support the same amount of archive types as patool does.
+    def test_conflicting_filenames(self):
+        archive_data = io.BytesIO()
+        with zipfile.ZipFile(archive_data, "w") as f:
+            f.writestr("foo", b"some content")
+            f.writestr("foo/bar", b"more content")
+        with self.assertRaises(InvalidArchive):
+            extract_files_from_archive(archive_data.getvalue())
+
+
+MockHTTPFile = namedtuple("MockHTTPFile", ["filename", "body"])
+
+
+class TestExtractFilesFromTornado(unittest.TestCase):
+
+    def setUp(self):
+        super(TestExtractFilesFromTornado, self).setUp()
+
+        patcher = \
+            patch("cms.server.contest.submission.extract_files_from_archive")
+        self.extract_files_from_archive = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_empty(self):
+        self.assertEqual(extract_files_from_tornado(dict()), list())
+
+    def test_success(self):
+        tornado_files = {
+            "foo.%l": [MockHTTPFile("foo.py", b"some python stuff")],
+            "bar.%l": [MockHTTPFile("bar.c", b"one file in C"),
+                       MockHTTPFile("bar.cxx", b"the same file in C++")],
+            # Make sure that empty lists have no effect.
+            "baz": []}
+        six.assertCountEqual(self, extract_files_from_tornado(tornado_files), [
+            ReceivedFile("foo.%l", "foo.py", b"some python stuff"),
+            ReceivedFile("bar.%l", "bar.c", b"one file in C"),
+            ReceivedFile("bar.%l", "bar.cxx", b"the same file in C++")])
+
+    def test_not_archive_if_other_codenames(self):
+        tornado_files = {
+            "submission": [MockHTTPFile("sub.zip", b"this is an archive")],
+            "foo.%l": [MockHTTPFile("foo.c", b"this is something else")]}
+        six.assertCountEqual(self, extract_files_from_tornado(tornado_files), [
+            ReceivedFile("submission", "sub.zip", b"this is an archive"),
+            ReceivedFile("foo.%l", "foo.c", b"this is something else")])
+
+    def test_not_archive_if_other_files(self):
+        tornado_files = {
+            "submission": [MockHTTPFile("sub.zip", b"this is an archive"),
+                           MockHTTPFile("sub2.zip", b"this is another one")]}
+        six.assertCountEqual(self, extract_files_from_tornado(tornado_files), [
+            ReceivedFile("submission", "sub.zip", b"this is an archive"),
+            ReceivedFile("submission", "sub2.zip", b"this is another one")])
+
+    def test_good_archive(self):
+        tornado_files = {
+            "submission": [MockHTTPFile("archive.zip", b"this is an archive")]}
+        self.assertIs(extract_files_from_tornado(tornado_files),
+                      self.extract_files_from_archive.return_value)
+        self.extract_files_from_archive.assert_called_once_with(
+            b"this is an archive")
+
+    def test_bad_archive(self):
+        tornado_files = {
+            "submission": [MockHTTPFile("archive.zip",
+                                        b"this is not a valid archive")]}
+        self.extract_files_from_archive.side_effect = InvalidArchive
+        with self.assertRaises(InvalidArchive):
+            extract_files_from_tornado(tornado_files)
+        self.extract_files_from_archive.assert_called_once_with(
+            b"this is not a valid archive")
+
+
+def make_language(name, source_extensions):
+    language = MagicMock()
+    language.configure_mock(name=name,
+                            source_extensions=source_extensions,
+                            source_extension=source_extensions[0])
+    return language
+
+
+C_LANG = make_language("C", [".c"])
+# Has many extensions.
+CPP_LANG = make_language("C++", [".cpp", ".cxx", ".cc"])
+# Have the same extensions.
+PY2_LANG = make_language("Py2", [".py"])
+PY3_LANG = make_language("Py3", [".py"])
+# Have extensions that create a weird corner case.
+LONG_OVERLAP_LANG = make_language("LongOverlap", [".suf.fix"])
+SHORT_OVERLAP_LANG = make_language("ShortOverlap", [".fix"])
+# The two in one.
+SELF_OVERLAP_LANG = make_language("SelfOverlap", [".suf.fix", ".fix"])
+
+FOO_CONTENT = b"this is the content of a file"
+BAR_CONTENT = b"this is the content of another file"
+BAZ_CONTENT = b"this is the content of a third file"
+SPAM_CONTENT = b"this is the content of a fourth file"
+HAM_CONTENT = b"this is the content of a fifth file"
+EGGS_CONTENT = b"this is the content of a sixth file"
+
+
+class TestMatchFilesAndLanguages(unittest.TestCase):
+
+    def setUp(self):
+        super(TestMatchFilesAndLanguages, self).setUp()
+
+        self.languages = set()
+
+        patcher = patch("cms.server.contest.submission.LANGUAGES",
+                        self.languages)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch("cms.server.contest.submission.get_language",
+                        self.mock_get_language)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def mock_get_language(self, language_name):
+        for language in self.languages:
+            if language.name == language_name:
+                return language
+        raise KeyError()
+
+    # Test success scenarios.
+
+    def test_success_language_required(self):
+        self.languages.update({C_LANG, CPP_LANG})
+
+        # Both languageful and languageless files with and without
+        # codename and filename are matched correctly against a
+        # language-specific submission format.
+        # Also check that when the codename matches the "extensionless"
+        # filename is irrelevant (the extension matters, however).
+        files, language = match_files_and_languages(
+            [ReceivedFile("foo.%l", "my_name.cpp", FOO_CONTENT),
+             ReceivedFile("bar.%l", None, BAR_CONTENT),
+             ReceivedFile(None, "baz.cc", BAZ_CONTENT),
+             ReceivedFile("spam.txt", "my_other_name", SPAM_CONTENT),
+             ReceivedFile("eggs.zip", None, HAM_CONTENT),
+             ReceivedFile(None, "ham", EGGS_CONTENT)],
+            None,
+            {"foo.%l", "bar.%l", "baz.%l",
+             "spam.txt", "eggs.zip", "ham",
+             "superfluous"},
+            None)
+        self.assertEqual(files, {"foo.%l": FOO_CONTENT,
+                                 "bar.%l": BAR_CONTENT,
+                                 "baz.%l": BAZ_CONTENT,
+                                 "spam.txt": SPAM_CONTENT,
+                                 "eggs.zip": HAM_CONTENT,
+                                 "ham": EGGS_CONTENT})
+        self.assertIs(language, CPP_LANG)
+
+    def test_success_language_agnostic(self):
+        self.languages.update({C_LANG, CPP_LANG})
+
+        # Languageless files with and without codename and filename are
+        # matched correctly against a language-agnostic submission
+        # format.
+        files, language = match_files_and_languages(
+            [ReceivedFile("foo.txt", "my_name", FOO_CONTENT),
+             ReceivedFile("bar.zip", None, BAR_CONTENT),
+             ReceivedFile(None, "baz", BAZ_CONTENT)],
+            None,
+            {"foo.txt", "bar.zip", "baz",
+             "superfluous"},
+            None)
+        self.assertEqual(files, {"foo.txt": FOO_CONTENT,
+                                 "bar.zip": BAR_CONTENT,
+                                 "baz": BAZ_CONTENT})
+        self.assertIsNone(language)
+
+    # Test support for language-agnostic formats.
+
+    def test_language_agnostic_always_possible(self):
+        self.languages.update({C_LANG, CPP_LANG})
+
+        # Even if language candidates are given, they are superseded by
+        # the implicit None when applicable.
+        files, language = match_files_and_languages(
+            [ReceivedFile("foo.txt", None, FOO_CONTENT)],
+            {"C"}, {"foo.txt", "bar.zip"}, None)
+        self.assertEqual(files, {"foo.txt": FOO_CONTENT})
+        self.assertIsNone(language)
+
+        # Even if a set of allowed languages is given, None (when
+        # applicable) is always allowed.
+        files, language = match_files_and_languages(
+            [ReceivedFile("foo.txt", None, FOO_CONTENT)],
+            None, {"foo.txt", "bar.zip"}, ["C++"])
+        self.assertEqual(files, {"foo.txt": FOO_CONTENT})
+        self.assertIsNone(language)
+
+    # Tests for issues matching files.
+
+    def test_bad_file(self):
+        self.languages.update({C_LANG})
+
+        # Different codename.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", None, FOO_CONTENT)],
+                {"C"}, {"bar.%l"}, None)
+
+        # Incompatible filename.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile(None, "foo.c", FOO_CONTENT)],
+                {"C"}, {"bar.%l"}, None)
+
+        # The same in a language-agnostic setting.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.txt", None, FOO_CONTENT)],
+                None, {"bar.txt"}, None)
+
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile(None, "foo.txt", FOO_CONTENT)],
+                None, {"bar.txt"}, None)
+
+    def test_bad_extension(self):
+        self.languages.update({C_LANG})
+
+        # Even when the codename (and, here, but not necessarily, the
+        # extensionless filename) match, the filename's extension needs
+        # to be compatible with the language.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "foo.cpp", FOO_CONTENT)],
+                {"C"}, {"foo.%l"}, None)
+
+    def test_duplicate_files(self):
+        self.languages.update({C_LANG})
+
+        # If two files match the same codename (even if through
+        # different means) then the match is invalid.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "bar.c", FOO_CONTENT),
+                 ReceivedFile(None, "foo.c", BAR_CONTENT)],
+                None, {"foo.%l"}, None)
+
+    def test_ambiguous_file(self):
+        self.languages.update({C_LANG, CPP_LANG})
+
+        # For an admittedly weird submission format, a single file could
+        # successfully match multiple elements.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile(None, "foo.c", FOO_CONTENT)],
+                {"C"}, {"foo.%l", "foo.c"}, None)
+
+        # This brings in some weird side-effects, for example matching
+        # an unexpected language as it's the only one left.
+        files, language = match_files_and_languages(
+            [ReceivedFile(None, "foo.c", FOO_CONTENT)],
+            {"C", "C++"}, {"foo.%l", "foo.c"}, None)
+        self.assertEqual(files, {"foo.c": FOO_CONTENT})
+        self.assertIs(language, CPP_LANG)
+
+        # And although in theory it could be disambiguated in some cases
+        # if one were smart enough, we aren't.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "bar.c", FOO_CONTENT),
+                 ReceivedFile(None, "foo.c", FOO_CONTENT)],
+                {"C"}, {"foo.%l", "foo.c"}, None)
+
+    def test_ambiguous_file_2(self):
+        self.languages.update(
+            {SELF_OVERLAP_LANG, LONG_OVERLAP_LANG, SHORT_OVERLAP_LANG})
+
+        # For an even weirder language and submission format, a single
+        # file could successfully match two language-specific elements
+        # of the submission format.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile(None, "foo.suf.fix", FOO_CONTENT)],
+                {"SelfOverlap"}, {"foo.%l", "foo.suf.%l"}, None)
+
+        # Wow, much overlap, very ambiguous.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile(None, "foo.suf.fix", FOO_CONTENT)],
+                {"SelfOverlap", "LongOverlap", "ShortOverlap"},
+                {"foo.%l", "foo.suf.%l"}, None)
+
+        # I'm doing this just for the fun.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile(None, "foo.suf.fix", FOO_CONTENT)],
+                {"SelfOverlap", "LongOverlap", "ShortOverlap"},
+                {"foo.%l"}, None)
+
+    # Tests for language issues and ways to solve them.
+
+    def test_forbidden_language(self):
+        self.languages.update({C_LANG, CPP_LANG})
+
+        # The (autoguessed) language that would match is forbidden.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "foo.c", FOO_CONTENT)],
+                None, {"foo.%l"}, ["C++", "Py2"])
+
+        # The same if the language is given.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "foo.c", FOO_CONTENT)],
+                {"C"}, {"foo.%l"}, ["C++", "Py2"])
+
+        # It fails also if any of the given languages is forbidden, even
+        # if some other one is given, allowed and matches.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "foo.c", FOO_CONTENT)],
+                {"C", "C++"}, {"foo.%l"}, ["C", "Py2"])
+
+    def test_missing_extensions(self):
+        self.languages.update({C_LANG, CPP_LANG})
+        given_files = [ReceivedFile("foo.%l", None, FOO_CONTENT)]
+        submission_format = {"foo.%l"}
+
+        # The situation is ambiguous: it matches for every language, as
+        # there is no extension to clarify and no language is given.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                given_files, None, submission_format, None)
+
+        # Restricting the candidates fixes it.
+        files, language = match_files_and_languages(
+            given_files, {"C"}, submission_format, None)
+        self.assertEqual(files, {"foo.%l": FOO_CONTENT})
+        self.assertIs(language, C_LANG)
+
+        # So does limiting the allowed languages.
+        files, language = match_files_and_languages(
+            given_files, None, submission_format, ["C++"])
+        self.assertEqual(files, {"foo.%l": FOO_CONTENT})
+        self.assertIs(language, CPP_LANG)
+
+    def test_ambiguous_extensions(self):
+        self.languages.update({PY2_LANG, PY3_LANG})
+        given_files = [ReceivedFile("foo.%l", "foo.py", FOO_CONTENT)]
+        submission_format = {"foo.%l"}
+
+        # The situation is ambiguous: both languages match the
+        # extension.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                given_files, None, submission_format, None)
+
+        # Restricting the candidates fixes it.
+        files, language = match_files_and_languages(
+            given_files, {"Py2"}, submission_format, None)
+        self.assertEqual(files, {"foo.%l": FOO_CONTENT})
+        self.assertIs(language, PY2_LANG)
+
+        # So does limiting the allowed languages.
+        files, language = match_files_and_languages(
+            given_files, None, submission_format, ["Py3"])
+        self.assertEqual(files, {"foo.%l": FOO_CONTENT})
+        self.assertIs(language, PY3_LANG)
+
+    def test_overlapping_extensions(self):
+        self.languages.update({LONG_OVERLAP_LANG, SHORT_OVERLAP_LANG})
+        given_files = [ReceivedFile(None, "foo.suf.fix", FOO_CONTENT)]
+        submission_format = {"foo.%l", "foo.suf.%l"}
+
+        # The situation is ambiguous: both languages match, although
+        # each does so to a different element of the submission format.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                given_files, None, submission_format, None)
+
+        # Restricting the candidates fixes it.
+        files, language = match_files_and_languages(
+            given_files, {"LongOverlap"}, submission_format, None)
+        self.assertEqual(files, {"foo.%l": FOO_CONTENT})
+        self.assertIs(language, LONG_OVERLAP_LANG)
+
+        # So does limiting the allowed languages.
+        files, language = match_files_and_languages(
+            given_files, None, submission_format, ["ShortOverlap"])
+        self.assertEqual(files, {"foo.suf.%l": FOO_CONTENT})
+        self.assertIs(language, SHORT_OVERLAP_LANG)
+
+    # Test some corner cases.
+
+    def test_neither_codename_nor_filename(self):
+        self.languages.update({C_LANG})
+
+        # Without neither codename nor filename, there's nothing to base
+        # a match on.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile(None, None, FOO_CONTENT)],
+                {"C"}, {"foo.%l"}, None)
+
+    def test_nonexisting_given_languages(self):
+        self.languages.update({C_LANG, CPP_LANG})
+
+        # Passing a language that doesn't exist means the contestant
+        # doesn't know what they are doing: we're not following through.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "foo.c", FOO_CONTENT)],
+                {"C", "BadLang"}, {"foo.%l"}, None)
+
+    def test_nonexisting_allowed_languages(self):
+        self.languages.update({C_LANG, CPP_LANG})
+
+        # Non-existing languages among the allowed languages are seen as
+        # a configuration error: admins should intervene but contestants
+        # shouldn't suffer, and thus these items are simply ignored.
+        # Both when used to constitute the candidates (as no candidates
+        # were given)...
+        files, language = match_files_and_languages(
+            [ReceivedFile("foo.%l", "foo.c", FOO_CONTENT)],
+            None, {"foo.%l"}, ["C", "BadLang"])
+        self.assertEqual(files, {"foo.%l": FOO_CONTENT})
+        self.assertIs(language, C_LANG)
+
+        # And when they act as filter for the given candidates.
+        files, language = match_files_and_languages(
+            [ReceivedFile("foo.%l", "foo.c", FOO_CONTENT)],
+            {"C"}, {"foo.%l"}, ["C", "BadLang"])
+        self.assertEqual(files, {"foo.%l": FOO_CONTENT})
+        self.assertIs(language, C_LANG)
+
+    def test_given_files_empty(self):
+        self.languages.update({C_LANG, CPP_LANG})
+
+        # No files vacuously match every submission format for every
+        # language, hence this is ambiguous.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                list(), None, {"foo.%l"}, None)
+
+        # For just a single fixed language it could be considered valid,
+        # however in the best case it would be rejected later because
+        # some (all) files are missing and in the worst case the files
+        # from the previous submission would be fetched: no reasonable
+        # user could have meant this on purpose, we reject.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                list(), {"C"}, {"foo.%l"}, None)
+
+        # The same holds for a language-agnostic submission format:
+        # moreover, in that case there wouldn't be any ambiguity from
+        # the start as only one "language" is allowed (i.e., None).
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                list(), None, {"foo.txt"}, None)
+
+    def test_given_languages_empty(self):
+        self.languages.update({C_LANG, CPP_LANG})
+
+        # If there are no candidate languages, then none can match.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "foo.c", FOO_CONTENT)],
+                set(), {"foo.%l"}, None)
+
+        # This is debatable: technically we should match with None,
+        # however the user clearly did something nonsensical, we better
+        # stop and tell them they have messed up.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.txt", "foo.txt", FOO_CONTENT)],
+                set(), {"foo.txt"}, None)
+
+    def test_submission_format_empty(self):
+        self.languages.update({C_LANG, CPP_LANG})
+
+        # If no files are wanted, any file will cause an invalid match.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "foo.c", FOO_CONTENT)],
+                {"C"}, set(), None)
+
+        # Even in language-agnostic settings.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.txt", "foo.txt", FOO_CONTENT)],
+                None, set(), None)
+
+        # If there are no files this could be made to work. However we
+        # decided that this means the contestant is very confused and
+        # thus abort instead.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                list(), None, set(), None)
+
+    def test_allowed_languages_empty(self):
+        self.languages.update({C_LANG})
+
+        # An empty list of allowed languages means no language allowed:
+        # any attempt at matching must necessarily fail.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "foo.c", FOO_CONTENT)],
+                {"C"}, {"foo.%l"}, list())
+
+        # If all allowed languages are invalid, it's as if there weren't
+        # any.
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "foo.c", FOO_CONTENT)],
+                {"C"}, {"foo.%l"}, ["BadLang"])
+
+        # The same holds if no candidates are given (this difference is
+        # relevant because now the allowed ones are used as candidates,
+        # instead of acting only as a filter).
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "foo.c", FOO_CONTENT)],
+                None, {"foo.%l"}, list())
+
+        with self.assertRaises(InvalidFilesOrLanguages):
+            match_files_and_languages(
+                [ReceivedFile("foo.%l", "foo.c", FOO_CONTENT)],
+                None, {"foo.%l"}, ["BadLang"])
+
+        # However the "None" language, if applicable (i.e., if the
+        # submission format is language-agnostic), is always allowed.
+        files, language = match_files_and_languages(
+            [ReceivedFile("foo.txt", "foo.txt", FOO_CONTENT)],
+            None, {"foo.txt"}, list())
+        self.assertEqual(files, {"foo.txt": FOO_CONTENT})
+        self.assertIsNone(language)
+
+        files, language = match_files_and_languages(
+            [ReceivedFile("foo.txt", "foo.txt", FOO_CONTENT)],
+            None, {"foo.txt"}, ["BadLang"])
+        self.assertEqual(files, {"foo.txt": FOO_CONTENT})
+        self.assertIsNone(language)
+
+
+class TestFetchFileDigestsFromPreviousSubmission(DatabaseMixin,
+                                                 unittest.TestCase):
+
+    def setUp(self):
+        super(TestFetchFileDigestsFromPreviousSubmission, self).setUp()
+
+        self.contest = self.add_contest()
+        self.participation = self.add_participation(contest=self.contest)
+        self.task = self.add_task(contest=self.contest)
+
+        self.languages = {C_LANG, CPP_LANG, PY2_LANG, PY3_LANG}
+
+        patcher = patch("cms.server.contest.submission.LANGUAGES",
+                        self.languages)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch("cms.server.contest.submission.get_language",
+                        self.mock_get_language)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def mock_get_language(self, language_name):
+        for language in self.languages:
+            if language.name == language_name:
+                return language
+        raise KeyError()
+
+    def insert_submission(self, language, file_digests):
+        s = self.add_submission(
+            language=language, participation=self.participation, task=self.task)
+        for codename, digest in iteritems(file_digests):
+            self.add_file(filename=codename, digest=digest, submission=s)
+
+    def insert_user_test(
+            self, language, input_digest, file_digests, manager_digests):
+        t = self.add_user_test(
+            language=language, input=input_digest,
+            participation=self.participation, task=self.task)
+        for codename, digest in iteritems(file_digests):
+            self.add_user_test_file(filename=codename, digest=digest,
+                                    user_test=t)
+        for filename, digest in iteritems(manager_digests):
+            self.add_user_test_manager(filename=filename, digest=digest,
+                                       user_test=t)
+
+    def call(self, language, codenames, cls=Submission):
+        return fetch_file_digests_from_previous_submission(
+            self.session, self.participation, self.task, language, codenames,
+            cls)
+
+    def test_success_submission(self):
+        foo_digest = unique_digest()
+        baz_digest = unique_digest()
+        self.insert_submission("C",
+                               {"foo.%l": foo_digest, "baz.txt": baz_digest})
+        self.assertEqual(self.call(C_LANG, {"foo.%l", "bar.txt"}),
+                         {"foo.%l": foo_digest})
+
+    def test_no_submission(self):
+        self.assertEqual(self.call(C_LANG, {"foo.%l", "bar.txt"}),
+                         dict())
+
+    def test_previous_submission_wrong_language(self):
+        foo_digest = unique_digest()
+        baz_digest = unique_digest()
+        self.insert_submission("C",
+                               {"foo.%l": foo_digest, "baz.txt": baz_digest})
+        self.assertEqual(self.call(PY2_LANG, {"foo.%l", "bar.txt"}),
+                         dict())
+
+    def test_language_agnostic(self):
+        foo_digest = unique_digest()
+        baz_digest = unique_digest()
+        self.insert_submission(None,
+                               {"foo.txt": foo_digest, "baz": baz_digest})
+        self.assertEqual(self.call(None, {"foo.txt", "bar.zip"}),
+                         {"foo.txt": foo_digest})
+
+    def test_success_user_test(self):
+        input_digest = unique_digest()
+        foo_digest = unique_digest()
+        baz_digest = unique_digest()
+        spam_digest = unique_digest()
+        eggs_digest = unique_digest()
+        self.insert_user_test("C", input_digest,
+                              {"foo.%l": foo_digest, "baz.txt": baz_digest},
+                              {"spam.c": spam_digest, "eggs.h": eggs_digest})
+        self.assertEqual(self.call(C_LANG, {"input",
+                                            "foo.%l", "bar.txt",
+                                            "spam.%l", "ham"},
+                                   cls=UserTest),
+                         {"input": input_digest,
+                          "foo.%l": foo_digest,
+                          "spam.%l": spam_digest})
+
+    def test_no_user_test(self):
+        self.assertEqual(self.call(C_LANG, {"foo.%l", "bar.txt"},
+                                   cls=UserTest),
+                         dict())
+
+    def test_previous_user_test_wrong_language(self):
+        foo_digest = unique_digest()
+        baz_digest = unique_digest()
+        input_digest = unique_digest()
+        spam_digest = unique_digest()
+        eggs_digest = unique_digest()
+        self.insert_user_test("C", input_digest,
+                              {"foo.%l": foo_digest, "baz.txt": baz_digest},
+                              {"spam.c": spam_digest, "eggs.h": eggs_digest})
+        self.assertEqual(self.call(PY2_LANG, {"input",
+                                              "foo.%l", "bar.txt",
+                                              "spam.%l", "ham"},
+                                   cls=UserTest),
+                         dict())
+
+    def test_managers_can_use_only_primary_extension(self):
+        input_digest = unique_digest()
+        foo_digest = unique_digest()
+        bar_digest = unique_digest()
+        self.insert_user_test("C++", input_digest, dict(),
+                              {"foo.cpp": foo_digest, "bar.cc": bar_digest})
+        self.assertEqual(self.call(CPP_LANG, {"foo.%l", "bar.%l"},
+                                   cls=UserTest),
+                         {"foo.%l": foo_digest})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Move the code out of the handler to a separate module. Split it into several functions, in order for it to be more modular, reusable and testable. Add extensive docstrings and unit tests.

This change makes the code longer but easier to understand as each function takes care of a single specific duty (before, they were all tangled steps). It also clarifies the semantics, where the intended behaviours are documented, exemplified and verified in docstrings and unit tests (before, some quirks emerged from interactions between far parts of the code and from a history of layered incomplete or incorrect changes). Moreover it reduces code duplication between submissions and user tests.

Some differences in semantics were introduced:
* before, submitting an archive was only allowed in language-agnostic settings; now it's always allowed (even though the interface hasn't yet been updated to reflect this).
* before, the language had always to be explicitly provided, now it will be guessed if necessary (from all allowed languages or from a user-provided set of candidates).
* before, when submitting an incremental user test on a task that allowed it only the missing source files would be fetched from the previous test, not the missing input or managers, this is now fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/945)
<!-- Reviewable:end -->
