### PR TITLE
Couple of tweaks to CWS's submission list UI.

### DIFF
--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -196,15 +196,13 @@ class SubmissionStatusHandler(ContestHandler):
         if data["status"] == SubmissionResult.COMPILING:
             data["status_text"] = self._("Compiling...")
         elif data["status"] == SubmissionResult.COMPILATION_FAILED:
-            data["status_text"] = "%s <a class=\"details\">%s</a>" % (
-                self._("Compilation failed"), self._("details"))
+            data["status_text"] = self._("Compilation failed")
         elif data["status"] == SubmissionResult.EVALUATING:
             data["status_text"] = self._("Evaluating...")
         elif data["status"] == SubmissionResult.SCORING:
             data["status_text"] = self._("Scoring...")
         elif data["status"] == SubmissionResult.SCORED:
-            data["status_text"] = "%s <a class=\"details\">%s</a>" % (
-                self._("Evaluated"), self._("details"))
+            data["status_text"] = self._("Evaluated")
 
             score_type = task.active_dataset.score_type_object
             if score_type.max_public_score > 0:

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -8,13 +8,16 @@
     <td class="status">
 {% if status == SubmissionResult.COMPILING %}
         {% trans %}Compiling...{% endtrans %}
+      <img class="details" src="{{ url("static", "loading.gif") }}" />
 {% elif status == SubmissionResult.COMPILATION_FAILED %}
         {% trans %}Compilation failed{% endtrans %}
         <a class="details">{% trans %}details{% endtrans %}</a>
 {% elif status == SubmissionResult.EVALUATING %}
         {% trans %}Evaluating...{% endtrans %}
+      <img class="details" src="{{ url("static", "loading.gif") }}" />
 {% elif status == SubmissionResult.SCORING %}
         {% trans %}Scoring...{% endtrans %}
+      <img class="details" src="{{ url("static", "loading.gif") }}" />
 {% elif status == SubmissionResult.SCORED %}
         {% trans %}Evaluated{% endtrans %}
         <a class="details">{% trans %}details{% endtrans %}</a>

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -42,7 +42,15 @@ function get_score_class (score, max_score) {
 update_submission_row = function (submission_id, data) {
     var row = $("#submission_list tbody tr[data-submission=\"" + submission_id + "\"]");
     row.attr("data-status", data["status"]);
-    row.children("td.status").html(data["status_text"]);
+    row.children("td.status").text(data["status_text"]);
+    if (data["status"] != {{ SubmissionResult.COMPILATION_FAILED }}
+            && data["status"] != {{ SubmissionResult.SCORED }}) {
+        row.children("td.status").append(
+            $("<img class=\"details\" src=\"{{ url("static", "loading.gif") }}\"/>"));
+    } else {
+        row.children("td.status").append(
+            $("<a class=\"details\">{% trans %}details{% endtrans %}</a>"));
+    }
     if (data["status"] == {{ SubmissionResult.SCORED }}) {
         if (data["public_score"] != undefined) {
             row.children("td.public_score").addClass(get_score_class(data["public_score"], data["max_public_score"]));

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -69,11 +69,25 @@ update_submission_row = function (submission_id, data) {
 };
 
 schedule_update_submission_row = function (submission_id) {
+    if (typeof(schedule_update_submission_row.delays) === "undefined") {
+        schedule_update_submission_row.delays = {};
+    }
+    if (!schedule_update_submission_row.delays[submission_id]) {
+        schedule_update_submission_row.delays[submission_id] = 1000.0;
+    } else {
+        // We want exponential backoff, but slightly staggered across submissions to
+        // avoid asking about all of them at the same time, so we use 1.4 plus a
+        // value depending on the submission id.
+        var hash = (37 * parseInt(submission_id)) % 100 / 100.0;
+        schedule_update_submission_row.delays[submission_id] =
+            schedule_update_submission_row.delays[submission_id]
+                * (1.4 + hash * 0.2);
+    }
     setTimeout(function () {
         $.get(utils.contest_url("tasks", "{{ task.name }}", "submissions", submission_id), function (data) {
             update_submission_row(submission_id, data);
         });
-    }, 10000);
+    }, schedule_update_submission_row.delays[submission_id]);
 };
 
 $(document).ready(function () {


### PR DESCRIPTION
The exponentially backing off strategy starts with much more frequent
queries than before - I think somebody was asking for it due to
contestants keeping hit refresh anyway... Looking at my usage pattern
I think I agree with them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1012)
<!-- Reviewable:end -->
