### PR TITLE
Fix notifications in CWS being translated after being formatted

### DIFF
--- a/cms/locale/cms.pot
+++ b/cms/locale/cms.pot
@@ -156,7 +156,7 @@ msgstr ""
 #, python-format
 msgid ""
 "Subject must be at most %(max_subject_length)d characters, content at most "
-"%(max_text_length)d.max_subject_length"
+"%(max_text_length)d."
 msgstr ""
 
 msgid "contest-token"

--- a/cms/server/contest/communication.py
+++ b/cms/server/contest/communication.py
@@ -50,10 +50,11 @@ class QuestionsNotAllowed(Exception):
 class UnacceptableQuestion(Exception):
     """Raised when a question can't be accepted."""
 
-    def __init__(self, subject, text):
-        super().__init__(subject, text)
+    def __init__(self, subject, text, text_params=None):
+        super().__init__(subject, text, text_params)
         self.subject = subject
         self.text = text
+        self.text_params = text_params
 
 
 def accept_question(sql_session, participation, timestamp, subject, text):
@@ -90,9 +91,9 @@ def accept_question(sql_session, participation, timestamp, subject, text):
         raise UnacceptableQuestion(
             N_("Question too long!"),
             N_("Subject must be at most %(max_subject_length)d characters, "
-               "content at most %(max_text_length)d."
-               % {"max_subject_length": Question.MAX_SUBJECT_LENGTH,
-                  "max_text_length": Question.MAX_TEXT_LENGTH}))
+               "content at most %(max_text_length)d."),
+            {"max_subject_length": Question.MAX_SUBJECT_LENGTH,
+             "max_text_length": Question.MAX_TEXT_LENGTH})
 
     question = Question(timestamp, subject, text, participation=participation)
     sql_session.add(question)

--- a/cms/server/contest/handlers/communication.py
+++ b/cms/server/contest/handlers/communication.py
@@ -71,7 +71,7 @@ class QuestionHandler(ContestHandler):
         except QuestionsNotAllowed:
             raise tornado.web.HTTPError(404)
         except UnacceptableQuestion as e:
