### PR TITLE
prerequisites.py: fail properly when isolate doesn't build

### DIFF
--- a/prerequisites.py
+++ b/prerequisites.py
@@ -195,11 +195,9 @@ def build_isolate():
     assert_not_root()
 
     print("===== Compiling isolate")
-    os.chdir("isolate")
     # We make only the executable isolate, otherwise the tool a2x
     # is needed and we have to add more compilation dependencies.
-    subprocess.call(["make", "isolate"])
-    os.chdir("..")
+    subprocess.check_call(["make", "-C", "isolate", "isolate"])
 
 
 def install_isolate():
@@ -305,9 +303,8 @@ def install():
         build()
     else:
         # Run build() command as not root
-        if subprocess.call(["sudo", "-E", "-u", real_user,
-                            sys.executable, sys.argv[0], "build"]):
-            exit(1)
+        subprocess.check_call(["sudo", "-E", "-u", real_user,
+                               sys.executable, sys.argv[0], "build"])
 
     install_isolate()
 
@@ -344,7 +341,7 @@ def install():
         print("===== Adding yourself to the %s group" % CMSUSER)
         if ask("Type Y if you want me to automatically add "
                "\"%s\" to the %s group: " % (real_user, CMSUSER)):
-            subprocess.call(["usermod", "-a", "-G", CMSUSER, real_user])
+            subprocess.check_call(["usermod", "-a", "-G", CMSUSER, real_user])
             print("""
 ###########################################################################
 ###                                                                     ###


### PR DESCRIPTION
Also fix other similar places and apply minor improvements to the make command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1066)
<!-- Reviewable:end -->
