### PR TITLE
Fix extraction of translation messages by Babel

### DIFF
--- a/babel_mapping.cfg
+++ b/babel_mapping.cfg
@@ -4,5 +4,6 @@
 [python: server/*.py]
 [python: server/contest/*.py]
 [python: server/contest/handlers/*.py]
+[python: server/contest/submission/*.py]
 [jinja2: server/contest/templates/*.html]
 trimmed: 1

--- a/cms/locale/cms.pot
+++ b/cms/locale/cms.pot
@@ -338,6 +338,85 @@ msgstr ""
 msgid "Executed"
 msgstr ""
 
+msgid "Too many submissions!"
+msgstr ""
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d submissions among all tasks."
+msgstr ""
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d submissions on this task."
+msgstr ""
+
+msgid "Submissions too frequent!"
+msgstr ""
+
+#, python-format
+msgid "Among all tasks, you can submit again after %d seconds from last submission."
+msgstr ""
+
+#, python-format
+msgid "For this task, you can submit again after %d seconds from last submission."
+msgstr ""
+
+msgid "Invalid archive format!"
+msgstr ""
+
+msgid "The submitted archive could not be opened."
+msgstr ""
+
+msgid "Invalid submission format!"
+msgstr ""
+
+msgid "Submission too big!"
+msgstr ""
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr ""
+
+msgid "Submission storage failed!"
+msgstr ""
+
+msgid "Too many tests!"
+msgstr ""
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d tests among all tasks."
+msgstr ""
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d tests on this task."
+msgstr ""
+
+msgid "Tests too frequent!"
+msgstr ""
+
+#, python-format
+msgid "Among all tasks, you can test again after %d seconds from last test."
+msgstr ""
+
+#, python-format
+msgid "For this task, you can test again after %d seconds from last test."
+msgstr ""
+
+msgid "Invalid test format!"
+msgstr ""
+
+msgid "Test too big!"
+msgstr ""
+
+msgid "Input too big!"
+msgstr ""
+
+#, python-format
+msgid "The input file must be at most %d bytes long."
+msgstr ""
+
+msgid "Test storage failed!"
+msgstr ""
+
 msgid "Communication"
 msgstr ""
 


### PR DESCRIPTION
A directory was missing.

We could honestly just use `**.py` to extract from all Python files in the repo rather than listing all directories individually. I don't think we would have that many false positives (possibly none at all). I think I originally listed the directories because that was what we were doing before adopting Babel and I wanted to have the files processed in the same order to reduce the diff to the cms.pot file, which however ended being quite large regardless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1047)
<!-- Reviewable:end -->
