### PR TITLE
Extract eval_output from tasktypes, and run whitediff without sandbox

### DIFF
--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -368,9 +368,8 @@ class SandboxBase(with_metaclass(ABCMeta, object)):
         executable (bool): to set permissions.
 
         """
-        file_ = self.create_file(path, executable)
-        self.file_cacher.get_file_to_fobj(digest, file_)
-        file_.close()
+        with self.create_file(path, executable) as dest_fobj:
+            self.file_cacher.get_file_to_fobj(digest, dest_fobj)
 
     def create_file_from_string(self, path, content, executable=False):
         """Write some data to a file in the sandbox.
@@ -380,9 +379,8 @@ class SandboxBase(with_metaclass(ABCMeta, object)):
         executable (bool): to set permissions.
 
         """
-        file_ = self.create_file(path, executable)
-        file_.write(content)
-        file_.close()
+        with self.create_file(path, executable) as dest_fobj:
+            dest_fobj.write(content)
 
     def get_file(self, path, trunc_len=None):
         """Open a file in the sandbox given its relative path.

--- a/cms/grading/steps/__init__.py
+++ b/cms/grading/steps/__init__.py
@@ -33,7 +33,8 @@ from .evaluation import EVALUATION_MESSAGES, evaluation_step, \
 from .messages import HumanMessage, MessageCollection
 from .stats import execution_stats, merge_execution_stats
 from .trusted import checker_step, extract_outcome_and_text, trusted_step
