### PR TITLE
Support having 2 tasks with the same name on DB

### DIFF
--- a/cms/db/task.py
+++ b/cms/db/task.py
@@ -99,8 +99,7 @@ class Task(Base):
     # Short name and long human readable title of the task.
     name = Column(
         Codename,
-        nullable=False,
-        unique=True)
+        nullable=False)
     title = Column(
         Unicode,
         nullable=False)

--- a/cmscontrib/AddStatement.py
+++ b/cmscontrib/AddStatement.py
@@ -44,8 +44,8 @@ from cmscontrib.importing import ImportDataError, task_from_db
 logger = logging.getLogger(__name__)
 
 
-def add_statement(task_name, task_id, language_code, statement_file,
-                  overwrite):
+def add_statement(task_name, language_code, statement_file,
+                  overwrite, task_id=None):
     logger.info("Adding the statement(language: %s) of task %s "
                 "in the database.", language_code, task_name)
 
@@ -85,7 +85,6 @@ def add_statement(task_name, task_id, language_code, statement_file,
         session.commit()
 
     logger.info("Statement added.")
-    return True
 
 
 def main():
@@ -109,15 +108,15 @@ def main():
     args = parser.parse_args()
 
     try:
-        success = add_statement(
-            args.task_name, args.task_id, args.language_code,
-            args.statement_file, args.overwrite)
+        add_statement(
+            args.task_name, args.language_code,
+            args.statement_file, args.overwrite, args.task_id)
     except ImportDataError as e:
         logger.error(str(e))
         logger.info("Error while importing, no changes were made.")
         return 1
 
-    return 0 if success is True else 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/cmscontrib/AddSubmission.py
+++ b/cmscontrib/AddSubmission.py
@@ -98,7 +98,8 @@ def add_submission(contest_id, username, task_name, timestamp, files):
             .filter(Task.name == task_name)\
             .first()
         if task is None:
-            logging.critical("Unable to find task `%s'.", task_name)
+            logging.critical("Unable to find task `%s' in the contest.",
+                             task_name)
             return False
 
         elements = set(task.submission_format)
@@ -163,7 +164,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Adds a submission to a contest in CMS.")
     parser.add_argument("-c", "--contest-id", action="store", type=int,
-                        help="id of contest where to add the user")
+                        help="id of contest where to add the submission")
     parser.add_argument("-f", "--file", action="append", type=utf8_decoder,
                         help="in the form <name>:<file>, where name is the "
                         "name as required by CMS, and file is the name of "

--- a/cmscontrib/AddTestcases.py
+++ b/cmscontrib/AddTestcases.py
@@ -4,6 +4,7 @@
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2016 Peyman Jabbarzade Ganje <peyman.jabarzade@gmail.com>
 # Copyright © 2016 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2018 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -36,23 +37,21 @@ import sys
 import re
 
 from cms import utf8_decoder
-from cms.db import Contest, Dataset, SessionGen, Task
+from cms.db import Dataset, SessionGen
 from cms.db.filecacher import FileCacher
 from cmscommon.importers import import_testcases_from_zipfile
+from cmscontrib.importing import ImportDataError, task_from_db
 
 
 logger = logging.getLogger(__name__)
 
 
 def add_testcases(archive, input_template, output_template,
-                  task_name, dataset_description=None, contest_name=None,
+                  task_name, task_id, dataset_description=None,
                   public=False, overwrite=False):
     with SessionGen() as session:
-        task = session.query(Task)\
-            .filter(Task.name == task_name).first()
-        if not task:
-            logger.error("No task called %s found." % task_name)
-            return False
+        task = task_from_db(session, task_name, task_id)
+
         dataset = task.active_dataset
         if dataset_description is not None:
             dataset = session.query(Dataset)\
@@ -60,15 +59,8 @@ def add_testcases(archive, input_template, output_template,
                 .filter(Dataset.description == dataset_description)\
                 .first()
             if not dataset:
-                logger.error("No dataset called %s found."
+                logger.error("No dataset called `%s' found."
                              % dataset_description)
-                return False
-        if contest_name is not None:
-            contest = session.query(Contest)\
-                .filter(Contest.name == contest_name).first()
-            if task.contest != contest:
-                logger.error("%s is not in %s" %
-                             (task_name, contest_name))
                 return False
 
         file_cacher = FileCacher()
@@ -108,16 +100,22 @@ def main():
                         help="if testcases should be public")
     parser.add_argument("-o", "--overwrite", action="store_true",
                         help="if testcases can overwrite existing testcases")
-    parser.add_argument("-c", "--contest_name", action="store",
-                        help="contest which testcases will be attached to")
+    parser.add_argument("-t", "--task-id", action="store", type=int,
+                        help="optional task ID used for disambiguation")
     parser.add_argument("-d", "--dataset_description", action="store",
                         help="dataset testcases will be attached to")
     args = parser.parse_args()
 
-    success = add_testcases(
-        args.file, args.inputtemplate, args.outputtemplate,
-        args.task_name, args.dataset_description, args.contest_name,
-        args.public, args.overwrite)
+    try:
+        success = add_testcases(
+            args.file, args.inputtemplate, args.outputtemplate,
+            args.task_name, args.dataset_description, args.contest_name,
+            args.public, args.overwrite)
+    except ImportDataError as e:
+        logger.error(str(e))
+        logger.info("Error while importing, no changes were made.")
+        return 1
+
     return 0 if success is True else 1
 
 

--- a/cmscontrib/ImportContest.py
+++ b/cmscontrib/ImportContest.py
@@ -240,7 +240,7 @@ class ContestImporter(object):
                 "contest yet. It is recommended to double-check if this is "
                 "REALLY the task intended to be imported in the contest, and "
                 "not some previously-imported task that happens to have the "
-                "same name as this new one.")
+                "same name as this new one." % taskname)
 
             # Proceed using that task.
 

