### PR TITLE
Do not set multithreaded in sandboxes where max_processes is already set later

### DIFF
--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -198,10 +198,7 @@ class Batch(TaskType):
             return
 
         # Create the sandbox.
-        sandbox = create_sandbox(
-            file_cacher,
-            multithreaded=job.multithreaded_sandbox,
-            name="compile")
+        sandbox = create_sandbox(file_cacher, name="compile")
         job.sandboxes.append(sandbox.path)
 
         user_file_format = next(iterkeys(job.files))
@@ -348,12 +345,8 @@ class Batch(TaskType):
                 else:
 
                     # Create a brand-new sandbox just for checking. Only admin
-                    # code runs in it, so we allow multithreading and many
-                    # processes (still with a limit to avoid fork-bombs).
-                    checkbox = create_sandbox(
-                        file_cacher,
-                        multithreaded=True,
-                        name="check")
+                    # code runs in it, so we allow multithreading.
+                    checkbox = create_sandbox(file_cacher, name="check")
                     job.sandboxes.append(checkbox.path)
 
                     checker_success, outcome, text = self._eval_output(

--- a/cms/grading/tasktypes/OutputOnly.py
+++ b/cms/grading/tasktypes/OutputOnly.py
@@ -127,19 +127,10 @@ class OutputOnly(TaskType):
 
     def evaluate(self, job, file_cacher):
         """See TaskType.evaluate."""
-        sandbox = create_sandbox(
-            file_cacher,
-            multithreaded=job.multithreaded_sandbox,
-            name="evaluate")
-        job.sandboxes.append(sandbox.path)
-
-        # Immediately prepare the skeleton to return
-        job.plus = {}
-
-        outcome = None
-        text = []
-
         user_output_filename = self._get_user_output_filename(job)
+
+        # There is no actual evaluation, so no statistics.
+        job.plus = {}
 
         # Since we allow partial submission, if the file is not
         # present we report that the outcome is 0.
@@ -150,6 +141,9 @@ class OutputOnly(TaskType):
             return
 
         # First and only one step: diffing (manual or with manager).
+
+        sandbox = create_sandbox(file_cacher, name="check")
+        job.sandboxes.append(sandbox.path)
 
         # Put user output and reference solution into the sandbox.
         sandbox.create_file_from_storage(

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -145,10 +145,7 @@ class TwoSteps(TaskType):
             return
 
         # First and only one compilation.
-        sandbox = create_sandbox(
-            file_cacher,
-            multithreaded=job.multithreaded_sandbox,
-            name="compile")
+        sandbox = create_sandbox(file_cacher, name="compile")
         job.sandboxes.append(sandbox.path)
         files_to_get = {}
 


### PR DESCRIPTION
Namely, in sandboxes where we do a compilation_step or a trusted_step.