### PR TITLE
Multi-source tasks and Python language

### DIFF
--- a/cms/grading/languages/python2_cpython.py
+++ b/cms/grading/languages/python2_cpython.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Contest Management System - http://cms-dev.github.io/
-# Copyright © 2016-2017 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2016-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -41,6 +41,8 @@ class Python2CPython(CompiledLanguage):
 
     """
 
+    MAIN_FILENAME = "__main__.pyc"
+
     @property
     def name(self):
         """See Language.name."""
@@ -55,11 +57,27 @@ class Python2CPython(CompiledLanguage):
                                  source_filenames, executable_filename,
                                  for_evaluation=True):
         """See Language.get_compilation_commands."""
-        py_command = ["/usr/bin/python2", "-m", "py_compile",
-                      source_filenames[0]]
-        mv_command = ["/bin/mv", "%s.pyc" % os.path.splitext(os.path.basename(
-                      source_filenames[0]))[0], executable_filename]
-        return [py_command, mv_command]
+        zip_filename = "%s.zip" % executable_filename
+
+        commands = []
+        files_to_package = []
+        commands.append(["/usr/bin/python2", "-m", "compileall", "."])
+        for idx, source_filename in enumerate(source_filenames):
+            basename = os.path.splitext(os.path.basename(source_filename))[0]
+            pyc_filename = "%s.pyc" % basename
+            # The file with the entry point must be in first position.
+            if idx == 0:
+                commands.append(["/bin/mv", pyc_filename, self.MAIN_FILENAME])
+                files_to_package.append(self.MAIN_FILENAME)
+            else:
+                files_to_package.append(pyc_filename)
+
+        # zip does not support writing to a file without extension.
+        commands.append(["/usr/bin/zip", "-r", zip_filename]
+                        + files_to_package)
+        commands.append(["/bin/mv", zip_filename, executable_filename])
+
+        return commands
 
     def get_evaluation_commands(
             self, executable_filename, main=None, args=None):

--- a/cms/grading/languages/python3_cpython.py
+++ b/cms/grading/languages/python3_cpython.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Contest Management System - http://cms-dev.github.io/
-# Copyright © 2016-2017 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2016-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -41,6 +41,8 @@ class Python3CPython(CompiledLanguage):
 
     """
 
+    MAIN_FILENAME = "__main__.pyc"
+
     @property
     def name(self):
         """See Language.name."""
@@ -55,13 +57,27 @@ class Python3CPython(CompiledLanguage):
                                  source_filenames, executable_filename,
                                  for_evaluation=True):
         """See Language.get_compilation_commands."""
-        basename = os.path.splitext(os.path.basename(source_filenames[0]))[0]
-        compilation_program = ";".join([
-            "import py_compile as m",
-            "m.compile(%s, %s, doraise=True)" % (
-                repr(basename + ".py"), repr(basename))])
-        py_command = ["/usr/bin/python3", "-c", compilation_program]
-        return [py_command]
+        zip_filename = "%s.zip" % executable_filename
+
+        commands = []
+        files_to_package = []
+        commands.append(["/usr/bin/python3", "-m", "compileall", "-b", "."])
+        for idx, source_filename in enumerate(source_filenames):
+            basename = os.path.splitext(os.path.basename(source_filename))[0]
+            pyc_filename = "%s.pyc" % basename
+            # The file with the entry point must be in first position.
+            if idx == 0:
+                commands.append(["/bin/mv", pyc_filename, self.MAIN_FILENAME])
+                files_to_package.append(self.MAIN_FILENAME)
+            else:
+                files_to_package.append(pyc_filename)
+
+        # zip does not support writing to a file without extension.
+        commands.append(["/usr/bin/zip", "-r", zip_filename]
+                        + files_to_package)
+        commands.append(["/bin/mv", zip_filename, executable_filename])
+
+        return commands
 
     def get_evaluation_commands(
             self, executable_filename, main=None, args=None):

--- a/cmstestsuite/Tests.py
+++ b/cmstestsuite/Tests.py
@@ -243,16 +243,18 @@ ALL_TESTS = [
          languages=ALL_LANGUAGES,
          checks=[CheckOverallScore(0, 100)]),
 
