### PR TITLE
Use BigInteger for storing execution_memory in the database

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -88,7 +88,7 @@ __all__ = [
 
 # Instantiate or import these objects.
 
-version = 33
+version = 34
 
 engine = create_engine(config.database, echo=config.database_debug,
                        pool_timeout=60, pool_recycle=120)

--- a/cms/db/base.py
+++ b/cms/db/base.py
@@ -37,7 +37,8 @@ from sqlalchemy.orm.session import object_session
 from sqlalchemy.orm import \
     class_mapper, object_mapper, ColumnProperty, RelationshipProperty
 from sqlalchemy.types import \
-    Boolean, Integer, Float, String, Unicode, Enum, DateTime, Interval
+    Boolean, Integer, Float, String, Unicode, Enum, DateTime, Interval, \
+    BigInteger
 from sqlalchemy.dialects.postgresql import ARRAY, CIDR, JSONB
 
 import six
@@ -56,6 +57,7 @@ from . import engine, CastingArray
 _TYPE_MAP = {
     Boolean: bool,
     Integer: six.integer_types,
+    BigInteger: six.integer_types,
     Float: float,
     Enum: six.text_type,
     Unicode: six.text_type,

--- a/cms/db/submission.py
+++ b/cms/db/submission.py
@@ -37,7 +37,8 @@ from future.builtins import *  # noqa
 from sqlalchemy import Boolean
 from sqlalchemy.schema import Column, ForeignKey, ForeignKeyConstraint, \
     UniqueConstraint
-from sqlalchemy.types import Integer, Float, String, Unicode, DateTime, Enum
+from sqlalchemy.types import Integer, Float, String, Unicode, DateTime, Enum, \
+    BigInteger
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.collections import attribute_mapped_collection
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
@@ -747,7 +748,7 @@ class Evaluation(Base):
 
     # Memory used by the evaluation, in bytes.
     execution_memory = Column(
-        Integer,
+        BigInteger,
         nullable=True)
 
     # Worker shard and sandbox where the evaluation was performed.

--- a/cms/db/submission.py
+++ b/cms/db/submission.py
@@ -336,7 +336,7 @@ class SubmissionResult(Base):
         Float,
         nullable=True)
     compilation_memory = Column(
-        Integer,
+        BigInteger,
         nullable=True)
 
     # Worker shard and sandbox where the compilation was performed.

--- a/cms/db/task.py
+++ b/cms/db/task.py
@@ -39,7 +39,7 @@ from datetime import timedelta
 from sqlalchemy.schema import Column, ForeignKey, CheckConstraint, \
     UniqueConstraint, ForeignKeyConstraint
 from sqlalchemy.types import Boolean, Integer, Float, String, Unicode, \
-    Interval, Enum
+    Interval, Enum, BigInteger
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.collections import attribute_mapped_collection
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
@@ -391,7 +391,7 @@ class Dataset(Base):
         CheckConstraint("time_limit > 0"),
         nullable=True)
     memory_limit = Column(
-        Integer,
+        BigInteger,
         CheckConstraint("memory_limit > 0"),
         nullable=True)
 

--- a/cms/db/usertest.py
+++ b/cms/db/usertest.py
@@ -318,7 +318,7 @@ class UserTestResult(Base):
         Float,
         nullable=True)
     compilation_memory = Column(
-        Integer,
+        BigInteger,
         nullable=True)
 
     # Worker shard and sandbox where the compilation was performed.

--- a/cms/db/usertest.py
+++ b/cms/db/usertest.py
@@ -32,7 +32,8 @@ from future.builtins import *  # noqa
 
 from sqlalchemy.schema import Column, ForeignKey, ForeignKeyConstraint, \
     UniqueConstraint
-from sqlalchemy.types import Integer, Float, String, Unicode, DateTime
+from sqlalchemy.types import Integer, Float, String, Unicode, DateTime, \
+    BigInteger
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.collections import attribute_mapped_collection
 from sqlalchemy.dialects.postgresql import ARRAY
@@ -357,7 +358,7 @@ class UserTestResult(Base):
         Float,
         nullable=True)
     execution_memory = Column(
-        Integer,
+        BigInteger,
         nullable=True)
 
     # Worker shard and sandbox where the evaluation was performed.

--- a/cmscontrib/updaters/update_34.py
+++ b/cmscontrib/updaters/update_34.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A class to update a dump created by CMS.
+
+Used by ContestImporter and DumpUpdater.
+
+This updater is no-op as we only changed some fields from Integer to
+BigInteger.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *  # noqa
+from future.builtins import *  # noqa
+
+
+class Updater(object):
+
+    def __init__(self, data):
+        assert data["_version"] == 33
+        self.objs = data
+
+    def run(self):
+        return self.objs


### PR DESCRIPTION
When a submission or user test used more than 2GB of memory, the number
of used bytes doesn't fit in an Integer (which has to be < 2^31 in Postgresql). EvaluationService will throw an exception
``sqlalchemy.exc.DataError: (psycopg2.DataError) integer out of range``.

This commit changes the type of the execution_memory columns to BigInteger (< 2^63 in Postgresql).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/974)
<!-- Reviewable:end -->
