### PR TITLE
Tests for score types and some better messaging in case of wrong parameters

### DIFF
--- a/cms/grading/ScoreType.py
+++ b/cms/grading/ScoreType.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2010-2012 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
-# Copyright © 2010-2013 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2013-2016 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2015 wafrelka <wafrelka@gmail.com>
@@ -76,8 +76,13 @@ class ScoreType(with_metaclass(ABCMeta, object)):
         self.public_testcases = public_testcases
 
         # Preload the maximum possible scores.
-        self.max_score, self.max_public_score, self.ranking_headers = \
-            self.max_scores()
+        try:
+            self.max_score, self.max_public_score, self.ranking_headers = \
+                self.max_scores()
+        except Exception as e:
+            raise ValueError(
+                "Unable to instantiate score type (probably due to invalid "
+                "values for the score type parameters): %s." % e)
 
         self.template = GLOBAL_ENVIRONMENT.from_string(self.TEMPLATE)
 

--- a/cms/server/admin/handlers/task.py
+++ b/cms/server/admin/handlers/task.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2010-2013 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
-# Copyright © 2010-2017 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2012-2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
@@ -198,6 +198,16 @@ class TaskHandler(BaseHandler):
             for testcase in itervalues(dataset.testcases):
                 testcase.public = bool(self.get_argument(
                     "testcase_%s_public" % testcase.id, False))
+
+            # Test that the score type parameters are valid.
+            try:
+                dataset.score_type_object
+            except (AssertionError, ValueError) as error:
+                self.application.service.add_notification(
+                    make_datetime(), "Invalid score type parameters",
+                    str(error))
+                self.redirect(self.url("task", task_id))
+                return
 
         if self.try_commit():
             # Update the task and score on RWS.