-    # Tasks with graders. Python and PHP are not yet supported.
+    # Tasks with graders. PHP is not yet supported.
 
     Test('managed-correct',
          task=batch_fileio_managed, filenames=['managed-correct.%l'],
-         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA, LANG_C_SHARP),
+         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_PYTHON, LANG_JAVA,
+                    LANG_C_SHARP),
          checks=[CheckOverallScore(100, 100)]),
 
     Test('managed-incorrect',
          task=batch_fileio_managed, filenames=['managed-incorrect.%l'],
-         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA, LANG_C_SHARP),
+         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_PYTHON, LANG_JAVA,
+                    LANG_C_SHARP),
          checks=[CheckOverallScore(0, 100)]),
 
     # Communication tasks. Python and PHP are not yet supported.
@@ -260,37 +262,37 @@ ALL_TESTS = [
     Test('communication-fifoio-correct',
          task=communication_fifoio_stubbed,
          filenames=['communication-stubbed-correct.%l'],
-         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA),
+         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_PYTHON, LANG_JAVA),
          checks=[CheckOverallScore(100, 100)]),
 
     Test('communication-fifoio-incorrect',
          task=communication_fifoio_stubbed,
          filenames=['communication-stubbed-incorrect.%l'],
-         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA),
+         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_PYTHON, LANG_JAVA),
          checks=[CheckOverallScore(0, 100)]),
 
     Test('communication-stdio-correct',
          task=communication_stdio_stubbed,
          filenames=['communication-stubbed-correct.%l'],
-         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA),
+         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_PYTHON, LANG_JAVA),
          checks=[CheckOverallScore(100, 100)]),
 
     Test('communication-stdio-incorrect',
          task=communication_stdio_stubbed,
          filenames=['communication-stubbed-incorrect.%l'],
-         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA),
+         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_PYTHON, LANG_JAVA),
          checks=[CheckOverallScore(0, 100)]),
 
     Test('communication-stdio-unstubbed-correct',
          task=communication_stdio,
          filenames=['communication-stdio-correct.%l'],
-         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA),
+         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_PYTHON, LANG_JAVA),
          checks=[CheckOverallScore(100, 100)]),
 
     Test('communication-stdio-unstubbed-incorrect',
          task=communication_stdio,
          filenames=['communication-stdio-incorrect.%l'],
-         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA),
+         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_PYTHON, LANG_JAVA),
          checks=[CheckOverallScore(0, 100)]),
 
     # Communication tasks with two processes.
@@ -299,28 +301,28 @@ ALL_TESTS = [
          task=communication_many_fifoio_stubbed,
          filenames=['communication-many-correct-user1.%l',
                     'communication-many-correct-user2.%l'],
-         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA),
+         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_PYTHON, LANG_JAVA),
          checks=[CheckOverallScore(100, 100)]),
 
     Test('communication-many-fifoio-incorrect',
          task=communication_many_fifoio_stubbed,
          filenames=['communication-many-incorrect-user1.%l',
                     'communication-many-incorrect-user2.%l'],
-         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA),
+         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_PYTHON, LANG_JAVA),
          checks=[CheckOverallScore(0, 100)]),
 
     Test('communication-many-stdio-correct',
          task=communication_many_stdio_stubbed,
          filenames=['communication-many-correct-user1.%l',
                     'communication-many-correct-user2.%l'],
-         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA),
+         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_PYTHON, LANG_JAVA),
          checks=[CheckOverallScore(100, 100)]),
 
     Test('communication-many-stdio-incorrect',
          task=communication_many_stdio_stubbed,
          filenames=['communication-many-incorrect-user1.%l',
                     'communication-many-incorrect-user2.%l'],
-         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_JAVA),
+         languages=(LANG_C, LANG_CPP, LANG_PASCAL, LANG_PYTHON, LANG_JAVA),
          checks=[CheckOverallScore(0, 100)]),
 
     # TwoSteps

--- a/cmstestsuite/code/communication-many-correct-user1.py
+++ b/cmstestsuite/code/communication-many-correct-user1.py
@@ -1,0 +1,2 @@
+def userfunc1(x):
+    return x

