### PR TITLE
Improve handling of processes by RS

### DIFF
--- a/cms/service/ResourceService.py
+++ b/cms/service/ResourceService.py
@@ -139,7 +139,7 @@ class ProcessMatcher(object):
         if "python" not in cl_interpreter:
             return None
 
-        cl_service = re.search(r"\b%s([a-zA-Z]+)$" %
+        cl_service = re.search(r"^%s([a-zA-Z]+)$" %
                                re.escape(os.path.join(BIN_PATH, "cms")),
                                cmdline[start_index + 1])
         if not cl_service:

--- a/cms/service/ResourceService.py
+++ b/cms/service/ResourceService.py
@@ -5,7 +5,7 @@
 # Copyright © 2010-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2013-2017 Luca Wehrstedt <luca.wehrstedt@gmail.com>
-# Copyright © 2014 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2014-2018 William Di Luigi <williamdiluigi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -28,6 +28,7 @@ that saves the resources usage in that machine.
 import logging
 import os
 import re
+import sys
 import time
 from collections import defaultdict, deque
 from shlex import quote as shell_quote
@@ -42,6 +43,8 @@ from cms.io import Service, rpc_method
 
 logger = logging.getLogger(__name__)
 
+
+BIN_PATH = os.path.dirname(sys.argv[0])
 
 B_TO_MB = 1024 * 1024
 
@@ -136,7 +139,9 @@ class ProcessMatcher(object):
         if "python" not in cl_interpreter:
             return None
 
-        cl_service = re.search(r"\bcms([a-zA-Z]+)$", cmdline[start_index + 1])
+        cl_service = re.search(r"\b%s([a-zA-Z]+)$" %
+                               re.escape(os.path.join(BIN_PATH, "cms")),
+                               cmdline[start_index + 1])
         if not cl_service:
             return None
         cl_service = cl_service.groups()[0]
@@ -242,7 +247,7 @@ class ResourceService(Service):
                 # it, since it causes no trouble.
                 logger.info("Restarting (%s, %s)...",
                             service.name, service.shard)
-                command = "cms%s" % service.name
+                command = os.path.join(BIN_PATH, "cms%s" % service.name)
                 if not config.installed:
                     command = os.path.join(
                         ".",

--- a/cmstestsuite/unit_tests/service/ResourceServiceTest.py
+++ b/cmstestsuite/unit_tests/service/ResourceServiceTest.py
@@ -18,11 +18,13 @@
 
 """Tests for ResourceService."""
 
+import os
 import sys
 import unittest
 from unittest.mock import patch
 
 from cms import ServiceCoord
+from cms.service import ResourceService
 from cms.service.ResourceService import ProcessMatcher
 
 
@@ -30,29 +32,31 @@ class TestProcessMatcher(unittest.TestCase):
 
     def setUp(self):
         self.pm = ProcessMatcher()
+
+        path = os.path.join(ResourceService.BIN_PATH, "cms")
         self.w0_cmdlines = [
-            "/usr/bin/python2 cmsWorker 0",
-            "/usr/bin/python2 cmsWorker",
-            "python2 cmsWorker 0 -c 1",
-            "python2 cmsWorker -c 1",
-            "python2 cmsWorker -c 1 0",
-            "/usr/bin/env python2 cmsWorker 0",
-            "/usr/bin/env python2 cmsWorker",
-            "/usr/bin/env python2 cmsWorker 0 -c 1",
-            "/usr/bin/env python2 cmsWorker -c 1",
-            "/usr/bin/env python2 cmsWorker -c 1 0",
-            sys.executable + " cmsWorker",
-            sys.executable + " cmsWorker 0",
-            sys.executable + " cmsWorker 0 -c 1",
-            sys.executable + " cmsWorker -c 1",
-            sys.executable + " cmsWorker -c 1 0",
+            "/usr/bin/python3 %sWorker 0" % path,
+            "/usr/bin/python3 %sWorker" % path,
+            "python3 %sWorker 0 -c 1" % path,
+            "python3 %sWorker -c 1" % path,
+            "python3 %sWorker -c 1 0" % path,
+            "/usr/bin/env python3 %sWorker 0" % path,
+            "/usr/bin/env python3 %sWorker" % path,
+            "/usr/bin/env python3 %sWorker 0 -c 1" % path,
+            "/usr/bin/env python3 %sWorker -c 1" % path,
+            "/usr/bin/env python3 %sWorker -c 1 0" % path,
+            sys.executable + " %sWorker" % path,
+            sys.executable + " %sWorker 0" % path,
+            sys.executable + " %sWorker 0 -c 1" % path,
+            sys.executable + " %sWorker -c 1" % path,
+            sys.executable + " %sWorker -c 1 0" % path,
         ]
         self.bad_cmdlines = [
             "ps",
-            "less cmsWorker 0",
-            "less /usr/bin/python2 cmsWorker 0",
-            "/usr/bin/python2 cmsWorker 1",
-            "/usr/bin/python2 cmsAdminWebServer 0",
+            "less %sWorker 0" % path,
+            "less /usr/bin/python3 %sWorker 0" % path,
+            "/usr/bin/python3 %sWorker 1" % path,
+            "/usr/bin/python3 %sAdminWebServer 0" % path,
         ]
         self.w0 = ServiceCoord("Worker", 0)
 
@@ -71,7 +75,7 @@ class TestProcessMatcher(unittest.TestCase):
             with patch.object(ProcessMatcher, '_get_all_processes') as f:
                 f.return_value = (TestProcessMatcher._get_all_processes_ret(
                     self.bad_cmdlines + [(c, "good")] + self.bad_cmdlines))
-                self.assertEquals(self.pm.find(self.w0), "good")
+                self.assertEqual(self.pm.find(self.w0), "good")
 
     def test_find_fails(self):
         service = ServiceCoord("EvaluationService", 0)


### PR DESCRIPTION
ResourceService checks that each sub-process is already running and,
in that case, it does not start them. This is broken when trying to
run multiple CMS instances (with different virtual environments,
different databases, different cms.conf) because RS will think that
the process "cmsChecker" for example is already started.

To solve this, we now include the full path of each executable when
checking for already-started processes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1033)
<!-- Reviewable:end -->
