### PR TITLE
Add a WSGI middleware to serve files instead of having Tornado do it

### DIFF
--- a/cms/io/web_service.py
+++ b/cms/io/web_service.py
@@ -38,6 +38,9 @@ from gevent.pywsgi import WSGIServer
 from werkzeug.wsgi import DispatcherMiddleware, SharedDataMiddleware
 from werkzeug.contrib.fixers import ProxyFix
 
+from cms.db.filecacher import FileCacher
+from cms.server.file_middleware import FileServerMiddleware
+
 from .service import Service
 from .web_rpc import RPCMiddleware
 
@@ -74,6 +77,9 @@ class WebService(Service):
                 self.wsgi_app, {"/static": entry},
                 cache=True, cache_timeout=SECONDS_IN_A_YEAR,
                 fallback_mimetype="application/octet-stream")
+
+        self.file_cacher = FileCacher(self)
+        self.wsgi_app = FileServerMiddleware(self.file_cacher, self.wsgi_app)
 
         if rpc_enabled:
             self.wsgi_app = DispatcherMiddleware(

--- a/cms/server/__init__.py
+++ b/cms/server/__init__.py
@@ -25,10 +25,10 @@ from future.builtins.disabled import *  # noqa
 from future.builtins import *  # noqa
 
 from .util import \
-    CommonRequestHandler, file_handler_gen, Url, multi_contest
+    CommonRequestHandler, FileHandlerMixin, Url, multi_contest
 
 
 __all__ = [
     # util
-    "CommonRequestHandler", "file_handler_gen", "Url", "multi_contest",
+    "CommonRequestHandler", "FileHandlerMixin", "Url", "multi_contest",
 ]

--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -53,7 +53,7 @@ from cms.db import Admin, Contest, Participation, Question, Submission, \
     SubmissionResult, Task, Team, User, UserTest
 from cms.grading.scoretypes import get_score_type_class
 from cms.grading.tasktypes import get_task_type_class
-from cms.server import CommonRequestHandler, file_handler_gen
+from cms.server import CommonRequestHandler, FileHandlerMixin
 from cmscommon.datetime import make_datetime
 from cmscommon.crypto import hash_password, parse_authentication
 
@@ -636,7 +636,8 @@ class BaseHandler(CommonRequestHandler):
         return self.url("login")
 
 
-FileHandler = file_handler_gen(BaseHandler)
+class FileHandler(BaseHandler, FileHandlerMixin):
+    pass
 
 
 class FileFromDigestHandler(FileHandler):

--- a/cms/server/admin/server.py
+++ b/cms/server/admin/server.py
@@ -41,7 +41,6 @@ from sqlalchemy import func, not_
 from cmscommon.binary import hex_to_bin
 from cms import config, ServiceCoord, get_service_shards
 from cms.db import SessionGen, Dataset, Submission, SubmissionResult, Task
-from cms.db.filecacher import FileCacher
 from cms.io import WebService, rpc_method
 from cms.service import EvaluationService
 
@@ -81,7 +80,6 @@ class AdminWebServer(WebService):
         # A list of pending notifications.
         self.notifications = []
 
-        self.file_cacher = FileCacher(self)
         self.admin_web_server = self.connect_to(
             ServiceCoord("AdminWebServer", 0))
         self.evaluation_service = self.connect_to(

--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -45,7 +45,7 @@ import tornado.web
 
 from cms import config, TOKEN_MODE_MIXED
 from cms.db import Contest, Submission, Task, UserTest
-from cms.server import file_handler_gen
+from cms.server import FileHandlerMixin
 from cms.locale import filter_language_codes
 from cms.server.contest.authentication import authenticate_request
 from cmscommon.datetime import get_timezone
@@ -290,4 +290,5 @@ class ContestHandler(BaseHandler):
         self.add_notification(subject, text, NOTIFICATION_ERROR)
 
 
-FileHandler = file_handler_gen(ContestHandler)
+class FileHandler(ContestHandler, FileHandlerMixin):
+    pass

--- a/cms/server/contest/server.py
+++ b/cms/server/contest/server.py
@@ -53,7 +53,6 @@ from cms.server.contest.jinja2_toolbox import CWS_ENVIRONMENT
 from cmscommon.binary import hex_to_bin
 from cms import ConfigError, ServiceCoord, config
 from cms.io import WebService
-from cms.db.filecacher import FileCacher
 from cms.locale import get_translations
 
 from .handlers import HANDLERS
@@ -126,7 +125,6 @@ class ContestWebServer(WebService):
         # Retrieve the available translations.
         self.translations = get_translations()
 
-        self.file_cacher = FileCacher(self)
         self.evaluation_service = self.connect_to(
             ServiceCoord("EvaluationService", 0))
         self.scoring_service = self.connect_to(

--- a/cms/server/file_middleware.py
+++ b/cms/server/file_middleware.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *
+from future.builtins import *
+
+from werkzeug.exceptions import HTTPException, NotFound, ServiceUnavailable
+from werkzeug.wrappers import Response, Request
+from werkzeug.wsgi import responder, wrap_file
+
+from cms.db.filecacher import FileCacher, TombstoneError
+
+
+SECONDS_IN_A_YEAR = 365 * 24 * 60 * 60
+
+
+class FileServerMiddleware(object):
+
+    """Intercept requests wanting to serve files and serve those files.
+
+    Tornado's WSGI adapter contravenes the specification by buffering
+    the entire output produced by a handler rather than streaming it
+    down as soon as it's available (even when an explicit flush is
+    issued). This is especially problematic when serving files, as it
+    causes them to be entirely loaded into memory, providing a vector
+    for a denial-of-service attack.
+
+    This class is one half of a two-part solution to this problem. When
+    a Tornado handler wants to serve a file it instead serves an empty
+    response with custom headers. This middleware looks out for
+    responses of that form and, when it encounters one, it fetches and
+    streams back the file that was requested, using a proper compliant
+    way.
+
+    """
+
+    def __init__(self, file_cacher, app):
+        """Create an instance.
+
+        file_cacher (FileCacher): the cacher to retrieve files from.
+        app (function): the WSGI application to wrap.
+
+        """
+        self.file_cacher = file_cacher
+        self.wrapped_app = app
+
+    def __call__(self, environ, start_response):
+        """Execute this instance as a WSGI application.
+
+        See the PEP for the meaning of parameters. The separation of
+        __call__ and wsgi_app eases the insertion of middlewares.
+
+        """
+        return self.wsgi_app(environ, start_response)
+
+    @responder
+    def wsgi_app(self, environ, start_response):
+        """Execute this instance as a WSGI application.
+
+        See the PEP for the meaning of parameters. The separation of
+        __call__ and wsgi_app eases the insertion of middlewares.
+
+        """
+        original_response = Response.from_app(self.wrapped_app, environ)
+
+        if "X-CMS-File-Digest" not in original_response.headers:
+            return original_response
+
+        digest = original_response.headers.pop("X-CMS-File-Digest")
+        filename = original_response.headers.pop("X-CMS-File-Filename", None)
+        mimetype = original_response.mimetype
+
+        try:
+            fobj = self.file_cacher.get_file(digest)
+            size = self.file_cacher.get_size(digest)
+        except KeyError:
+            return NotFound()
+        except TombstoneError:
+            return ServiceUnavailable()
+
+        request = Request(environ)
+        request.encoding_errors = "strict"
+
+        response = Response()
+        response.status_code = 200
+        response.mimetype = mimetype
+        if filename is not None:
+            response.headers.add(
+                "Content-Disposition", "attachment", filename=filename)
+        response.set_etag(digest)
+        response.cache_control.max_age = SECONDS_IN_A_YEAR
+        response.cache_control.private = True
+        response.response = \
+            wrap_file(environ, fobj, buffer_size=FileCacher.CHUNK_SIZE)
+        response.direct_passthrough = True
+
+        try:
+            # This takes care of conditional and partial requests.
+            response.make_conditional(
+                request, accept_ranges=True, complete_length=size)
+        except HTTPException as exc:
+            return exc
+
+        return response

--- a/cms/server/file_middleware.py
+++ b/cms/server/file_middleware.py
@@ -35,7 +35,6 @@ SECONDS_IN_A_YEAR = 365 * 24 * 60 * 60
 
 
 class FileServerMiddleware(object):
-
     """Intercept requests wanting to serve files and serve those files.
 
     Tornado's WSGI adapter contravenes the specification by buffering
@@ -53,6 +52,9 @@ class FileServerMiddleware(object):
     way.
 
     """
+
+    DIGEST_HEADER = "X-CMS-File-Digest"
+    FILENAME_HEADER = "X-CMS-File-Filename"
 
     def __init__(self, file_cacher, app):
         """Create an instance.
@@ -83,11 +85,11 @@ class FileServerMiddleware(object):
         """
         original_response = Response.from_app(self.wrapped_app, environ)
 
-        if "X-CMS-File-Digest" not in original_response.headers:
+        if self.DIGEST_HEADER not in original_response.headers:
             return original_response
 
-        digest = original_response.headers.pop("X-CMS-File-Digest")
-        filename = original_response.headers.pop("X-CMS-File-Filename", None)
+        digest = original_response.headers.pop(self.DIGEST_HEADER)
+        filename = original_response.headers.pop(self.FILENAME_HEADER, None)
         mimetype = original_response.mimetype
 
         try:

--- a/cms/server/util.py
+++ b/cms/server/util.py
@@ -41,6 +41,7 @@ from future.moves.urllib.parse import quote, urlencode
 from tornado.web import RequestHandler
 
 from cms.db import Session
+from cms.server.file_middleware import FileServerMiddleware
 from cmscommon.datetime import make_datetime
 
 
@@ -84,8 +85,8 @@ class FileHandlerMixin(RequestHandler):
         filename (str): the name the file should be served as.
 
         """
-        self.set_header("X-CMS-File-Digest", digest)
-        self.set_header("X-CMS-File-Filename", filename)
+        self.set_header(FileServerMiddleware.DIGEST_HEADER, digest)
+        self.set_header(FileServerMiddleware.FILENAME_HEADER, filename)
         self.set_header("Content-Type", content_type)
         self.finish()
 

--- a/cms/server/util.py
+++ b/cms/server/util.py
@@ -34,17 +34,13 @@ from __future__ import unicode_literals
 from future.builtins.disabled import *  # noqa
 from future.builtins import *  # noqa
 
-import time
 import logging
+from functools import wraps
 from future.moves.urllib.parse import quote, urlencode
 
-from functools import wraps
 from tornado.web import RequestHandler
 
-import gevent
-
 from cms.db import Session
-from cms.db.filecacher import FileCacher
 from cmscommon.datetime import make_datetime
 
 
@@ -67,73 +63,31 @@ def multi_contest(f):
     return wrapped_f
 
 
-def file_handler_gen(BaseClass):
-    """This generates an extension of the BaseHandler that allows us
-    to send files to the user. This *Gen is needed because the code in
-    the class FileHandler is exactly the same (in AWS and CWS) but
-    they inherits from different BaseHandler.
+class FileHandlerMixin(RequestHandler):
 
-    BaseClass (type): the BaseHandler of our server.
+    """Provide methods for serving files.
 
-    return (type): a FileHandler extending BaseClass.
+    Due to shortcomings of Tornado's WSGI support we need to resort to
+    hack-ish solutions to achieve efficient file serving. For a more
+    detailed explanation see the docstrings of FileServerMiddleware.
 
     """
-    class FileHandler(BaseClass):
-        """Base class for handlers that need to serve a file to the user.
+
+    def fetch(self, digest, content_type, filename):
+        """Serve the file with the given digest.
+
+        This will just add the headers required to trigger
+        FileServerMiddleware, which will do the real work.
+
+        digest (str): the digest of the file that has to be served.
+        content_type (str): the MIME type the file should be served as.
+        filename (str): the name the file should be served as.
 
         """
-        def fetch(self, digest, content_type, filename):
-            """Send a file from FileCacher by its digest."""
-            if len(digest) == 0:
-                logger.error("No digest given")
-                self.finish()
-                return
-            try:
-                with self.service.file_cacher.get_file(digest) \
-                        as self.temp_file:
-                    self._fetch_temp_file(content_type, filename)
-            except Exception:
-                logger.error("Exception while retrieving file `%s'.", digest,
-                             exc_info=True)
-                self.finish()
-
-        def _fetch_temp_file(self, content_type, filename):
-            """When calling this method, self.temp_file must be a fileobj
-            seeked at the beginning of the file.
-
-            """
-            self.set_header("Content-Type", content_type)
-            self.set_header("Content-Disposition",
-                            "attachment; filename=\"%s\"" % filename)
-            self.start_time = time.time()
-            self.size = 0
-
-            # TODO - Here I'm changing things as few as possible when
-            # switching from the asynchronous to the greenlet-based
-            # framework; at some point this should be rewritten in a
-            # somewhat more greenlet-idomatic way...
-            ret = True
-            while ret:
-                ret = self._fetch_write_chunk()
-                gevent.sleep(0)
-
-        def _fetch_write_chunk(self):
-            """Send a chunk of the file to the browser.
-
-            """
-            data = self.temp_file.read(FileCacher.CHUNK_SIZE)
-            length = len(data)
-            self.size += length / (1024 * 1024)
-            self.write(data)
-            if length < FileCacher.CHUNK_SIZE:
-                duration = time.time() - self.start_time
-                logger.info("%.3lf seconds for %.3lf MB",
-                            duration, self.size)
-                self.finish()
-                return False
-            return True
-
-    return FileHandler
+        self.set_header("X-CMS-File-Digest", digest)
+        self.set_header("X-CMS-File-Filename", filename)
+        self.set_header("Content-Type", content_type)
+        self.finish()
 
 
 def get_url_root(request_path):

--- a/cmstestsuite/unit_tests/server/file_middleware_test.py
+++ b/cmstestsuite/unit_tests/server/file_middleware_test.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future.builtins.disabled import *
+from future.builtins import *
+
+import io
+import random
+import unittest
+
+from mock import Mock
+from werkzeug.http import quote_header_value
+from werkzeug.test import Client, EnvironBuilder
+from werkzeug.wrappers import Response
+from werkzeug.wsgi import responder
+
+from cms.db.filecacher import TombstoneError
+from cms.server.file_middleware import FileServerMiddleware
+from cmscommon.digest import bytes_digest
+
+
+class TestFileByDigestMiddleware(unittest.TestCase):
+
+    def setUp(self):
+        # We need to wrap the generator in a list because of a
+        # shortcoming of future's bytes implementation.
+        self.content = bytes([random.getrandbits(8) for _ in range(1024)])
+        self.digest = bytes_digest(self.content)
+
+        self.filename = "foobar.pdf"
+        self.mimetype = "image/jpeg"
+
+        self.file_cacher = Mock()
+        self.file_cacher.get_file = Mock(
+            side_effect=lambda digest: io.BytesIO(self.content))
+        self.file_cacher.get_size = Mock(return_value=len(self.content))
+
+        self.serve_file = True
+        self.provide_filename = True
+
+        self.wsgi_app = FileServerMiddleware(self.file_cacher, self.wrapped_wsgi_app)
+        self.environ_builder = EnvironBuilder("/some/url")
+        self.client = Client(self.wsgi_app, Response)
+
+    @responder
+    def wrapped_wsgi_app(self, environ, start_response):
+        self.assertEqual(environ, self.environ)
+        if self.serve_file:
+            headers = {"X-CMS-File-Digest": self.digest}
+            if self.provide_filename:
+                headers["X-CMS-File-Filename"] = self.filename
+            return Response(headers=headers, mimetype=self.mimetype)
+        else:
+            return Response(b"some other content", mimetype="text/plain")
+
+    def request(self, headers=None):
+        if headers is not None:
+            for key, value in headers:
+                self.environ_builder.headers.add(key, value)
+        self.environ = self.environ_builder.get_environ()
+        return self.client.open(self.environ)
+
+    def test_success(self):
+        response = self.request()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, self.mimetype)
+        self.assertEqual(
+            response.headers.get("content-disposition"),
+            "attachment; filename=%s" % quote_header_value(self.filename))
+        self.assertTupleEqual(response.get_etag(), (self.digest, False))
+        self.assertEqual(response.accept_ranges, "bytes")
+        self.assertGreater(response.cache_control.max_age, 0)
+        self.assertTrue(response.cache_control.private)
+        self.assertFalse(response.cache_control.public)
+        self.assertEqual(response.get_data(), self.content)
+
+        self.file_cacher.get_file.assert_called_once_with(self.digest)
+
+    def test_not_a_file(self):
+        self.serve_file = False
+
+        response = self.request()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "text/plain")
+        self.assertEqual(response.get_data(), b"some other content")
+
+    def test_no_filename(self):
+        self.provide_filename = False
+
+        response = self.request()
+
+        self.assertNotIn("content-disposition", response.headers)
+
+    def test_not_found(self):
+        self.file_cacher.get_file.side_effect = KeyError()
+
+        response = self.request()
+
+        self.assertEqual(response.status_code, 404)
+
+        self.file_cacher.get_file.assert_called_once_with(self.digest)
+
+    def test_tombstone(self):
+        self.file_cacher.get_file.side_effect = TombstoneError()
+
+        response = self.request()
+
+        self.assertEqual(response.status_code, 503)
+
+        self.file_cacher.get_file.assert_called_once_with(self.digest)
+
+    def test_conditional_request(self):
+        # Test an etag that matches.
+        response = self.request(headers=[("If-None-Match", self.digest)])
+        self.assertEqual(response.status_code, 304)
+        self.assertEqual(len(response.get_data()), 0)
+
+        # Test an etag that doesn't match.
+        response = self.request(headers=[("If-None-Match", "not the etag")])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_data(), self.content)
+
+    def test_range_request(self):
+        # Test a range that is strictly included.
+        response = self.request(headers=[("Range", "bytes=256-767")])
+        self.assertEqual(response.status_code, 206)
+        self.assertEqual(response.content_range.units, "bytes")
+        self.assertEqual(response.content_range.start, 256)
+        self.assertEqual(response.content_range.stop, 768)
+        self.assertEqual(response.content_range.length, 1024)
+        self.assertEqual(response.get_data(), self.content[256:768])
+
+        # Test a range that ends after the end of the file.
+        response = self.request(headers=[("Range", "bytes=256-2047")])
+        self.assertEqual(response.status_code, 206)
+        self.assertEqual(response.content_range.units, "bytes")
+        self.assertEqual(response.content_range.start, 256)
+        self.assertEqual(response.content_range.stop, 1024)
+        self.assertEqual(response.content_range.length, 1024)
+        self.assertEqual(response.get_data(), self.content[256:])
+
+        # Test a range that starts after the end of the file.
+        response = self.request(headers=[("Range", "bytes=1536-")])
+        self.assertEqual(response.status_code, 416)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmstestsuite/unit_tests/server/file_middleware_test.py
+++ b/cmstestsuite/unit_tests/server/file_middleware_test.py
@@ -69,9 +69,9 @@ class TestFileByDigestMiddleware(unittest.TestCase):
     def wrapped_wsgi_app(self, environ, start_response):
         self.assertEqual(environ, self.environ)
         if self.serve_file:
-            headers = {"X-CMS-File-Digest": self.digest}
+            headers = {FileServerMiddleware.DIGEST_HEADER: self.digest}
             if self.provide_filename:
-                headers["X-CMS-File-Filename"] = self.filename
+                headers[FileServerMiddleware.FILENAME_HEADER] = self.filename
             return Response(headers=headers, mimetype=self.mimetype)
         else:
             return Response(b"some other content", mimetype="text/plain")

--- a/cmstestsuite/unit_tests/server/file_middleware_test.py
+++ b/cmstestsuite/unit_tests/server/file_middleware_test.py
@@ -58,7 +58,8 @@ class TestFileByDigestMiddleware(unittest.TestCase):
         self.serve_file = True
         self.provide_filename = True
 
-        self.wsgi_app = FileServerMiddleware(self.file_cacher, self.wrapped_wsgi_app)
+        self.wsgi_app = \
+            FileServerMiddleware(self.file_cacher,self.wrapped_wsgi_app)
         self.environ_builder = EnvironBuilder("/some/url")
         self.client = Client(self.wsgi_app, Response)
 


### PR DESCRIPTION
The Tornado WSGI adapter buffers the whole response before starting to send it to the client. This causes unexpected spikes in memory usage and could be a vector for a denial-of-service attack. The Tornado devs have no intention of fixing this, as their WSGI support is sub-standard by design.

This commit implements file serving as a "native" WSGI application and inserts it as a middleware into our stack. The Tornado handlers that want to serve files have to issue an empty response with some custom headers. These requests will be intercepted by the middleware that will replace them with the actual files, in an efficient streaming fashion. The middleware also supports conditional requests (based on the ETag header) and partial requests (based on the Range header).

This also uses a mixin class to provide the file-serving methods to the handlers rather than a function that would dynamically extend a given class (thus avoiding magic and improving static analysis).

Unit tests are introduced too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/984)
<!-- Reviewable:end -->
