### PR TITLE
Cosmetic changes to TTs \ {Communication}

### DIFF
--- a/cms/grading/tasktypes/OutputOnly.py
+++ b/cms/grading/tasktypes/OutputOnly.py
@@ -121,9 +121,6 @@ class OutputOnly(TaskType):
         """See TaskType.evaluate."""
         user_output_filename = self._get_user_output_filename(job)
 
-        # There is no actual evaluation, so no statistics.
-        job.plus = {}
-
         # Since we allow partial submission, if the file is not
         # present we report that the outcome is 0.
         if user_output_filename not in job.files:
@@ -133,12 +130,14 @@ class OutputOnly(TaskType):
             return
 
         # First and only step: eval the user output.
-        success, outcome, text = eval_output(
+        box_success, outcome, text = eval_output(
             file_cacher, job,
             OutputOnly.CHECKER_CODENAME if self._uses_checker() else None,
             user_output_digest=job.files[user_output_filename].digest)
 
-        # Whatever happened, we conclude.
-        job.success = success
+        # Fill in the job with the results.
+        job.success = box_success
         job.outcome = str(outcome) if outcome is not None else None
         job.text = text
+        # There is no actual evaluation, so no statistics.
+        job.plus = {}


### PR DESCRIPTION
Communication will follow in a different, heavier, PR.

Mostly here we change names: "success/operation_success" ->
"box_success", "plus" -> "stats"; then some simplifications in some
iterations (using iteritems instead of iterkeys + lookup), some fewer
useless line wrappings.

We remove the "TODO" to check the exit status of the sandbox, since
that is already happening within evaluation_step_after_run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/961)
<!-- Reviewable:end -->
