### PR TITLE
Remove excessive whitespace in CWS license notice

### DIFF
--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -204,10 +204,9 @@ $(document).ready(function () {
                         </ul>
                     </div>
                     <span class="license_notice">
-                    <a href="http://github.com/cms-dev/cms/" rel="author noreferrer" target="_blank">{% trans %}Contest Management System{% endtrans %}</a>
+                    <a href="https://github.com/cms-dev/cms" rel="author noreferrer" target="_blank">{% trans %}Contest Management System{% endtrans %}</a>
                     {% trans %}is released under the{% endtrans %}
-                    <a href="http://www.gnu.org/licenses/agpl" rel="license noreferrer" target="_blank">{% trans %}GNU Affero General Public License{% endtrans %}</a>
-                    .
+                    <a href="https://www.gnu.org/licenses/agpl" rel="license noreferrer" target="_blank">{% trans %}GNU Affero General Public License{% endtrans %}</a>.
                     </span>
                 </div>
     {% block core %}{% endblock core %}


### PR DESCRIPTION
Also change links to use HTTPS.

There's also a minor problem with trailing whitespace after the period (seen when you select all text). It is common for many other locations, so I didn't try to fix it yet. **EDIT**: Actually, no need to bother with this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1049)
<!-- Reviewable:end -->
