### PR TITLE
RWS: return 0 after dropping stored data

### DIFF
--- a/cmsranking/RankingWebServer.py
+++ b/cmsranking/RankingWebServer.py
@@ -519,7 +519,7 @@ def main():
             shutil.rmtree(config.lib_dir)
         else:
             print("Not removing directory %s." % config.lib_dir)
-        return 1
+        return 0
 
     stores = dict()
 


### PR DESCRIPTION
In RankingWebServer's main(), after the data is dropped, the return code should return 0 (to signify success) instead of 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1013)
<!-- Reviewable:end -->
