### PR TITLE
Ensure compiled translation .mo files are picked up during build phase

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,10 @@ def find_version():
 class build_py_and_l10n(build_py):
     def run(self):
         self.run_command("compile_catalog")
+        # The build command of distutils/setuptools searches the tree
+        # and compiles a list of data files before run() is called and
+        # then stores that value. Hence we need to refresh it.
+        self.data_files = self._get_data_files()
         super().run()
 
 


### PR DESCRIPTION
There was a bug where simply running `./setup.py install` from a fresh checkout would compile the .po files into .mo files but wouldn't copy them to the `build/` subdirectory. Running `build` then `install` (or running `install` twice) would fix that issue as the files compiled by the first pass would get picked up at the second one.

This issue didn't affect the `develop` mode, since there the "installed" package is just a symlink to the source tree, where these files exist.

This needs to be backported to v1.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1059)
<!-- Reviewable:end -->
