### PR TITLE
RWS: add -y switch to allow unattended data drop

### DIFF
--- a/cmsranking/RankingWebServer.py
+++ b/cmsranking/RankingWebServer.py
@@ -528,7 +528,7 @@ def main():
     config.load(args.config)
 
     if args.drop:
-        ans = input("Are you sure you want to delete directory %s? [y/N]" %
+        ans = input("Are you sure you want to delete directory %s? [y/N] " %
                     config.lib_dir).strip().lower()
         if ans in ['y', 'yes']:
             print("Removing directory %s." % config.lib_dir)

--- a/cmsranking/RankingWebServer.py
+++ b/cmsranking/RankingWebServer.py
@@ -522,14 +522,19 @@ def main():
                         help="override config file")
     parser.add_argument("-d", "--drop", action="store_true",
                         help="drop the data already stored")
+    parser.add_argument("-y", "--yes", action="store_true",
+                        help="do not require confirmation on dropping data")
     args = parser.parse_args()
 
     config = Config()
     config.load(args.config)
 
     if args.drop:
-        ans = input("Are you sure you want to delete directory %s? [y/N] " %
-                    config.lib_dir).strip().lower()
+        if args.yes:
+            ans = 'y'
+        else:
+            ans = input("Are you sure you want to delete directory %s? [y/N] " %
+                        config.lib_dir).strip().lower()
         if ans in ['y', 'yes']:
             print("Removing directory %s." % config.lib_dir)
             shutil.rmtree(config.lib_dir)


### PR DESCRIPTION
If the `-y` switch is specified then CMS would drop the data directory without asking for confirmation. This is desirable for automation scripts since without the switch, the script would have to pipe yes into the RWS process (`yes | cmsRankingWebServer -d`). `cmsDropDB` has this switch so I think RWS should also have one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1057)
<!-- Reviewable:end -->