--- a/cmstestsuite/code/communication-many-correct-user2.py
+++ b/cmstestsuite/code/communication-many-correct-user2.py
@@ -1,0 +1,2 @@
+def userfunc2(x):
+    return -x

--- a/cmstestsuite/code/communication-many-incorrect-user1.py
+++ b/cmstestsuite/code/communication-many-incorrect-user1.py
@@ -1,0 +1,2 @@
+def userfunc1(x):
+    return x + 1

--- a/cmstestsuite/code/communication-many-incorrect-user2.py
+++ b/cmstestsuite/code/communication-many-incorrect-user2.py
@@ -1,0 +1,2 @@
+def userfunc2(x):
+    return -x + 1

--- a/cmstestsuite/code/communication-stdio-correct.py
+++ b/cmstestsuite/code/communication-stdio-correct.py
@@ -1,0 +1,13 @@
+import sys
+
+while True:
+    n = sys.stdin.readline().strip()
+    if n == "":
+        # EOF, let's quit.
+        break
+
+    n = int(n)
+    if n == 0:
+        break
+    sys.stdout.write("correct %d\n" % n)
+    sys.stdout.flush()

--- a/cmstestsuite/code/communication-stdio-incorrect.py
+++ b/cmstestsuite/code/communication-stdio-incorrect.py
@@ -1,0 +1,13 @@
+import sys
+
+while True:
+    n = sys.stdin.readline().strip()
+    if n == "":
+        # EOF, let's quit.
+        break
+
+    n = int(n)
+    if n == 0:
+        break
+    sys.stdout.write("correct %d\n" % (n + 1))
+    sys.stdout.flush()

--- a/cmstestsuite/code/communication-stubbed-correct.py
+++ b/cmstestsuite/code/communication-stubbed-correct.py
@@ -1,0 +1,2 @@
+def userfunc(x):
+    return x

--- a/cmstestsuite/code/communication-stubbed-incorrect.py
+++ b/cmstestsuite/code/communication-stubbed-incorrect.py
@@ -1,0 +1,2 @@
+def userfunc(x):
+    return x + 1

--- a/cmstestsuite/code/managed-correct.py
+++ b/cmstestsuite/code/managed-correct.py
@@ -1,0 +1,2 @@
+def userfunc(x):
+    return x

--- a/cmstestsuite/code/managed-incorrect.py
+++ b/cmstestsuite/code/managed-incorrect.py
@@ -1,0 +1,2 @@
+def userfunc(x):
+    return x + 1

--- a/cmstestsuite/tasks/batch_fileio_managed/__init__.py
+++ b/cmstestsuite/tasks/batch_fileio_managed/__init__.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2012 Bernard Blackham <bernard@largestprime.net>
-# Copyright © 2014-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2014-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -46,6 +46,7 @@ managers = [
     "grader.c",
     "grader.cpp",
     "grader.pas",
+    "grader.py",
     "grader.java",
     "grader.cs",
     "checker",

--- a/cmstestsuite/tasks/batch_fileio_managed/code/grader.py
+++ b/cmstestsuite/tasks/batch_fileio_managed/code/grader.py
@@ -1,0 +1,6 @@
+import batchfileiomanaged
+
+n = int(open("input.txt").readline().strip())
+f = open("output.txt", "w")
+f.write("correct %d\n" % batchfileiomanaged.userfunc(n))
+# f intentionally left open.

--- a/cmstestsuite/tasks/communication_fifoio_stubbed/__init__.py
+++ b/cmstestsuite/tasks/communication_fifoio_stubbed/__init__.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2012-2013 Bernard Blackham <bernard@largestprime.net>
-# Copyright © 2014-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2014-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -45,6 +45,7 @@ managers = [
     "stub.c",
     "stub.cpp",
     "stub.pas",
+    "stub.py",
     "stub.java",
     "manager",
 ]

--- a/cmstestsuite/tasks/communication_fifoio_stubbed/code/stub.py
+++ b/cmstestsuite/tasks/communication_fifoio_stubbed/code/stub.py
@@ -1,0 +1,18 @@
+import sys
+
+import communication  # Submission format is ["communication.%l"]
+
+fin = open(sys.argv[1], "r")
+fout = open(sys.argv[2], "w")
+
+while True:
+    n = fin.readline().strip()
+    if n == "":
+        # EOF, let's quit.
+        break
+
+    n = int(n)
+    if n == 0:
+        break
+    fout.write("correct %d\n" % communication.userfunc(n))
+    fout.flush()