--- a/cmstestsuite/unit_tests/grading/scoretypes/GroupMinTest.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/GroupMinTest.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the GroupMin score type."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *  # noqa
+from future.builtins import *  # noqa
+from six import iterkeys
+
+import unittest
+
+from cms.grading.scoretypes.GroupMin import GroupMin
+
+from cmstestsuite.unit_tests.grading.scoretypes.scoretypetestutils \
+    import ScoreTypeTestMixin
+
+
+class TestGroupMin(ScoreTypeTestMixin, unittest.TestCase):
+    """Test the GroupMin score type."""
+
+    def setUp(self):
+        super(TestGroupMin, self).setUp()
+        self._public_testcases = {
+            "1_0": True,
+            "1_1": True,
+            "2_0": True,
+            "2_1": False,
+            "3_0": False,
+            "3_1": False,
+        }
+
+    def test_paramaters_correct(self):
+        """Test that correct parameters do not throw."""
+        GroupMin([], self._public_testcases)
+        GroupMin([[40, 2], [60.0, 2]], self._public_testcases)
+        GroupMin([[40, "1_*"], [60.0, "2_*"]], self._public_testcases)
+
+    def test_paramaters_invalid_types(self):
+        with self.assertRaises(ValueError):
+            GroupMin([1], self._public_testcases)
+        with self.assertRaises(ValueError):
+            GroupMin(1, self._public_testcases)
+
+    def test_paramaters_invalid_wrong_item_len(self):
+        with self.assertRaises(ValueError):
+            GroupMin([[]], self._public_testcases)
+        with self.assertRaises(ValueError):
+            GroupMin([[1]], self._public_testcases)
+
+    @unittest.skip("Not yet detected.")
+    def test_paramaters_invalid_wrong_item_len_not_caught(self):
+        with self.assertRaises(ValueError):
+            GroupMin([[1, 2, 3]], self._public_testcases)
+
+    def test_parameter_invalid_wrong_max_score_type(self):
+        with self.assertRaises(ValueError):
+            GroupMin([["a", 10]], self._public_testcases)
+
+    def test_parameter_invalid_wrong_testcases_type(self):
+        with self.assertRaises(ValueError):
+            GroupMin([[100, 1j]], self._public_testcases)
+
+    def test_parameter_invalid_inconsistent_testcases_type(self):
+        with self.assertRaises(ValueError):
+            GroupMin([[40, 10], [40, "1_*"]], self._public_testcases)
+
+    @unittest.skip("Not yet detected.")
+    def test_paramaters_invalid_testcases_too_many(self):
+        with self.assertRaises(ValueError):
+            GroupMin([[100, 20]], self._public_testcases)
+
+    def test_parameter_invalid_testcases_regex_no_match_type(self):
+        with self.assertRaises(ValueError):
+            GroupMin([[100, "9_*"]], self._public_testcases)
+
+    def test_max_scores_regexp(self):
+        """Test max score is correct when groups are regexp-defined."""
+        s1, s2, s3 = 10.5, 30.5, 59
+        parameters = [[s1, "1_*"], [s2, "2_*"], [s3, "3_*"]]
+        header = ["Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
+
+        # Only group 1_* is public.
+        public_testcases = dict(self._public_testcases)
+        self.assertEqual(GroupMin(parameters, public_testcases).max_scores(),
+                         (s1 + s2 + s3, s1, header))
+
+        # All groups are public
+        for testcase in iterkeys(public_testcases):
+            public_testcases[testcase] = True
+        self.assertEqual(GroupMin(parameters, public_testcases).max_scores(),
+                         (s1 + s2 + s3, s1 + s2 + s3, header))
+
+        # No groups are public
+        for testcase in iterkeys(public_testcases):
+            public_testcases[testcase] = False
+        self.assertEqual(GroupMin(parameters, public_testcases).max_scores(),
+                         (s1 + s2 + s3, 0, header))
+
+    def test_max_scores_number(self):
+        """Test max score is correct when groups are number-defined."""
+        s1, s2, s3 = 10.5, 30.5, 59
+        parameters = [[s1, 2], [s2, 2], [s3, 2]]
+        header = ["Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
+
+        # Only group 1_* is public.
+        public_testcases = dict(self._public_testcases)
+        self.assertEqual(GroupMin(parameters, public_testcases).max_scores(),
+                         (s1 + s2 + s3, s1, header))
+
+        # All groups are public
+        for testcase in iterkeys(public_testcases):
+            public_testcases[testcase] = True
+        self.assertEqual(GroupMin(parameters, public_testcases).max_scores(),
+                         (s1 + s2 + s3, s1 + s2 + s3, header))
+
+        # No groups are public
+        for testcase in iterkeys(public_testcases):
+            public_testcases[testcase] = False
+        self.assertEqual(GroupMin(parameters, public_testcases).max_scores(),
+                         (s1 + s2 + s3, 0.0, header))
+
+    def test_compute_score(self):
+        s1, s2, s3 = 10.5, 30.5, 59
+        parameters = [[s1, "1_*"], [s2, "2_*"], [s3, "3_*"]]
+        gmin = GroupMin(parameters, self._public_testcases)
+        sr = self.get_submission_result(self._public_testcases)
+
+        # All correct.
+        self.assertComputeScore(gmin.compute_score(sr),
+                                s1 + s2 + s3, s1, [s1, s2, s3])
+
+        # Some non-public subtask is incorrect.
+        self.set_outcome(sr, "3_1", 0.0)
+        self.assertComputeScore(gmin.compute_score(sr),
+                                s1 + s2, s1, [s1, s2, 0])
+
+        # Also the public subtask is incorrect.
+        self.set_outcome(sr, "1_0", 0.0)
+        self.set_outcome(sr, "1_1", 0.0)
+        sr.evaluations[1].outcome = 0.0
+        self.assertComputeScore(gmin.compute_score(sr),
+                                s2, 0.0, [0, s2, 0])
+
+        # Some partial results.
+        self.set_outcome(sr, "3_0", 0.5)
+        self.set_outcome(sr, "3_1", 0.1)
+        self.assertComputeScore(gmin.compute_score(sr),
+                                s2 + s3 * 0.1, 0.0, [0, s2, s3 * 0.1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmstestsuite/unit_tests/grading/scoretypes/GroupMulTest.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/GroupMulTest.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the GroupMul score type."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *  # noqa
+from future.builtins import *  # noqa
+from six import iterkeys
+
+import unittest
+
+from cms.grading.scoretypes.GroupMul import GroupMul
+
+from cmstestsuite.unit_tests.grading.scoretypes.scoretypetestutils \
+    import ScoreTypeTestMixin
+
+
+class TestGroupMul(ScoreTypeTestMixin, unittest.TestCase):
+    """Test the GroupMul score type."""
+
+    def setUp(self):
+        super(TestGroupMul, self).setUp()
+        self._public_testcases = {
+            "1_0": True,
+            "1_1": True,
+            "2_0": True,
+            "2_1": False,
+            "3_0": False,
+            "3_1": False,
+        }
+
+    def test_paramaters_correct(self):
+        """Test that correct parameters do not throw."""
+        GroupMul([], self._public_testcases)
+        GroupMul([[40, 2], [60.0, 2]], self._public_testcases)
+        GroupMul([[40, "1_*"], [60.0, "2_*"]], self._public_testcases)
+
+    def test_paramaters_invalid_types(self):
+        with self.assertRaises(ValueError):
+            GroupMul([1], self._public_testcases)
+        with self.assertRaises(ValueError):
+            GroupMul(1, self._public_testcases)
+
+    def test_paramaters_invalid_wrong_item_len(self):
+        with self.assertRaises(ValueError):
+            GroupMul([[]], self._public_testcases)
+        with self.assertRaises(ValueError):
+            GroupMul([[1]], self._public_testcases)
+
+    @unittest.skip("Not yet detected.")
+    def test_paramaters_invalid_wrong_item_len_not_caught(self):
+        with self.assertRaises(ValueError):
+            GroupMul([[1, 2, 3]], self._public_testcases)
+
+    def test_parameter_invalid_wrong_max_score_type(self):
+        with self.assertRaises(ValueError):
+            GroupMul([["a", 10]], self._public_testcases)
+
+    def test_parameter_invalid_wrong_testcases_type(self):
+        with self.assertRaises(ValueError):
+            GroupMul([[100, 1j]], self._public_testcases)
+
+    def test_parameter_invalid_inconsistent_testcases_type(self):
+        with self.assertRaises(ValueError):
+            GroupMul([[40, 10], [40, "1_*"]], self._public_testcases)
+
+    @unittest.skip("Not yet detected.")
+    def test_paramaters_invalid_testcases_too_many(self):
+        with self.assertRaises(ValueError):
+            GroupMul([[100, 20]], self._public_testcases)
+
+    def test_parameter_invalid_testcases_regex_no_match_type(self):
+        with self.assertRaises(ValueError):
+            GroupMul([[100, "9_*"]], self._public_testcases)
+
+    def test_max_scores_regexp(self):
+        """Test max score is correct when groups are regexp-defined."""
+        s1, s2, s3 = 10.5, 30.5, 59
+        parameters = [[s1, "1_*"], [s2, "2_*"], [s3, "3_*"]]
+        header = ["Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
+
+        # Only group 1_* is public.
+        public_testcases = dict(self._public_testcases)
+        self.assertEqual(GroupMul(parameters, public_testcases).max_scores(),
+                         (s1 + s2 + s3, s1, header))
+
+        # All groups are public
+        for testcase in iterkeys(public_testcases):
+            public_testcases[testcase] = True
+        self.assertEqual(GroupMul(parameters, public_testcases).max_scores(),
+                         (s1 + s2 + s3, s1 + s2 + s3, header))
+
+        # No groups are public
+        for testcase in iterkeys(public_testcases):
+            public_testcases[testcase] = False
+        self.assertEqual(GroupMul(parameters, public_testcases).max_scores(),
+                         (s1 + s2 + s3, 0, header))
+
+    def test_max_scores_number(self):
+        """Test max score is correct when groups are number-defined."""
+        s1, s2, s3 = 10.5, 30.5, 59
+        parameters = [[s1, 2], [s2, 2], [s3, 2]]
+        header = ["Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
+
+        # Only group 1_* is public.
+        public_testcases = dict(self._public_testcases)
+        self.assertEqual(GroupMul(parameters, public_testcases).max_scores(),
+                         (s1 + s2 + s3, s1, header))
+
+        # All groups are public
+        for testcase in iterkeys(public_testcases):
+            public_testcases[testcase] = True
+        self.assertEqual(GroupMul(parameters, public_testcases).max_scores(),
+                         (s1 + s2 + s3, s1 + s2 + s3, header))
+
+        # No groups are public
+        for testcase in iterkeys(public_testcases):
+            public_testcases[testcase] = False
+        self.assertEqual(GroupMul(parameters, public_testcases).max_scores(),
+                         (s1 + s2 + s3, 0, header))
+
+    def test_compute_score(self):
+        s1, s2, s3 = 10.5, 30.5, 59
+        parameters = [[s1, "1_*"], [s2, "2_*"], [s3, "3_*"]]
+        gmul = GroupMul(parameters, self._public_testcases)
+        sr = self.get_submission_result(self._public_testcases)
+
+        # All correct.
+        self.assertComputeScore(gmul.compute_score(sr),
+                                s1 + s2 + s3, s1, [s1, s2, s3])
+
+        # Some non-public subtask is incorrect.
+        self.set_outcome(sr, "3_1", 0.0)
+        self.assertComputeScore(gmul.compute_score(sr),
+                                s1 + s2, s1, [s1, s2, 0])
+
+        # Also the public subtask is incorrect.
+        self.set_outcome(sr, "1_0", 0.0)
+        self.set_outcome(sr, "1_1", 0.0)
+        self.assertComputeScore(gmul.compute_score(sr),
+                                s2, 0.0, [0, s2, 0])
+
+        # Some partial results.
+        self.set_outcome(sr, "3_0", 0.5)
+        self.set_outcome(sr, "3_1", 0.1)
+        self.assertComputeScore(gmul.compute_score(sr),
+                                s2 + s3 * 0.5 * 0.1, 0.0,
+                                [0, s2, s3 * 0.5 * 0.1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmstestsuite/unit_tests/grading/scoretypes/GroupThresholdTest.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/GroupThresholdTest.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the GroupThreshold score type."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *  # noqa
+from future.builtins import *  # noqa
+from six import iterkeys
+
+import unittest
+
+from cms.grading.scoretypes.GroupThreshold import GroupThreshold
+
+from cmstestsuite.unit_tests.grading.scoretypes.scoretypetestutils \
+    import ScoreTypeTestMixin
+
+
+class TestGroupThreshold(ScoreTypeTestMixin, unittest.TestCase):
+    """Test the GroupThreshold score type."""
+
+    def setUp(self):
+        super(TestGroupThreshold, self).setUp()
+        self._public_testcases = {
+            "1_0": True,
+            "1_1": True,
+            "2_0": True,
+            "2_1": False,
+            "3_0": False,
+            "3_1": False,
+        }
+
+    def test_paramaters_correct(self):
+        """Test that correct parameters do not throw."""
+        GroupThreshold([], self._public_testcases)
+        GroupThreshold([[40, 2, 500], [60.0, 2, 1000]],
+                       self._public_testcases)
+        GroupThreshold([[40, "1_*", 500.5], [60.0, "2_*", 1000]],
+                       self._public_testcases)
+
+    def test_paramaters_invalid_types(self):
+        with self.assertRaises(ValueError):
+            GroupThreshold([1], self._public_testcases)
+        with self.assertRaises(ValueError):
+            GroupThreshold(1, self._public_testcases)
+
+    def test_paramaters_invalid_wrong_item_len(self):
+        with self.assertRaises(ValueError):
+            GroupThreshold([[]], self._public_testcases)
+        with self.assertRaises(ValueError):
+            GroupThreshold([[1]], self._public_testcases)
+
+    @unittest.skip("Not yet detected.")
+    def test_paramaters_invalid_wrong_item_len_not_caught(self):
+        with self.assertRaises(ValueError):
+            GroupThreshold([[1, 2]], self._public_testcases)
+
+    def test_parameter_invalid_wrong_max_score_type(self):
+        with self.assertRaises(ValueError):
+            GroupThreshold([["a", 10, 1000]], self._public_testcases)
+
+    def test_parameter_invalid_wrong_testcases_type(self):
+        with self.assertRaises(ValueError):
+            GroupThreshold([[100, 1j, 1000]], self._public_testcases)
+
+    def test_parameter_invalid_inconsistent_testcases_type(self):
+        with self.assertRaises(ValueError):
+            GroupThreshold([[40, 10, 500], [40, "1_*", 1000]],
+                           self._public_testcases)
+
+    @unittest.skip("Not yet detected.")
+    def test_paramaters_invalid_testcases_too_many(self):
+        with self.assertRaises(ValueError):
+            GroupThreshold([[100, 20, 1000]], self._public_testcases)
+
+    def test_parameter_invalid_testcases_regex_no_match_type(self):
+        with self.assertRaises(ValueError):
+            GroupThreshold([[100, "9_*", 1000]], self._public_testcases)
+
+    @unittest.skip("Not yet detected.")
+    def test_parameter_invalid_wrong_threshold_type_not_caught(self):
+        with self.assertRaises(ValueError):
+            GroupThreshold([[100, 1, 1000j]], self._public_testcases)
+
+    def test_max_scores_regexp(self):
+        """Test max score is correct when groups are regexp-defined."""
+        s1, s2, s3 = 10.5, 30.5, 59
+        parameters = [[s1, "1_*", 10], [s2, "2_*", 20], [s3, "3_*", 30]]
+        header = ["Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
+
+        # Only group 1_* is public.
+        public_testcases = dict(self._public_testcases)
+        self.assertEqual(
+            GroupThreshold(parameters, public_testcases).max_scores(),
+            (s1 + s2 + s3, s1, header))
+
+        # All groups are public
+        for testcase in iterkeys(public_testcases):
+            public_testcases[testcase] = True
+        self.assertEqual(
+            GroupThreshold(parameters, public_testcases).max_scores(),
+            (s1 + s2 + s3, s1 + s2 + s3, header))
+
+        # No groups are public
+        for testcase in iterkeys(public_testcases):
+            public_testcases[testcase] = False
+        self.assertEqual(
+            GroupThreshold(parameters, public_testcases).max_scores(),
+            (s1 + s2 + s3, 0, header))
+
+    def test_max_scores_number(self):
+        """Test max score is correct when groups are number-defined."""
+        s1, s2, s3 = 10.5, 30.5, 59
+        parameters = [[s1, 2, 10], [s2, 2, 20], [s3, 2, 30]]
+        header = ["Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
+
+        # Only group 1_* is public.
+        public_testcases = dict(self._public_testcases)
+        self.assertEqual(
+            GroupThreshold(parameters, public_testcases).max_scores(),
+            (s1 + s2 + s3, s1, header))
+
+        # All groups are public
+        for testcase in iterkeys(public_testcases):
+            public_testcases[testcase] = True
+        self.assertEqual(
+            GroupThreshold(parameters, public_testcases).max_scores(),
+            (s1 + s2 + s3, s1 + s2 + s3, header))
+
+        # No groups are public
+        for testcase in iterkeys(public_testcases):
+            public_testcases[testcase] = False
+        self.assertEqual(
+            GroupThreshold(parameters, public_testcases).max_scores(),
+            (s1 + s2 + s3, 0, header))
+
+    def test_compute_score(self):
+        s1, s2, s3 = 10.5, 30.5, 59
+        parameters = [[s1, "1_*", 10], [s2, "2_*", 20], [s3, "3_*", 30]]
+        st = GroupThreshold(parameters, self._public_testcases)
+        sr = self.get_submission_result(self._public_testcases)
+
+        # All correct (below threshold).
+        for evaluation in sr.evaluations:
+            evaluation.outcome = 5.5
+        self.assertComputeScore(st.compute_score(sr),
+                                s1 + s2 + s3, s1, [s1, s2, s3])
+
+        # Some non-public subtask is incorrect.
+        self.set_outcome(sr, "3_1", 100.5)
+        self.assertComputeScore(st.compute_score(sr),
+                                s1 + s2, s1, [s1, s2, 0])
+
+        # Also the public subtask is incorrect.
+        self.set_outcome(sr, "1_0", 12.5)
+        self.set_outcome(sr, "1_1", 12.5)
+        self.assertComputeScore(st.compute_score(sr),
+                                s2, 0.0, [0, s2, 0])
+
+        # Outcome equal to 0 is special and treated as error even if it is
+        # below the threshold.
+        self.set_outcome(sr, "1_0", 0.0)
+        self.set_outcome(sr, "1_1", 0.0)
+        self.assertComputeScore(st.compute_score(sr),
+                                s2, 0.0, [0, s2, 0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmstestsuite/unit_tests/grading/scoretypes/SumTest.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/SumTest.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the Sum score type."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *  # noqa
+from future.builtins import *  # noqa
+
+import unittest
+
+from cms.grading.scoretypes.Sum import Sum
+
+from cmstestsuite.unit_tests.grading.scoretypes.scoretypetestutils \
+    import ScoreTypeTestMixin
+
+
+class TestSum(ScoreTypeTestMixin, unittest.TestCase):
+    """Test the Sum score type."""
+
+    def setUp(self):
+        super(TestSum, self).setUp()
+        self._public_testcases = {
+            "0": False,
+            "1": True,
+            "2": False,
+            "3": False,
+        }
+
+    def test_paramaters_correct(self):
+        """Test that correct parameters do not throw."""
+        Sum(100, self._public_testcases)
+        Sum(1.5, self._public_testcases)
+
+    def test_paramaters_invalid(self):
+        with self.assertRaises(ValueError):
+            Sum([], self._public_testcases)
+        with self.assertRaises(ValueError):
+            Sum("1", self._public_testcases)
+
+    def test_max_scores(self):
+        testcase_score = 10.5
+        self.assertEqual(Sum(testcase_score,
+                             self._public_testcases).max_scores(),
+                         (testcase_score * 4, testcase_score, []))
+
+    def test_compute_score(self):
+        testcase_score = 10.5
+        st = Sum(testcase_score, self._public_testcases)
+        sr = self.get_submission_result(self._public_testcases)
+
+        # All correct.
+        self.assertComputeScore(st.compute_score(sr),
+                                testcase_score * 4, testcase_score, [])
+
+        # Some non-public subtask is incorrect.
+        self.set_outcome(sr, "3", 0.0)
+        self.assertComputeScore(st.compute_score(sr),
+                                testcase_score * 3, testcase_score, [])
+
+        # Also the public subtask is incorrect.
+        self.set_outcome(sr, "1", 0.0)
+        self.assertComputeScore(st.compute_score(sr),
+                                testcase_score * 2, 0.0, [])
+
+        # Now the public subtask has some partial scores.
+        self.set_outcome(sr, "1", 0.2)
+        self.assertComputeScore(st.compute_score(sr),
+                                testcase_score * 2.2, testcase_score * 0.2, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmstestsuite/unit_tests/grading/scoretypes/__init__.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/__init__.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *  # noqa
+from future.builtins import *  # noqa

--- a/cmstestsuite/unit_tests/grading/scoretypes/scoretypetestutils.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/scoretypetestutils.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities for testing score types."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *  # noqa
+from future.builtins import *  # noqa
+from six import iterkeys
+
+from mock import Mock
+
+
+class ScoreTypeTestMixin(object):
+    """A test mixin to make it easier to test score types."""
+
+    def assertComputeScore(self, scores, total, public, rws_scores):
+        self.assertAlmostEqual(scores[0], total)
+        self.assertAlmostEqual(scores[2], public)
+        self.assertEqual(scores[4], [str(score) for score in rws_scores])
+
+    @staticmethod
+    def get_submission_result(testcases):
+        sr = Mock()
+        sr.evaluated.return_value = True
+        # Reversed to make sure the score type does not depend on the order.
+        sr.evaluations = [
+            ScoreTypeTestMixin.get_evaluation(codename, 1.0)
+            for codename in reversed(sorted(iterkeys(testcases)))]
+        return sr
+
+    @staticmethod
+    def get_evaluation(codename, outcome):
+        evaluation = Mock()
+        evaluation.codename = codename
+        evaluation.outcome = outcome
+        evaluation.execution_memory = 100
+        evaluation.execution_time = 0.5
+        evaluation.text = "Nothing to report"
+        return evaluation
+
+    @staticmethod
+    def set_outcome(sr, codename, outcome):
+        for evaluation in sr.evaluations:
+            if evaluation.codename == codename:
+                evaluation.outcome = outcome
+                return
+        raise ValueError("set_outcome called for non-existing codename %s."
+                         % codename)


### PR DESCRIPTION
So I was cleaning up some old branches, and there was something useful.

I had this branch with these two changes (tests and the instantiation
check), in addition to more thorough validations of the parameters
inside the score types (that would make the full test suite pass). I'm
not going to submit this other change, because the correct solution
would be to use ParameterTypes and have the validation for free, but
I'm keeping all the tests (with skip) so that we can just enable them
when we have the full validation.

I also have a branch that promises to use ParameterTypes for score
types, but I'm not sure in which shape it is...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/968)
<!-- Reviewable:end -->