--- a/cmscontrib/ImportContest.py
+++ b/cmscontrib/ImportContest.py
@@ -239,7 +239,7 @@ class ContestImporter(object):
                 "A task with name \"%s\" was found and it's not attached to a "
                 "contest yet. It is recommended to double-check if this is "
                 "REALLY the task intended to be imported in the contest, and "
-                "not some previously-imported task that happen to have the "
+                "not some previously-imported task that happens to have the "
                 "same name as this new one.")
 
             # Proceed using that task.

--- a/cmscontrib/ImportDataset.py
+++ b/cmscontrib/ImportDataset.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 
 class DatasetImporter(object):
-    def __init__(self, path, description, loader_class, task_id):
+    def __init__(self, path, description, loader_class, task_id=None):
         self.file_cacher = FileCacher()
         self.description = description
         self.loader = loader_class(os.path.abspath(path), self.file_cacher)

--- a/cmscontrib/ImportDataset.py
+++ b/cmscontrib/ImportDataset.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Contest Management System - http://cms-dev.github.io/
-# Copyright © 2016 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2018 William Di Luigi <williamdiluigi@gmail.com>
 # Copyright © 2016-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/cmscontrib/RemoveTask.py
+++ b/cmscontrib/RemoveTask.py
@@ -47,7 +47,7 @@ def ask(task_name):
     return ans in ["y", "yes"]
 
 
-def remove_task(task_name, task_id):
+def remove_task(task_name, task_id=None):
     with SessionGen() as session:
         task = task_from_db(session, task_name, task_id)
 

--- a/cmscontrib/importing.py
+++ b/cmscontrib/importing.py
@@ -65,16 +65,16 @@ def contest_from_db(contest_id, session):
     return contest
 
 
-def task_from_db(session, task_name, task_id):
+def task_from_db(session, task_name=None, task_id=None):
     """Return the task object with the given name
 
     session (Session): SQLAlchemy session to use.
-    task_name (string|None): the name of the task, or None to return None.
+    task_name (str|None): the name of the task, or None to return None.
     task_id (int|None): the ID of the task, or None.
 
     return (Task|None): None if task_name is None, or the task.
-    raise (ImportDataError): if there is no task with the given name.
-    raise (AmbiguousTaskName): if the task name is ambiguous.
+    raise (ImportDataError): if there is no task with the given name or if the
+                             task name is ambiguous.
 
     """
     if task_name is None:

--- a/cmstestsuite/unit_tests/cmscontrib/ImportContestTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/ImportContestTest.py
@@ -93,7 +93,7 @@ class TestImportContest(DatabaseMixin, unittest.TestCase):
     def setUp(self):
         super(TestImportContest, self).setUp()
 
-        # DB already contains a contest in a contest with a submission.
+        # DB already contains a task in a contest with a submission.
         self.contest = self.add_contest()
         self.participation = self.add_participation(contest=self.contest)
         self.task = self.add_task(contest=self.contest)
@@ -206,19 +206,19 @@ class TestImportContest(DatabaseMixin, unittest.TestCase):
 
         self.assertFalse(ret)
 
-    def test_import_task_in_db_already_attached_fail(self):
+    def test_import_task_in_db_already_attached_success(self):
         # Completely new contest, but the task is already attached to another
-        # contest in the DB.
+        # contest in the DB. It should be imported as a "detached" new task.
         name = "new_name"
         description = "new_desc"
         contest = self.get_contest(name=name, description=description)
-        task = self.get_task(name=self.task_name, title=self.task_title,
+        task = self.get_task(name=self.task_name, title=self.task_title + " 2",
                              contest=contest)
         ret = self.do_import(contest, [(task, True)], [],
                              import_tasks=True, update_tasks=True)
 
-        self.assertFalse(ret)
-        # Task still tied to the original contest.
+        self.assertTrue(ret)
+        # The original contest is unchanged.
         self.assertContestInDb(self.name, self.description,
                                [(self.task_name, self.task_title)],
                                [(self.username, self.last_name)])


### PR DESCRIPTION
Currently we have three separate uniqueness constraints: (name), (name, contest_id), and (num, contest_id). The first one is not really useful and in some cases it's really annoying (current workaround is adding the `contestname_` as a prefix of taskname).

Fixes #765 

Before:

```
Indexes:
    "tasks_pkey" PRIMARY KEY, btree (id)
    "tasks_contest_id_name_key" UNIQUE CONSTRAINT, btree (contest_id, name)
    "tasks_contest_id_num_key" UNIQUE CONSTRAINT, btree (contest_id, num)
    "tasks_name_key" UNIQUE CONSTRAINT, btree (name)
    "ix_tasks_contest_id" btree (contest_id)
```

After:

```
Indexes:
    "tasks_pkey" PRIMARY KEY, btree (id)
    "tasks_contest_id_name_key" UNIQUE CONSTRAINT, btree (contest_id, name)
    "tasks_contest_id_num_key" UNIQUE CONSTRAINT, btree (contest_id, num)
    "ix_tasks_contest_id" btree (contest_id)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/998)
<!-- Reviewable:end -->
