### PR TITLE
Fix inconsistent color coding of task’s score

### DIFF
--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -34,9 +34,9 @@ $(document).on("click", "#submission_list tbody tr td.status .details", function
 });
 
 function get_score_class (score, max_score) {
-    if (Number.parseFloat(score).toPrecision(6) <= 0) {
+    if (Number.parseFloat(score).toFixed(6) <= 0) {
         return "score_0";
-    } else if (Number.parseFloat(score).toPrecision(6) >= Number.parseFloat(max_score).toPrecision(6)) {
+    } else if (Number.parseFloat(score).toFixed(6) >= Number.parseFloat(max_score).toFixed(6)) {
         return "score_100";
     } else {
         return "score_0_100";

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -34,9 +34,9 @@ $(document).on("click", "#submission_list tbody tr td.status .details", function
 });
 
 function get_score_class (score, max_score) {
-    if (score <= 0) {
+    if (Number.parseFloat(score).toPrecision(6) <= 0) {
         return "score_0";
-    } else if (score >= max_score) {
+    } else if (Number.parseFloat(score).toPrecision(6) >= Number.parseFloat(max_score).toPrecision(6)) {
         return "score_100";
     } else {
         return "score_0_100";


### PR DESCRIPTION
The problem arises due to floating point imprecision, making float comparison faulty. Rounding such floats to be precise as much as 6 decimal digits seems to fix the problem.

Related to the first problem in #1077.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1078)
<!-- Reviewable:end -->
