### PR TITLE
AWS: Added score as seen by the user field to submission details

### DIFF
--- a/cms/server/admin/templates/submission.html
+++ b/cms/server/admin/templates/submission.html
@@ -122,6 +122,18 @@
           {% endif %}
         </td>
       </tr>
+      {% if status == SubmissionResult.SCORED and st is defined %}
+      <tr>
+        <td>Score as seen by user</td>
+        <td>
+          {% if s.token is not none %}
+            {{ st.format_score(sr.score, st.max_score, sr.score_details, s.task.score_precision) }}
+          {% else %}
+            {{ st.format_score(sr.public_score, st.max_public_score, sr.public_score_details, s.task.score_precision) }}
+          {% endif %}
+        </td>
+      </tr>
+      {% endif %}
       {% if sr is not none %}
       <tr>
         <td>Failures during compilation</td>


### PR DESCRIPTION
In AWS for submission, there is a view of evaluation as seen by the user, but it doesn't provide a good summary of this view (sum of points).
Therefore I added a field that shows the score that is visible for the user for this submission.

This would allow to easier follow up contestants progress in contest and reason about their taken decisions based on the score visible to them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1079)
<!-- Reviewable:end -->
