### PR TITLE
Fix newlines in plain text ranking

### DIFF
--- a/cms/server/admin/templates/ranking.txt
+++ b/cms/server/admin/templates/ranking.txt
@@ -3,6 +3,7 @@
 {% for p in contest.participations|sort(attribute="total_score")|reverse %}
 {% if not p.hidden %}
 {{ "%20s"|format(p.user.username) }} {{ "%30s"|format("%s %s"|format(p.user.first_name, p.user.last_name)) }}{% if show_teams %}{{ "%30s"|format(p.team.name if p.team else "") }}{% endif %} {% for task in contest.tasks %}{% set t_score, t_partial = p.scores[loop.index0] %}{{ "%%13.%dlf"|format(task.score_precision)|format(t_score) }}{% if t_partial %}*{% else %} {% endif %} {% endfor %}{% set total_score, partial = p.total_score %}{{ "%%7.%dlf"|format(contest.score_precision)|format(total_score) }}{% if partial %}*{% else %} {% endif %}
+
 {% endif %}
 {% endfor %}
 {% endblock core %}


### PR DESCRIPTION
Due to trim_blocks being enabled in Jinja environment, the plain text template didn't actually output newlines after each ranking entry. The simplest fix is to add the missing newline manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1039)
<!-- Reviewable:end -->
