### PR TITLE
Fixed bug if the memory ends between 1000 and 1024 XiB

### DIFF
--- a/cms/locale/locale.py
+++ b/cms/locale/locale.py
@@ -10,6 +10,7 @@
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
 # Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
 # Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
+# Copyright © 2018 Edoardo Morassutto <edoardo.morassutto@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/cms/locale/locale.py
+++ b/cms/locale/locale.py
@@ -223,7 +223,8 @@ class Translation:
             if n < self.PREFIX_FACTOR:
                 f = copy.copy(self.locale.decimal_formats[None])
                 # We need int because floor returns a float in py2.
-                d = int(2 - math.floor(math.log10(n)))
+                # if 1000 <= n < 1024 d can be negative, cap to 0 decimals
+                d = max(0, int(2 - math.floor(math.log10(n))))
                 f.frac_prec = (d, d)
                 return (self.gettext(unit)
                         % babel.numbers.format_decimal(n, format=f,

--- a/cmstestsuite/unit_tests/locale/locale_test.py
+++ b/cmstestsuite/unit_tests/locale/locale_test.py
@@ -2,6 +2,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2018 Edoardo Morassutto <edoardo.morassutto@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -472,6 +473,8 @@ class TestFormatSize(unittest.TestCase):
                          "1,000 bytes")
         self.assertEqual(ENGLISH.format_size(1024),
                          "1.00 KiB")
+        self.assertEqual(ENGLISH.format_size(1000 * 1024),
+                         "1,000 KiB")
 
     def test_large(self):
         # Ensure larger units are used for larger values, with rounding
@@ -554,7 +557,7 @@ class TestTranslateMimetype(unittest.TestCase):
 
     @unittest.skipIf(not os.path.isfile(
         "/usr/share/locale/it/LC_MESSAGES/shared-mime-info.mo"),
-                     reason="need Italian shared-mime-info translation")
+        reason="need Italian shared-mime-info translation")
     def test_translate_mimetype(self):
         self.assertEqual(ENGLISH.translate_mimetype("PDF document"),
                          "PDF document")


### PR DESCRIPTION
If the memory used (or other values used as parameter of format_size) ends in the range [1000, 1024) KiB/MiB/GiB... AWS and CWS will fail rendering that size and the submission details **wont be shown** for both the contestants and (partially) the admins! This because the number of digits of the number was supposed being at most 3, not true anymore since 1024 is used as the base.

Allowing an extra significant digit for those cases is the proposed solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1055)
<!-- Reviewable:end -->
