### PR TITLE
Add a unit test triggering a bug in IP autologin, and fix the bug

### DIFF
--- a/cms/server/contest/authentication.py
+++ b/cms/server/contest/authentication.py
@@ -38,7 +38,7 @@ import json
 import logging
 from datetime import timedelta
 
-from sqlalchemy.orm import contains_eager
+from sqlalchemy.orm import contains_eager, joinedload
 
 from cms import config
 from cms.db import Participation, User
@@ -259,7 +259,7 @@ def _authenticate_request_by_ip_address(sql_session, contest, ip_address):
     ip_network = ipaddress.ip_network((ip_address, ip_address.max_prefixlen))
 
     participations = sql_session.query(Participation) \
-        .options(contains_eager(Participation.user)) \
+        .options(joinedload(Participation.user)) \
         .filter(Participation.contest == contest) \
         .filter(Participation.ip.any(ip_network))
 


### PR DESCRIPTION
Contains_eager must be used when an explicit join has already been added to the query. If not, it will just end up in a cross product. In that case, when loading participations and users, many rows are returned, one for every user. If the participation's user isn't in the identity map, a new one will be created with its fields initialized using the data of the first result row, even if it's for another user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1022)
<!-- Reviewable:end -->