-            self.notify_error(e.subject, e.text)
+            self.notify_error(e.subject, e.text, e.text_params)
         else:
             self.notify_success(N_("Question received"),
                                 N_("Your question has been received, you "

--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -264,19 +264,22 @@ class ContestHandler(BaseHandler):
             .offset(int(user_test_num) - 1) \
             .first()
 
-    def add_notification(self, subject, text, level):
-        self.service.add_notification(
-            self.current_user.user.username, self.timestamp,
-            self._(subject), self._(text), level)
+    def add_notification(self, subject, text, level, text_params=None):
+        subject = self._(subject)
+        text = self._(text)
+        if text_params is not None:
+            text %= text_params
+        self.service.add_notification(self.current_user.user.username,
+                                      self.timestamp, subject, text, level)
 
-    def notify_success(self, subject, text):
-        self.add_notification(subject, text, NOTIFICATION_SUCCESS)
+    def notify_success(self, subject, text, text_params=None):
+        self.add_notification(subject, text, NOTIFICATION_SUCCESS, text_params)
 
-    def notify_warning(self, subject, text):
-        self.add_notification(subject, text, NOTIFICATION_WARNING)
+    def notify_warning(self, subject, text, text_params=None):
+        self.add_notification(subject, text, NOTIFICATION_WARNING, text_params)
 
-    def notify_error(self, subject, text):
-        self.add_notification(subject, text, NOTIFICATION_ERROR)
+    def notify_error(self, subject, text, text_params=None):
+        self.add_notification(subject, text, NOTIFICATION_ERROR, text_params)
 
 
 class FileHandler(ContestHandler, FileHandlerMixin):

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -210,7 +210,7 @@ class PrintingHandler(ContestHandler):
         except PrintingDisabled:
             raise tornado.web.HTTPError(404)
         except UnacceptablePrintJob as e:
-            self.notify_error(e.subject, e.text)
+            self.notify_error(e.subject, e.text, e.text_params)
         else:
             self.service.printing_service.new_printjob(printjob_id=printjob.id)
             self.notify_success(N_("Print job received"),

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -84,8 +84,8 @@ class SubmitHandler(ContestHandler):
                 self.get_argument("language", None), official)
             self.sql_session.commit()
         except UnacceptableSubmission as e:
-            logger.info("Sent error: `%s' - `%s'", e.subject, e.text)
-            self.notify_error(e.subject, e.text)
+            logger.info("Sent error: `%s' - `%s'", e.subject, e.formatted_text)
+            self.notify_error(e.subject, e.text, e.text_params)
         else:
             self.service.evaluation_service.new_submission(
                 submission_id=submission.id)

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -137,8 +137,8 @@ class UserTestHandler(ContestHandler):
                            self.current_user.user.username, task_name)
             raise tornado.web.HTTPError(404)
         except UnacceptableUserTest as e:
-            logger.info("Sent error: `%s' - `%s'", e.subject, e.text)
-            self.notify_error(e.subject, e.text)
+            logger.info("Sent error: `%s' - `%s'", e.subject, e.formatted_text)
+            self.notify_error(e.subject, e.text, e.text_params)
         else:
             self.service.evaluation_service.new_user_test(
                 user_test_id=user_test.id)

--- a/cms/server/contest/printing.py
+++ b/cms/server/contest/printing.py
@@ -48,10 +48,11 @@ class PrintingDisabled(Exception):
 class UnacceptablePrintJob(Exception):
     """Raised when a printout request can't be accepted."""
 
-    def __init__(self, subject, text):
-        super().__init__(subject, text)
+    def __init__(self, subject, text, text_params=None):
+        super().__init__(subject, text, text_params)
         self.subject = subject
         self.text = text
+        self.text_params = text_params
 
 
 def accept_print_job(sql_session, file_cacher, participation, timestamp, files):
@@ -88,8 +89,8 @@ def accept_print_job(sql_session, file_cacher, participation, timestamp, files):
     if config.max_jobs_per_user <= old_count:
         raise UnacceptablePrintJob(
             N_("Too many print jobs!"),
-            N_("You have reached the maximum limit of at most %d print jobs.")
-            % config.max_jobs_per_user)
+            N_("You have reached the maximum limit of at most %d print jobs."),
+            config.max_jobs_per_user)
 
     if len(files) != 1 or "file" not in files or len(files["file"]) != 1:
         raise UnacceptablePrintJob(
@@ -102,7 +103,7 @@ def accept_print_job(sql_session, file_cacher, participation, timestamp, files):
     if len(data) > config.max_print_length:
         raise UnacceptablePrintJob(
             N_("File too big!"),
-            N_("Each file must be at most %d bytes long.") %
+            N_("Each file must be at most %d bytes long."),
             config.max_print_length)
 
     try:

--- a/cms/server/contest/submission/workflow.py
+++ b/cms/server/contest/submission/workflow.py
@@ -48,10 +48,17 @@ def N_(msgid):
 
 
 class UnacceptableSubmission(Exception):
-    def __init__(self, subject, text):
-        super().__init__("%s: %s" % (subject, text))
+    def __init__(self, subject, text, text_params=None):
+        super().__init__(subject, text, text_params)
         self.subject = subject
         self.text = text
+        self.text_params = text_params
+
+    @property
+    def formatted_text(self):
+        if self.text_params is None:
+            return self.text
+        return self.text % self.text_params
 
 
 def accept_submission(sql_session, file_cacher, participation, task, timestamp,
@@ -92,7 +99,7 @@ def accept_submission(sql_session, file_cacher, participation, task, timestamp,
         raise UnacceptableSubmission(
             N_("Too many submissions!"),
             N_("You have reached the maximum limit of "
-               "at most %d submissions among all tasks.") %
+               "at most %d submissions among all tasks."),
             contest.max_submission_number)
 
     if not check_max_number(sql_session, task.max_submission_number,
@@ -100,7 +107,7 @@ def accept_submission(sql_session, file_cacher, participation, task, timestamp,
         raise UnacceptableSubmission(
             N_("Too many submissions!"),
             N_("You have reached the maximum limit of "
-               "at most %d submissions on this task.") %
+               "at most %d submissions on this task."),
             task.max_submission_number)
 
     if not check_min_interval(sql_session, contest.min_submission_interval,
@@ -108,7 +115,7 @@ def accept_submission(sql_session, file_cacher, participation, task, timestamp,
         raise UnacceptableSubmission(
             N_("Submissions too frequent!"),
             N_("Among all tasks, you can submit again "
-               "after %d seconds from last submission.") %
+               "after %d seconds from last submission."),
             contest.min_submission_interval.total_seconds())
 
     if not check_min_interval(sql_session, task.min_submission_interval,
@@ -116,7 +123,7 @@ def accept_submission(sql_session, file_cacher, participation, task, timestamp,
         raise UnacceptableSubmission(
             N_("Submissions too frequent!"),
             N_("For this task, you can submit again "
-               "after %d seconds from last submission.") %
+               "after %d seconds from last submission."),
             task.min_submission_interval.total_seconds())
 
     # Process the data we received and ensure it's valid.
@@ -155,7 +162,7 @@ def accept_submission(sql_session, file_cacher, participation, task, timestamp,
            for content in files.values()):
         raise UnacceptableSubmission(
             N_("Submission too big!"),
-            N_("Each source file must be at most %d bytes long.") %
+            N_("Each source file must be at most %d bytes long."),
             config.max_submission_length)
 
     # All checks done, submission accepted.
@@ -208,10 +215,17 @@ class TestingNotAllowed(Exception):
 
 
 class UnacceptableUserTest(Exception):
-    def __init__(self, subject, text):
-        super().__init__("%s: %s" % (subject, text))
+    def __init__(self, subject, text, text_params=None):
+        super().__init__(subject, text, text_params)
         self.subject = subject
         self.text = text
+        self.text_params = text_params
+
+    @property
+    def formatted_text(self):
+        if self.text_params is None:
+            return self.text
+        return self.text % self.text_params
 
 
 def accept_user_test(sql_session, file_cacher, participation, task, timestamp,
@@ -252,7 +266,7 @@ def accept_user_test(sql_session, file_cacher, participation, task, timestamp,
         raise UnacceptableUserTest(
             N_("Too many tests!"),
             N_("You have reached the maximum limit of "
-               "at most %d tests among all tasks.") %
+               "at most %d tests among all tasks."),
             contest.max_user_test_number)
 
     if not check_max_number(sql_session, task.max_user_test_number,
@@ -260,7 +274,7 @@ def accept_user_test(sql_session, file_cacher, participation, task, timestamp,
         raise UnacceptableUserTest(
             N_("Too many tests!"),
             N_("You have reached the maximum limit of "
-               "at most %d tests on this task.") %
+               "at most %d tests on this task."),
             task.max_user_test_number)
 
     if not check_min_interval(sql_session, contest.min_user_test_interval,
@@ -269,7 +283,7 @@ def accept_user_test(sql_session, file_cacher, participation, task, timestamp,
         raise UnacceptableUserTest(
             N_("Tests too frequent!"),
             N_("Among all tasks, you can test again "
-               "after %d seconds from last test.") %
+               "after %d seconds from last test."),
             contest.min_user_test_interval.total_seconds())
 
     if not check_min_interval(sql_session, task.min_user_test_interval,
@@ -278,7 +292,7 @@ def accept_user_test(sql_session, file_cacher, participation, task, timestamp,
         raise UnacceptableUserTest(
             N_("Tests too frequent!"),
             N_("For this task, you can test again "
-               "after %d seconds from last test.") %
+               "after %d seconds from last test."),
             task.min_user_test_interval.total_seconds())
 
     # Process the data we received and ensure it's valid.
@@ -325,12 +339,12 @@ def accept_user_test(sql_session, file_cacher, participation, task, timestamp,
            if codename != "input"):
         raise UnacceptableUserTest(
             N_("Test too big!"),
-            N_("Each source file must be at most %d bytes long.") %
+            N_("Each source file must be at most %d bytes long."),
             config.max_submission_length)
     if "input" in files and len(files["input"]) > config.max_input_length:
         raise UnacceptableUserTest(
             N_("Input too big!"),
-            N_("The input file must be at most %d bytes long.") %
+            N_("The input file must be at most %d bytes long."),
             config.max_input_length)
 
     # All checks done, submission accepted.


### PR DESCRIPTION
We would mark for translation the message with placeholders (which is correct) but we would look the message up in the catalog after having formatted it, and then of course we wouldn't find any translation.

This also fixes an issue with message extraction.

This fixes #1040 and supersedes #1041.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1046)
<!-- Reviewable:end -->
