### PR TITLE
Do not use "average" of token modes when looking at a specific task

### DIFF
--- a/cms/server/contest/handlers/task.py
+++ b/cms/server/contest/handlers/task.py
@@ -3,7 +3,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2010-2014 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
-# Copyright © 2010-2017 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2012-2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2013 Bernard Blackham <bernard@largestprime.net>
@@ -63,7 +63,10 @@ class TaskDescriptionHandler(ContestHandler):
         if task is None:
             raise tornado.web.HTTPError(404)
 
-        self.render("task_description.html", task=task, **self.r_params)
+        self.render("task_description.html",
+                    task=task,
+                    tokens_task=task.token_mode,
+                    **self.r_params)
 
 
 class TaskStatementViewHandler(FileHandler):

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -162,6 +162,7 @@ class TaskSubmissionsHandler(ContestHandler):
         download_allowed = self.contest.submissions_download_allowed
         self.render("task_submissions.html",
                     task=task, submissions=submissions,
+                    tokens_task=task.token_mode,
                     tokens_info=tokens_info,
                     submissions_left=submissions_left,
                     submissions_download_allowed=download_allowed,

--- a/cms/server/contest/templates/submission_row.html
+++ b/cms/server/contest/templates/submission_row.html
@@ -96,7 +96,7 @@
         {% endif %}
     </td>
 {% endif %}
-{% if tokens_contest != TOKEN_MODE_DISABLED and tokens_tasks != TOKEN_MODE_DISABLED and actual_phase == 0 %}
+{% if tokens_contest != TOKEN_MODE_DISABLED and tokens_task != TOKEN_MODE_DISABLED and actual_phase == 0 %}
     <td class="token">
         {% if s.token is not none %}
         <a class="btn disabled">{% trans %}Played{% endtrans %}</a>

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -129,11 +129,11 @@
 </tr>
 {% endif %}
 
-{% if tokens_contest != TOKEN_MODE_DISABLED and tokens_tasks != TOKEN_MODE_DISABLED %}
+{% if tokens_contest != TOKEN_MODE_DISABLED and tokens_task != TOKEN_MODE_DISABLED %}
 <tr>
     <th>{% trans %}Tokens{% endtrans %}</th>
     <td colspan="2" class="token_rules">
-    {% if tokens_contest == TOKEN_MODE_INFINITE and tokens_tasks == TOKEN_MODE_INFINITE %}
+    {% if tokens_contest == TOKEN_MODE_INFINITE and tokens_task == TOKEN_MODE_INFINITE %}
         <p>
         {% trans %}You have an infinite number of tokens.{% endtrans %}
         </p>
@@ -141,7 +141,7 @@
         <p>
         {{ task|extract_token_params|format_token_rules }}
         </p>
-    {% elif tokens_tasks == TOKEN_MODE_INFINITE %}
+    {% elif tokens_task == TOKEN_MODE_INFINITE %}
         <p>
         {% trans type_pl=_("tokens"), contest_root=contest_url() %}You can find the rules for the {{ type_pl }} on the <a href="{{ contest_root }}">contest overview page</a>.{% endtrans %}
         </p>

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -184,7 +184,7 @@ $(document).ready(function () {
 
 <h2 style="margin: 40px 0 10px">{% trans %}Previous submissions{% endtrans %}</h2>
 
-{% if tokens_contest != TOKEN_MODE_DISABLED and tokens_tasks != TOKEN_MODE_DISABLED and actual_phase == 0 %}
+{% if tokens_contest != TOKEN_MODE_DISABLED and tokens_task != TOKEN_MODE_DISABLED and actual_phase == 0 %}
 <div style="padding-bottom:10px">
     {% set can_play_token = actual_phase == 0 and (tokens_info[0] > 0 or tokens_info[0] == -1) %}
     {% set need_to_wait = tokens_info[2] is not none %}
@@ -259,7 +259,7 @@ $(document).ready(function () {
         <col class="files"/>
     {% set num_cols = num_cols + 1 %}
 {% endif %}
-{% if tokens_contest != TOKEN_MODE_DISABLED and tokens_tasks != TOKEN_MODE_DISABLED and actual_phase == 0 %}
+{% if tokens_contest != TOKEN_MODE_DISABLED and tokens_task != TOKEN_MODE_DISABLED and actual_phase == 0 %}
         <col class="token"/>
     {% set num_cols = num_cols + 1 %}
 {% endif %}
@@ -286,7 +286,7 @@ $(document).ready(function () {
 {% if submissions_download_allowed %}
             <th class="files">{% trans %}Files{% endtrans %}</th>
 {% endif %}
-{% if tokens_contest != TOKEN_MODE_DISABLED and tokens_tasks != TOKEN_MODE_DISABLED and actual_phase == 0 %}
+{% if tokens_contest != TOKEN_MODE_DISABLED and tokens_task != TOKEN_MODE_DISABLED and actual_phase == 0 %}
             <th class="token">{% trans %}Token{% endtrans %}</th>
 {% endif %}
         </tr>


### PR DESCRIPTION
Use instead the token mode of that task.

This might be a bit controversial, in the sense that it might have
been intended to show comments about the tokens for all tasks if at
least one allows tokens. But I think this is still clear (probably
more). An alternative could be to show in the task description and
before the submission rows "Tokens are not allowed on this tasks" if
tokens_contest != DISABLED && tokens_task == DISABLED && tokens_tasks
!= DISABLED.