### PR TITLE
Provide more information when connection to the database fails

### DIFF
--- a/cms/db/util.py
+++ b/cms/db/util.py
@@ -24,6 +24,7 @@
 """
 
 import sys
+import logging
 
 from sqlalchemy import union
 from sqlalchemy.exc import OperationalError
@@ -33,6 +34,9 @@ from . import SessionGen, Digest, Contest, Participation, Statement, \
     Attachment, Task, Manager, Dataset, Testcase, Submission, File, \
     SubmissionResult, Executable, UserTest, UserTestFile, UserTestManager, \
     UserTestResult, UserTestExecutable, PrintJob
+
+
+logger = logging.getLogger(__name__)
 
 
 def test_db_connection():
@@ -47,7 +51,8 @@ def test_db_connection():
         # use it to ensure that the DB is accessible.
         with SessionGen() as session:
             session.execute("select 0;")
-    except OperationalError:
+    except OperationalError as e:
+        logger.error(e)
         raise ConfigError("Operational error while talking to the DB. "
                           "Is the connection string in cms.conf correct?")
 


### PR DESCRIPTION
It is useful to see the actual problem when connection to the database fails. Currently this information is printed neither on the standard error nor in the logs.

New output example:
```
2018-11-25 14:33:07,732 - INFO [<unknown>] Using configuration file /etc/cms.conf.
2018-11-25 14:33:09,288 - ERROR [<unknown>] (psycopg2.OperationalError) could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5433"?

2018-11-25 14:33:09,289 - CRITICAL [<unknown>] Operational error while talking to the DB. Is the connection string in cms.conf correct?
```

Normally this would be a use case for chained exceptions:
```python
    except OperationalError as e:
        raise ConfigError("Operational error while talking to the DB. "
                          "Is the connection string in cms.conf correct?") from e
```
but the `logger.critical()` function used to report errors on the upper level does not show chained exception info. (There is one that does, though: `logger.exception()`. But it also prints the full stack trace.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1081)
<!-- Reviewable:end -->
