### PR TITLE
New analysis spoiler attachments

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -105,7 +105,8 @@ from .fsobject import FSObject, LargeObject
 from .admin import Admin
 from .contest import Contest, Announcement
 from .user import User, Team, Participation, Message, Question
-from .task import Task, Statement, Attachment, Dataset, Manager, Testcase
+from .task import Task, Statement, Attachment, Spoiler, Dataset, Manager, \
+    Testcase
 from .submission import Submission, File, Token, SubmissionResult, \
     Executable, Evaluation
 from .usertest import UserTest, UserTestFile, UserTestManager, \

--- a/cms/db/task.py
+++ b/cms/db/task.py
@@ -251,6 +251,13 @@ class Task(Base):
         passive_deletes=True,
         back_populates="task")
 
+    spoilers = relationship(
+        "Spoiler",
+        collection_class=attribute_mapped_collection("filename"),
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        back_populates="task")
+
     datasets = relationship(
         "Dataset",
         # Due to active_dataset_id, SQLAlchemy cannot unambiguously
@@ -347,6 +354,39 @@ class Attachment(Base):
         Digest,
         nullable=False)
 
+class Spoiler(Base):
+    """Class to store additional files to give to the user together
+    with the statement of the task during analysis mode.
+
+    """
+    __tablename__ = 'spoilers'
+    __table_args__ = (
+        UniqueConstraint('task_id', 'filename'),
+    )
+
+    # Auto increment primary key.
+    id = Column(
+        Integer,
+        primary_key=True)
+
+    # Task (id and object) owning the spoiler.
+    task_id = Column(
+        Integer,
+        ForeignKey(Task.id,
+                   onupdate="CASCADE", ondelete="CASCADE"),
+        nullable=False,
+        index=True)
+    task = relationship(
+        Task,
+        back_populates="spoilers")
+
+    # Filename and digest of the provided spoiler.
+    filename = Column(
+        Filename,
+        nullable=False)
+    digest = Column(
+        Digest,
+        nullable=False)
 
 class Dataset(Base):
     """Class to store the information about a data set.

--- a/cms/db/util.py
+++ b/cms/db/util.py
@@ -38,7 +38,7 @@ from sqlalchemy.exc import OperationalError
 
 from cms import ConfigError
 from . import SessionGen, Digest, Contest, Participation, Statement, \
-    Attachment, Task, Manager, Dataset, Testcase, Submission, File, \
+    Attachment, Spoiler, Task, Manager, Dataset, Testcase, Submission, File, \
     SubmissionResult, Executable, UserTest, UserTestFile, UserTestManager, \
     UserTestResult, UserTestExecutable, PrintJob
 
@@ -296,6 +296,8 @@ def enumerate_files(
     queries.append(task_q.join(Task.statements).with_entities(Statement.digest))
     queries.append(task_q.join(Task.attachments)
                    .with_entities(Attachment.digest))
+    queries.append(task_q.join(Task.spoilers)
+                   .with_entities(Spoiler.digest))
 
     dataset_q = task_q.join(Task.datasets)
     queries.append(dataset_q.join(Dataset.managers)

--- a/cms/server/admin/handlers/__init__.py
+++ b/cms/server/admin/handlers/__init__.py
@@ -73,6 +73,8 @@ from .task import \
     StatementHandler, \
     AddAttachmentHandler, \
     AttachmentHandler, \
+    AddSpoilerHandler, \
+    SpoilerHandler, \
     TaskListHandler, \
     RemoveTaskHandler
 from .dataset import \
@@ -179,6 +181,8 @@ HANDLERS = [
     (r"/task/([0-9]+)/statement/([0-9]+)", StatementHandler),
     (r"/task/([0-9]+)/attachments/add", AddAttachmentHandler),
     (r"/task/([0-9]+)/attachment/([0-9]+)", AttachmentHandler),
+    (r"/task/([0-9]+)/spoilers/add", AddSpoilerHandler),
+    (r"/task/([0-9]+)/spoiler/([0-9]+)", SpoilerHandler),
 
     # Datasets
 

--- a/cms/server/admin/templates/add_spoiler.html
+++ b/cms/server/admin/templates/add_spoiler.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block core %}
+<div class="core_title">
+  <h1><a href="{{ url("task", task.id) }}">{{ task.title }} ({{ task.name }})</a> - Upload spoiler</h1>
+</div>
+<form enctype="multipart/form-data" action="{{ url("task", task.id, "spoilers", "add") }}" method="POST">
+  {{ xsrf_form_html|safe }}
+  <input type="file" name="spoiler"/><br/>
+  <input type="submit" value="Upload">
+  <input type="Reset" >
+</form>
+{% endblock core %}

--- a/cms/server/admin/templates/task.html
+++ b/cms/server/admin/templates/task.html
@@ -122,6 +122,27 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
       </tr>
       <tr>
         <td>
+          <span class="info" title="Spoilers for this task. In analysis mode, contestant can view and download spoilers from the task page."></span>
+          Analysis Spoilers
+{% if admin.permission_all %}
+          [<a href="{{ url("task", task.id, "spoilers", "add") }}">add</a>]
+{% endif %}
+        </td>
+        <td>
+          {% if task.spoilers|length == 0 %}
+            No spoilers.
+          {% else %}
+            {% for spoiler in itervalues(task.spoilers) %}
+              <div class="spoiler">
+                <a href="{{ url("file", spoiler.digest, spoiler.filename) }}">{{ spoiler.filename }}</a>
+                - <a onclick="CMS.AWSUtils.ajax_delete('{{ url("task", task.id, "spoiler", spoiler.id) }}'); ">Delete</a>
+              </div>
+            {% endfor %}
+          {% endif %}
+        </td>
+      </tr>
+      <tr>
+        <td>
           <span class="info" title="A comma-separated list with the names of the files that need to be submitted (with the language extensions changed to %l).
                                     The task type dictates the submission format. Consult the task type documentation to know the requirements."></span>
           Submission format

--- a/cms/server/contest/handlers/__init__.py
+++ b/cms/server/contest/handlers/__init__.py
@@ -41,7 +41,8 @@ from .main import \
 from .task import \
     TaskDescriptionHandler, \
     TaskStatementViewHandler, \
-    TaskAttachmentViewHandler
+    TaskAttachmentViewHandler, \
+    TaskSpoilerViewHandler
 from .tasksubmission import \
     SubmitHandler, \
     TaskSubmissionsHandler, \
@@ -77,6 +78,7 @@ HANDLERS = [
     (r"/tasks/(.*)/description", TaskDescriptionHandler),
     (r"/tasks/(.*)/statements/(.*)", TaskStatementViewHandler),
     (r"/tasks/(.*)/attachments/(.*)", TaskAttachmentViewHandler),
+    (r"/tasks/(.*)/spoilers/(.*)", TaskSpoilerViewHandler),
 
     # Task submissions
 

--- a/cms/server/contest/handlers/task.py
+++ b/cms/server/contest/handlers/task.py
@@ -115,3 +115,28 @@ class TaskAttachmentViewHandler(FileHandler):
             mimetype = 'application/octet-stream'
 
         self.fetch(attachment, mimetype, filename)
+
+
+class TaskSpoilerViewHandler(FileHandler):
+    """Shows an analysis spoiler file of a task in the contest.
+
+    """
+    @tornado.web.authenticated
+    @actual_phase_required(3)
+    @multi_contest
+    def get(self, task_name, filename):
+        task = self.get_task(task_name)
+        if task is None:
+            raise tornado.web.HTTPError(404)
+
+        if filename not in task.spoilers:
+            raise tornado.web.HTTPError(404)
+
+        spoiler = task.spoilers[filename].digest
+        self.sql_session.close()
+
+        mimetype = get_type_for_file_name(filename)
+        if mimetype is None:
+            mimetype = 'application/octet-stream'
+
+        self.fetch(spoiler, mimetype, filename)

--- a/cms/server/contest/static/cws_style.css
+++ b/cms/server/contest/static/cws_style.css
@@ -748,7 +748,7 @@ td.token_rules p:last-child {
 
 /*** Attachments */
 
-#attachments ul {
+.attachments ul {
     margin-left: 0;
     list-style-type: none;
     -webkit-column-count: 3;
@@ -759,7 +759,7 @@ td.token_rules p:last-child {
     column-gap: 8px;
 }
 
-#attachments ul li {
+.attachments ul li {
     -webkit-column-break-inside: avoid;
     -webkit-break-inside: avoid;
     -moz-break-inside: avoid;
@@ -768,14 +768,14 @@ td.token_rules p:last-child {
 
 /* this is a really ugly hack to simulate the no-break behavior on firefox */
 @-moz-document url-prefix() {
-    #attachments ul li {
+    .attachments ul li {
         display: table;
         table-layout: fixed;
         width: 100%;
     }
 }
 
-#attachments ul li a {
+.attachments ul li a {
     display: block;
     height: 36px;
     margin-bottom: 8px;
@@ -783,22 +783,22 @@ td.token_rules p:last-child {
     text-align: left;
 }
 
-#attachments ul li a:hover {
+.attachments ul li a:hover {
     background-color: #E3E3E3;
 }
 
-#attachments ul li img {
+.attachments ul li img {
     float: left;
     margin: 2px 8px 2px 2px;
 }
 
-#attachments ul li .first_line {
+.attachments ul li .first_line {
     display: block;
     height: 18px;
     overflow: hidden;
 }
 
-#attachments ul li .name {
+.attachments ul li .name {
     display: inline-block;
     max-width: 100%;
     overflow: hidden;
@@ -807,7 +807,7 @@ td.token_rules p:last-child {
     font-weight: bold;
 }
 
-#attachments ul li .size {
+.attachments ul li .size {
     float: right;
     font-style: italic;
     /* the size floats on right of the first line if there's enough space.
@@ -815,7 +815,7 @@ td.token_rules p:last-child {
        "disappearing" because the first line has overflow: hidden */
 }
 
-#attachments ul li .type {
+.attachments ul li .type {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -165,7 +165,7 @@
 
 {% if task.attachments|length > 0 %}
     <h2>{% trans %}Attachments{% endtrans %}</h2>
-    <div id="attachments">
+    <div class="attachments">
         <ul>
     {% for filename, attachment in task.attachments|dictsort(by="key") %}
         {% set mime_type = get_mimetype_for_file_name(filename) %}
@@ -179,6 +179,41 @@
         {% set file_size = handler.application.service.file_cacher.get_size(attachment.digest) %}
             <li>
                 <a href="{{ contest_url("tasks", task.name, "attachments", filename) }}" class="btn">
+            {% if type_icon is not none %}
+                    <img src="{{ url("static", "img", "mimetypes", "%s.png"|format(type_icon)) }}" alt="{{ mime_type }}" />
+            {% else %}
+                    <img src="{{ url("static", "img", "mimetypes", "unknown.png") }}" alt="{% trans %}unknown{% endtrans %}" />
+            {% endif %}
+                    <span class="first_line">
+                        <span class="name">{{ filename }}</span>
+                        <span class="size">{{ file_size|format_size }}</span>
+                    </span>
+            {% if type_name is not none %}
+                    <span class="type">{{ translation.translate_mimetype(type_name) }}</span>
+            {% endif %}
+                </a>
+            </li>
+    {% endfor %}
+        </ul>
+    </div>
+{% endif %}
+
+{% if contest.analysis_enabled and actual_phase == +3 and task.spoilers|length > 0 %}
+    <h2>{% trans %}Analysis Spoilers{% endtrans %}</h2>
+    <div class="attachments">
+        <ul>
+    {% for filename, spoiler in task.spoilers|dictsort(by="key") %}
+        {% set mime_type = get_mimetype_for_file_name(filename) %}
+        {% if mime_type is not none %}
+            {% set type_name = get_name_for_mimetype(mime_type) %}
+            {% set type_icon = get_icon_for_mimetype(mime_type) %}
+        {% else %}
+            {% set type_name = none %}
+            {% set type_icon = none %}
+        {% endif %}
+        {% set file_size = handler.application.service.file_cacher.get_size(spoiler.digest) %}
+            <li>
+                <a href="{{ contest_url("tasks", task.name, "spoilers", filename) }}" class="btn">
             {% if type_icon is not none %}
                     <img src="{{ url("static", "img", "mimetypes", "%s.png"|format(type_icon)) }}" alt="{{ mime_type }}" />
             {% else %}

--- a/cmscontrib/clean_files_tombstone.sql
+++ b/cmscontrib/clean_files_tombstone.sql
@@ -27,6 +27,7 @@ BEGIN;
     INSERT INTO digests_to_delete
       SELECT digest FROM fsobjects EXCEPT (
         SELECT digest FROM attachments UNION
+        SELECT digest FROM spoilers UNION
         SELECT digest FROM executables UNION
         SELECT digest FROM files UNION
         SELECT digest FROM managers UNION

--- a/cmscontrib/importing.py
+++ b/cmscontrib/importing.py
@@ -297,6 +297,7 @@ def update_task(old_task, new_task, parent=None, get_statements=True):
         Task.statements: get_statements,
         Task.datasets: update_datasets_fn,
         Task.attachments: True,
+        Task.spoilers: True,
         # Scalar columns exceptions.
         Task.num: False,
         Task.primary_statements: get_statements,


### PR DESCRIPTION
Introduce analysis mode spoilers (task attachments visible to contestants only in analysis mode).
This can be used for providing additional (or all) test data, sample solutions or anything
that contestants are not allowed to access during the contest, but only during analysis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1027)
<!-- Reviewable:end -->
