### PR TITLE
Clarify documentation about generating a new secret key

### DIFF
--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -90,9 +90,10 @@
     "_help": "numbers. It should be changed for each",
     "_help": "contest. Particularly, you should not use this example",
     "_help": "for other than testing. It must be a 16 bytes long",
-    "_help": "hexadecimal number. You can easily create a key",
-    "_help": "calling cmscommon.crypto.get_hex_random_key().",
+    "_help": "hexadecimal number. You can easily create a key calling:",
+    "_help": "python -c 'from cmscommon import crypto; print(crypto.get_hex_random_key())'",
     "secret_key":             "8e045a51e4b102ea803c06f92841a1fb",
+
 
     "_help": "Whether Tornado prints debug information on stdout.",
     "tornado_debug": false,


### PR DESCRIPTION
The current help comment in `config/cms.cinf.sample` suggests:
```
    "_help": "[...] You can easily create a key",
    "_help": "calling cmscommon.crypto.get_hex_random_key().",
```

this PR changes the help text to:
```
    "_help": "hexadecimal number. You can easily create a key calling:",
    "_help": "python -c 'from cmscommon import crypto; print(crypto.get_hex_random_key())'",
```

This is because if you just import `cmscommon`, the submodule `crypto` is not automatically imported:
as you can see from [`cmscommon/__init__.py`][cmscommon_init]:
```
$ python                                                                                                                                                                               129 ↵
Python 2.7.12 (default, Dec  4 2017, 14:50:18) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import cmscommon
>>> cmscommon.crypto.get_hex_random_key()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'crypto'
```

Another possibile fix is to include `crypto` in [`cmscommon/__init__.py`][cmscommon_init], but I prefered to just modify the help text.


[cmscommon_init]: https://github.com/cms-dev/cms/blob/master/cmscommon/__init__.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/973)
<!-- Reviewable:end -->
