### PR TITLE
Fix time frame messages for analysis phases

### DIFF
--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -152,13 +152,15 @@
     {% elif actual_phase == +1 %}
         {% trans start_time=participation.starting_time|format_datetime_smart %}You started your time frame at {{ start_time }} and you already finished it.{% endtrans %}
         {%+ trans %}There's nothing you can do now.{% endtrans %}
-    {% elif actual_phase == +2 %}
+    {% elif actual_phase >= +2 %}
         {% if participation.starting_time is none %}
             {% trans %}You never started your time frame. Now it's too late.{% endtrans %}
         {% else %}
             {% trans start_time=participation.starting_time|format_datetime_smart %}You started your time frame at {{ start_time }} and you already finished it.{% endtrans %}
         {% endif %}
-        {%+ trans %}There's nothing you can do now.{% endtrans %}
+        {% if actual_phase != +3 %}
+            {%+ trans %}There's nothing you can do now.{% endtrans %}
+        {% endif %}
     {% endif %}
             </p>
 


### PR DESCRIPTION
On the contest overview page, time frame messages for USACO-style contests weren't displayed correctly for late analysis and end of contest phases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1068)
<!-- Reviewable:end -->
