### PR TITLE
Make sure we can delete the sandbox once done

### DIFF
--- a/cms/grading/tasktypes/util.py
+++ b/cms/grading/tasktypes/util.py
@@ -83,17 +83,17 @@ def delete_sandbox(sandbox, success=True):
     success (boolean): if the job succeeded (no system errors).
 
     """
-    sandbox.cleanup()
     # If the job was not successful, we keep the sandbox around.
     if not success:
         logger.warning("Sandbox %s kept around because job did not succeeded.",
                        sandbox.get_root_path())
-    elif not config.keep_sandbox:
-        try:
-            sandbox.delete()
-        except (IOError, OSError):
-            err_msg = "Couldn't delete sandbox."
-            logger.warning(err_msg, exc_info=True)
+
+    delete = success and not config.keep_sandbox
+    try:
+        sandbox.cleanup(delete=delete)
+    except (IOError, OSError):
+        err_msg = "Couldn't delete sandbox."
+        logger.warning(err_msg, exc_info=True)
 
 
 def is_manager_for_compilation(filename, language):

--- a/cmstestsuite/unit_tests/grading/tasktypes/BatchTest.py
+++ b/cmstestsuite/unit_tests/grading/tasktypes/BatchTest.py
@@ -165,7 +165,7 @@ class TestCompile(TaskTypeTestMixin, unittest.TestCase):
         # Results put in job, executable stored and sandbox deleted.
         self.assertResultsInJob(job)
         sandbox.get_file_to_storage.assert_called_once_with("foo", ANY)
-        sandbox.delete.assert_called_once()
+        sandbox.cleanup.assert_called_once_with(delete=True)
 
     def test_alone_failure_missing_file(self):
         # For some reason the user submission is missing. This should not
@@ -201,7 +201,7 @@ class TestCompile(TaskTypeTestMixin, unittest.TestCase):
         # Results put in job, executable stored and sandbox deleted.
         self.assertResultsInJob(job)
         sandbox.get_file_to_storage.assert_called_once_with("bar_foo", ANY)
-        sandbox.delete.assert_called_once()
+        sandbox.cleanup.assert_called_once_with(delete=True)
 
     def test_alone_compilation_failure(self):
         # Compilation failure, but sandbox succeeded. It's the user's fault.
@@ -218,7 +218,7 @@ class TestCompile(TaskTypeTestMixin, unittest.TestCase):
         # But no executable stored.
         sandbox.get_file_to_storage.assert_not_called()
         # Still, we delete the sandbox, since it's not an error.
-        sandbox.delete.assert_called_once()
+        sandbox.cleanup.assert_called_once_with(delete=True)
 
     def test_alone_sandbox_failure(self):
         # Sandbox (or CMS) failure. It's the admins' fault.
@@ -233,7 +233,7 @@ class TestCompile(TaskTypeTestMixin, unittest.TestCase):
         self.assertResultsInJob(job)
         sandbox.get_file_to_storage.assert_not_called()
         # We preserve the sandbox to let admins check the problem.
-        sandbox.delete.assert_not_called()
+        sandbox.cleanup.assert_called_once_with(delete=False)
 
     def test_grader_success(self):
         # We sprinkle in also a header, that should be copied, but not the
@@ -265,7 +265,7 @@ class TestCompile(TaskTypeTestMixin, unittest.TestCase):
         # Results put in job, executable stored and sandbox deleted.
         self.assertResultsInJob(job)
         sandbox.get_file_to_storage.assert_called_once_with("foo", ANY)
-        sandbox.delete.assert_called_once()
+        sandbox.cleanup.assert_called_once_with(delete=True)
 
     def test_grader_failure_missing_grader(self):
         # Grader is missing from the managers, this is a configuration error.
@@ -373,7 +373,7 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
             user_output_path="/path/0/output.txt", user_output_filename="")
         # Results put in job and sandbox deleted.
         self.assertResultsInJob(job)
-        sandbox.delete.assert_called_once()
+        sandbox.cleanup.assert_called_once_with(delete=True)
 
     def test_stdio_diff_failure_missing_file(self):
         # For some reason the executable is missing. This should not happen
@@ -408,7 +408,7 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
         # eval_output should not have been called, but the since it didn't
         # have any error, the sandbox should be deleted.
         self.eval_output.assert_not_called()
-        sandbox.delete.assert_called_once()
+        sandbox.cleanup.assert_called_once_with(delete=True)
 
     def test_stdio_diff_evaluation_step_sandbox_failure_(self):
         tt, job = self.prepare(["alone", ["", ""], "diff"], {"foo": EXE_FOO})
@@ -420,7 +420,7 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
         self.assertResultsInJob(job)
         # eval_output should not have been called, and the sandbox not deleted.
         self.eval_output.assert_not_called()
-        sandbox.delete.assert_not_called()
+        sandbox.cleanup.assert_called_once_with(delete=False)
 
     def test_stdio_diff_eval_output_failure_(self):
         tt, job = self.prepare(["alone", ["", ""], "diff"], {"foo": EXE_FOO})
@@ -432,7 +432,7 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
         self.assertResultsInJob(job)
         # Even if the error is in the eval_output sandbox, we keep also the one
         # for evaluation_step to allow debugging.
-        sandbox.delete.assert_not_called()
+        sandbox.cleanup.assert_called_once_with(delete=False)
 
     def test_stdio_diff_get_output_success(self):
         tt, job = self.prepare(["alone", ["", ""], "diff"], {"foo": EXE_FOO})
@@ -494,7 +494,7 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
             user_output_filename="myout")
         # Results put in job and sandbox deleted.
         self.assertResultsInJob(job)
-        sandbox.delete.assert_called_once()
+        sandbox.cleanup.assert_called_once_with(delete=True)
 
     def test_stdio_checker_success(self):
         tt, job = self.prepare(["alone", ["", ""], "comparator"],
@@ -509,7 +509,7 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
             user_output_path="/path/0/output.txt", user_output_filename="")
         # Results put in job and sandbox deleted.
         self.assertResultsInJob(job)
-        sandbox.delete.assert_called_once()
+        sandbox.cleanup.assert_called_once_with(delete=True)
 
     def test_fileio_checker_success(self):
         tt, job = self.prepare(["alone", ["myin", "myout"], "comparator"],
@@ -525,7 +525,7 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
             user_output_filename="myout")
         # Results put in job and sandbox deleted.
         self.assertResultsInJob(job)
-        sandbox.delete.assert_called_once()
+        sandbox.cleanup.assert_called_once_with(delete=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In some systems, Java compilation creates directories and files; since
they are owned by the user within isolate, the user outside is unable
to delete them. This change essentially issues a chmod within isolate
when we want to later delete the whole sandbox, to make sure we will
be able to.

As a side effect, this merges cleanup() and delete(), that were anyway
very close already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/999)
<!-- Reviewable:end -->
