### PR TITLE
Rename async to async_config

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -97,7 +97,7 @@ class Config(object):
         directory.
 
         """
-        self.async = async_config
+        self.async_config = async_config
 
         # System-wide
         self.cmsuser = "cmsuser"
@@ -270,7 +270,7 @@ class Config(object):
             for shard_number, shard in \
                     enumerate(data["core_services"][service]):
                 coord = ServiceCoord(service, shard_number)
-                self.async.core_services[coord] = Address(*shard)
+                self.async_config.core_services[coord] = Address(*shard)
         del data["core_services"]
 
         for service in data["other_services"]:
@@ -279,7 +279,7 @@ class Config(object):
             for shard_number, shard in \
                     enumerate(data["other_services"][service]):
                 coord = ServiceCoord(service, shard_number)
-                self.async.other_services[coord] = Address(*shard)
+                self.async_config.other_services[coord] = Address(*shard)
         del data["other_services"]
 
         # Put everything else in self.

--- a/cms/service/Checker.py
+++ b/cms/service/Checker.py
@@ -48,7 +48,7 @@ class Checker(Service):
 
     def __init__(self, shard):
         Service.__init__(self, shard)
-        for service in config.async.core_services:
+        for service in config.async_config.core_services:
             self.connect_to(service)
         self.add_timeout(self.check, None, 90.0, immediately=True)
 

--- a/cms/service/ResourceService.py
+++ b/cms/service/ResourceService.py
@@ -292,7 +292,7 @@ class ResourceService(Service):
 
         """
         logger.debug("ResourceService._find_local_services")
-        services = config.async.core_services
+        services = config.async_config.core_services
         local_machine = services[self._my_coord].ip
         local_services = [x
                           for x in services


### PR DESCRIPTION
Since python 3.7, `async` is a reserved keyword, so we get a parser error in `conf.py`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/990)
<!-- Reviewable:end -->