-from .whitediff import _WHITES, _white_diff, white_diff_step
+from .whitediff import _WHITES, _white_diff, white_diff_step,\
+    white_diff_fobj_step
 
 
 __all__ = [
@@ -50,5 +51,5 @@ __all__ = [
     # trusted.py
     "checker_step", "extract_outcome_and_text", "trusted_step",
     # whitediff.py
-    "_WHITES", "_white_diff", "white_diff_step",
+    "_WHITES", "_white_diff", "white_diff_step", "white_diff_fobj_step"
 ]

--- a/cms/grading/steps/trusted.py
+++ b/cms/grading/steps/trusted.py
@@ -55,7 +55,7 @@ from .utils import generic_step
 logger = logging.getLogger(__name__)
 
 
-# Filename used for input and correct output in the checker sandbox.
+# Filenames used for input and correct output in the checker sandbox.
 CHECKER_INPUT_FILENAME = "input.txt"
 CHECKER_CORRECT_OUTPUT_FILENAME = "correct_output.txt"
 # Codename of the manager used to compare output (must be an executable), and

--- a/cms/grading/steps/whitediff.py
+++ b/cms/grading/steps/whitediff.py
@@ -118,12 +118,32 @@ def _white_diff(output, res):
                 return False
 
 
+def white_diff_fobj_step(output_fobj, correct_output_fobj):
+    """Compare user output and correct output with a simple diff.
+
+    It gives an outcome 1.0 if the output and the reference output are
+    identical (or differ just by white spaces) and 0.0 if they don't. Calling
+    this function means that the output file exists.
+
+    output_fobj (fileobj): file for the user output, opened in binary mode.
+    correct_output_fobj (fileobj): file for the correct output, opened in
+        binary mode.
+
+    return ((float, [str])): the outcome as above and a description text.
+
+    """
+    if _white_diff(output_fobj, correct_output_fobj):
+        return 1.0, [EVALUATION_MESSAGES.get("success").message]
+    else:
+        return 0.0, [EVALUATION_MESSAGES.get("wrong").message]
+
+
 def white_diff_step(sandbox, output_filename, correct_output_filename):
-    """Assess the correctedness of a solution by doing a simple white
-    diff against the reference solution. It gives an outcome 1.0 if
-    the output and the reference output are identical (or differ just
-    by white spaces) and 0.0 if they don't (or if the output doesn't
-    exist).
+    """Compare user output and correct output with a simple diff.
+
+    It gives an outcome 1.0 if the output and the reference output are
+    identical (or differ just by white spaces) and 0.0 if they don't (or if
+    the output doesn't exist).
 
     sandbox (Sandbox): the sandbox we consider.
     output_filename (str): the filename of user's output in the sandbox.
@@ -135,13 +155,7 @@ def white_diff_step(sandbox, output_filename, correct_output_filename):
     if sandbox.file_exists(output_filename):
         with sandbox.get_file(output_filename) as out_file, \
                 sandbox.get_file(correct_output_filename) as res_file:
-            if _white_diff(out_file, res_file):
-                outcome = 1.0
-                text = [EVALUATION_MESSAGES.get("success").message]
-            else:
-                outcome = 0.0
-                text = [EVALUATION_MESSAGES.get("wrong").message]
+            return white_diff_fobj_step(out_file, res_file)
     else:
-        outcome = 0.0
-        text = [EVALUATION_MESSAGES.get("nooutput").message, output_filename]
-    return outcome, text
+        return 0.0, [
+            EVALUATION_MESSAGES.get("nooutput").message, output_filename]

--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -30,17 +30,14 @@ from future.builtins import *  # noqa
 from six import iterkeys, iteritems
 
 import logging
-import os
-import shutil
 
-from cms.grading.steps import checker_step, compilation_step, \
-    evaluation_step, human_evaluation_message, is_evaluation_passed,\
-    white_diff_step
+from cms.grading.steps import compilation_step, \
+    evaluation_step, human_evaluation_message, is_evaluation_passed
 from cms.grading.languagemanager import LANGUAGES, get_language
 from cms.grading.ParameterTypes import ParameterTypeCollection, \
     ParameterTypeChoice, ParameterTypeString
 from cms.grading.TaskType import TaskType, \
-    create_sandbox, delete_sandbox, is_manager_for_compilation
+    create_sandbox, delete_sandbox, is_manager_for_compilation, eval_output
 from cms.db import Executable
 
 
@@ -80,8 +77,6 @@ class Batch(TaskType):
     """
     # Codename of the checker, if it is used.
     CHECKER_CODENAME = "checker"
-    # Filename of the reference solution in the sandbox evaluating the output.
-    CORRECT_OUTPUT_FILENAME = "res.txt"
     # Basename of the grader, used in the manager filename and as the main
     # class in languages that require us to specify it.
     GRADER_BASENAME = "grader"
@@ -343,55 +338,18 @@ class Batch(TaskType):
 
                 # Otherwise evaluate the output file.
                 else:
-
-                    # Create a brand-new sandbox just for checking. Only admin
-                    # code runs in it, so we allow multithreading.
-                    checkbox = create_sandbox(file_cacher, name="check")
-                    job.sandboxes.append(checkbox.path)
-
-                    checker_success, outcome, text = self._eval_output(
-                        checkbox, job, sandbox.get_root_path())
+                    checker_success, outcome, text = eval_output(
+                        file_cacher, job,
+                        Batch.CHECKER_CODENAME
+                        if self._uses_checker() else None,
+                        user_output_path=sandbox.relative_path(
+                            self._actual_output),
+                        user_output_filename=self.output_filename)
                     success = success and checker_success
 
         # Whatever happened, we conclude.
         job.success = success
-        job.outcome = "%s" % outcome if outcome is not None else None
+        job.outcome = str(outcome) if outcome is not None else None
         job.text = text
 
         delete_sandbox(sandbox, job.success)
-
-    def _eval_output(self, sandbox, job, eval_sandbox_path):
-        """Evaluate ("check") the output using a white diff or a checker.
-
-        sandbox (Sandbox): the sandbox to use to eval the output.
-        job (Job): the job triggering this checker run.
-        eval_sandbox_path (str): full path of the sandbox where the user output
-            was generated.
-
-        return (bool, float|None, [str]): success (true if the checker was able
-            to check the solution successfully), outcome and text.
-
-        """
-        # Put the user-produced output file into the checkbox. We treat links
-        # as potential attacks, and not use them.
-        output_src = os.path.join(eval_sandbox_path, self._actual_output)
-        output_dst = os.path.join(
-            sandbox.get_root_path(), self._actual_output)
-        if os.path.exists(output_src) and not os.path.islink(output_src):
-            shutil.copyfile(output_src, output_dst)
-
-        if self._uses_checker():
-            checker_digest = job.managers[Batch.CHECKER_CODENAME].digest \
-                if Batch.CHECKER_CODENAME in job.managers else None
-            success, outcome, text = checker_step(
-                sandbox, checker_digest, job.input, job.output,
-                self._actual_output)
-        else:
-            sandbox.create_file_from_storage(
-                Batch.CORRECT_OUTPUT_FILENAME, job.output)
-            success = True
-            outcome, text = white_diff_step(
-                sandbox, self._actual_output, Batch.CORRECT_OUTPUT_FILENAME)
-
-        delete_sandbox(sandbox, success)
-        return success, outcome, text

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -31,18 +31,16 @@ from six import iteritems
 
 import logging
 import os
-import shutil
 import tempfile
 
 from cms import config
 from cms.grading.Sandbox import wait_without_std
 from cms.grading.ParameterTypes import ParameterTypeChoice
-from cms.grading.steps import checker_step, compilation_step, \
-    evaluation_step_before_run, evaluation_step_after_run, \
-    is_evaluation_passed, human_evaluation_message, white_diff_step
+from cms.grading.steps import compilation_step, evaluation_step_before_run, \
+    evaluation_step_after_run, is_evaluation_passed, human_evaluation_message
 from cms.grading.languagemanager import LANGUAGES, get_language
 from cms.grading.TaskType import TaskType, \
-    create_sandbox, delete_sandbox
+    create_sandbox, delete_sandbox, eval_output
 from cms.db import Executable
 
 
@@ -76,8 +74,6 @@ class TwoSteps(TaskType):
     """
     # Codename of the checker, if it is used.
     CHECKER_CODENAME = "checker"
-    # Filename of the reference solution in the sandbox evaluating the output.
-    CORRECT_OUTPUT_FILENAME = "res.txt"
     # Filename of the input and of the contestant's solution.
     INPUT_FILENAME = "input.txt"
     OUTPUT_FILENAME = "output.txt"
@@ -357,14 +353,12 @@ class TwoSteps(TaskType):
 
                 # Otherwise evaluate the output file.
                 else:
-
-                    # Create a brand-new sandbox just for checking. Only admin
-                    # code runs in it, so we allow multithreading.
-                    checkbox = create_sandbox(file_cacher, name="check")
-                    job.sandboxes.append(checkbox.path)
-
-                    checker_success, outcome, text = self._eval_output(
-                        checkbox, job, second_sandbox.get_root_path())
+                    checker_success, outcome, text = eval_output(
+                        file_cacher, job,
+                        TwoSteps.CHECKER_CODENAME
+                        if self._uses_checker() else None,
+                        user_output_path=second_sandbox.relative_path(
+                            TwoSteps.OUTPUT_FILENAME))
                     success = success and checker_success
 
         # Whatever happened, we conclude.
@@ -374,41 +368,3 @@ class TwoSteps(TaskType):
 
         delete_sandbox(first_sandbox, job.success)
         delete_sandbox(second_sandbox, job.success)
-
-    def _eval_output(self, sandbox, job, eval_sandbox_path):
-        """Evaluate ("check") the output using a white diff or a checker.
-
-        sandbox (Sandbox): the sandbox to use to eval the output.
-        job (Job): the job triggering this checker run.
-        eval_sandbox_path (str): full path of the sandbox where the user output
-            was generated.
-
-        return (bool, float|None, [str]): success (true if the checker was able
-            to check the solution successfully), outcome and text.
-
-        """
-        # Put the user-produced output file into the checkbox. We treat links
-        # as potential attacks, and not use them.
-        output_src = os.path.join(eval_sandbox_path, TwoSteps.OUTPUT_FILENAME)
-        output_dst = os.path.join(
-            sandbox.get_root_path(), TwoSteps.OUTPUT_FILENAME)
-        if os.path.exists(output_src) and not os.path.islink(output_src):
-            shutil.copyfile(output_src, output_dst)
-
-        if self._uses_checker():
-            checker_digest = job.managers[TwoSteps.CHECKER_CODENAME].digest \
-                if TwoSteps.CHECKER_CODENAME in job.managers else None
-            success, outcome, text = checker_step(
-                sandbox, checker_digest, job.input, job.output,
-                TwoSteps.OUTPUT_FILENAME)
-        else:
-            # Put the reference solution and input into the sandbox.
-            sandbox.create_file_from_storage(
-                TwoSteps.CORRECT_OUTPUT_FILENAME, job.output)
-            success = True
-            outcome, text = white_diff_step(sandbox,
-                                            TwoSteps.OUTPUT_FILENAME,
-                                            TwoSteps.CORRECT_OUTPUT_FILENAME)
-
-        delete_sandbox(sandbox, success)
-        return success, outcome, text


### PR DESCRIPTION
- Move eval_output (the function running either checker or white diff
  on the user output) to TaskType.py; it cannot go in steps because it
  involves jobs, and creating and deleting sandboxes; already
  checker_step was a stretch, here we are also formally limited by
  circular imports.

- Add ability to run white diff on file objects instead than on paths.

- Use it to avoid having a sandbox for white diff, as suggested by
  @lerks: files are read directly from their current place (either a
  sandbox, or file cacher).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/953)
<!-- Reviewable:end -->