--- a/cmstestsuite/tasks/communication_many_fifoio_stubbed/__init__.py
+++ b/cmstestsuite/tasks/communication_many_fifoio_stubbed/__init__.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2012-2013 Bernard Blackham <bernard@largestprime.net>
-# Copyright © 2014-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2014-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2016 Masaki Hara <ackie.h.gmai@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -46,6 +46,7 @@ managers = [
     "stub.c",
     "stub.cpp",
     "stub.pas",
+    "stub.py",
     "stub.java",
     "manager",
 ]

--- a/cmstestsuite/tasks/communication_many_fifoio_stubbed/code/stub.py
+++ b/cmstestsuite/tasks/communication_many_fifoio_stubbed/code/stub.py
@@ -1,0 +1,23 @@
+import sys
+
+import user1
+import user2
+
+
+fin = open(sys.argv[1], "r")
+fout = open(sys.argv[2], "w")
+
+while True:
+    n = fin.readline().strip()
+    if n == "":
+        # EOF, let's quit.
+        break
+
+    n = int(n)
+    if n == 0:
+        break
+    if int(sys.argv[3]) == 0:
+        fout.write("correct %d\n" % user1.userfunc1(n))
+    else:
+        fout.write("correct %d\n" % user2.userfunc2(n))
+    fout.flush()

--- a/cmstestsuite/tasks/communication_many_stdio_stubbed/__init__.py
+++ b/cmstestsuite/tasks/communication_many_stdio_stubbed/__init__.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2012-2013 Bernard Blackham <bernard@largestprime.net>
-# Copyright © 2014-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2014-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2016 Masaki Hara <ackie.h.gmai@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -46,6 +46,7 @@ managers = [
     "stub.c",
     "stub.cpp",
     "stub.pas",
+    "stub.py",
     "stub.java",
     "manager",
 ]

--- a/cmstestsuite/tasks/communication_many_stdio_stubbed/code/stub.py
+++ b/cmstestsuite/tasks/communication_many_stdio_stubbed/code/stub.py
@@ -1,0 +1,20 @@
+import sys
+
+import user1
+import user2
+
+
+while True:
+    n = sys.stdin.readline().strip()
+    if n == "":
+        # EOF, let's quit.
+        break
+
+    n = int(n)
+    if n == 0:
+        break
+    if int(sys.argv[1]) == 0:
+        sys.stdout.write("correct %d\n" % user1.userfunc1(n))
+    else:
+        sys.stdout.write("correct %d\n" % user2.userfunc2(n))
+    sys.stdout.flush()

--- a/cmstestsuite/tasks/communication_stdio_stubbed/__init__.py
+++ b/cmstestsuite/tasks/communication_stdio_stubbed/__init__.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2012-2013 Bernard Blackham <bernard@largestprime.net>
-# Copyright © 2014-2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2014-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -45,6 +45,7 @@ managers = [
     "stub.c",
     "stub.cpp",
     "stub.pas",
+    "stub.py",
     "stub.java",
     "manager",
 ]

--- a/cmstestsuite/tasks/communication_stdio_stubbed/code/stub.py
+++ b/cmstestsuite/tasks/communication_stdio_stubbed/code/stub.py
@@ -1,0 +1,16 @@
+import sys
+
+import communication  # Submission format is ["communication.%l"]
+
+
+while True:
+    n = sys.stdin.readline().strip()
+    if n == "":
+        # EOF, let's quit.
+        break
+
+    n = int(n)
+    if n == 0:
+        break
+    sys.stdout.write("correct %d\n" % communication.userfunc(n))
+    sys.stdout.flush()


### PR DESCRIPTION
I also manually tested locally with Python 3. For next version we
might want to move the tests to Python 3...

Initially the PR contained also the move of Pascal from "fpc
source_filenames[0]" to "fpc source_filenames [...]", but only worked
locally, travis' version doesn't like it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1016)
<!-- Reviewable:end -->
