### PR TITLE
Override score_Type if explicitly specified

### DIFF
--- a/cmscontrib/loaders/italy_yaml.py
+++ b/cmscontrib/loaders/italy_yaml.py
@@ -6,7 +6,7 @@
 # Copyright © 2010-2017 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2013-2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
-# Copyright © 2014-2016 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2014-2018 William Di Luigi <williamdiluigi@gmail.com>
 # Copyright © 2015 Luca Chiodini <luca@chiodini.org>
 # Copyright © 2016 Andrea Cracco <guilucand@gmail.com>
 # Copyright © 2018 Edoardo Morassutto <edoardo.morassutto@gmail.com>
@@ -592,6 +592,12 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
             if n_input != 0:
                 input_value = total_value / n_input
             args["score_type_parameters"] = input_value
+
+        # Override score_type if explicitly specified
+        if "score_type" in conf and "score_type_parameters" in conf:
+            logger.warning("Overriding 'score_type' and 'score_type_parameters' as per task.yaml")
+            load(conf, args, "score_type")
+            load(conf, args, "score_type_parameters")
 
         # If output_only is set, then the task type is OutputOnly
         if conf.get('output_only', False):


### PR DESCRIPTION
This lets me import, for example, tasks that don't have generator (just input / output folders) and have subtasks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1002)
<!-- Reviewable:end -->
