### PR TITLE
Store hashed password in cookie to avoid re-hashing at every request

### DIFF
--- a/cms/server/contest/authentication.py
+++ b/cms/server/contest/authentication.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_password(participation):
-    """Find out what password a participation is expected to provide.
+    """Return the password the participation can log in with.
 
     participation (Participation): a participation.
 
@@ -135,8 +135,8 @@ def validate_login(
                 "contest %s, at %s", ip_address, username, contest.name,
                 timestamp)
 
-    # We store the hashed password (if hashing is used) so that the
-    # expensive bcrypt hashing doesn't need to be done at every request.
+    # If hashing is used, the cookie stores the hashed password so that
+    # the expensive bcrypt call doesn't need to be done at every request.
     return (participation,
             json.dumps([username, correct_password, make_timestamp(timestamp)])
                 .encode("utf-8"))

--- a/cms/server/contest/authentication.py
+++ b/cms/server/contest/authentication.py
@@ -44,35 +44,18 @@ __all__ = ["validate_login", "authenticate_request"]
 logger = logging.getLogger(__name__)
 
 
-def safe_validate_password(participation, password):
-    """Check that the password is correct for the authentication.
-
-    Validate the given password against the participation (using either
-    the global or the contest-specific password that is stored in the
-    database), and guard against a misconfiguration.
+def get_password(participation):
+    """Find out what password a participation is expected to provide.
 
     participation (Participation): a participation.
-    password (str): a password provided by someone trying to log in
-        claiming to be the given participation.
 
-    return (bool): whether the password matches the expected one.
+    return (str): the password that is on record for them.
 
     """
     if participation.password is None:
-        correct_password = participation.user.password
+        return participation.user.password
     else:
-        correct_password = participation.password
-
-    try:
-        password_valid = validate_password(correct_password, password)
-    except ValueError as e:
-        # This is either a programming or a configuration error.
-        logger.warning(
-            "Invalid password stored in database for user %s in contest %s: "
-            "%s", participation.user.username, participation.contest.name, e)
-        return False
-
-    return password_valid
+        return participation.password
 
 
 def validate_login(
@@ -124,7 +107,18 @@ def validate_login(
         log_failed_attempt("user not registered to contest")
         return None, None
 
-    if not safe_validate_password(participation, password):
+    correct_password = get_password(participation)
+
+    try:
+        password_valid = validate_password(correct_password, password)
+    except ValueError as e:
+        # This is either a programming or a configuration error.
+        logger.warning(
+            "Invalid password stored in database for user %s in contest %s: "
+            "%s", participation.user.username, participation.contest.name, e)
+        return None, None
+
+    if not password_valid:
         log_failed_attempt("wrong password")
         return None, None
 
@@ -141,8 +135,10 @@ def validate_login(
                 "contest %s, at %s", ip_address, username, contest.name,
                 timestamp)
 
+    # We store the hashed password (if hashing is used) so that the
+    # expensive bcrypt hashing doesn't need to be done at every request.
     return (participation,
-            json.dumps([username, password, make_timestamp(timestamp)])
+            json.dumps([username, correct_password, make_timestamp(timestamp)])
                 .encode("utf-8"))
 
 
@@ -341,7 +337,11 @@ def _authenticate_request_from_cookie(sql_session, contest, timestamp, cookie):
         log_failed_attempt("user not registered to contest")
         return None, None
 
-    if not safe_validate_password(participation, password):
+    correct_password = get_password(participation)
+
+    # We compare hashed password because it would be too expensive to
+    # re-hash the user-provided plaintext password at every request.
+    if password != correct_password:
         log_failed_attempt("wrong password")
         return None, None
 
@@ -349,6 +349,8 @@ def _authenticate_request_from_cookie(sql_session, contest, timestamp, cookie):
                 "returning from %s, at %s", username, contest.name, last_update,
                 timestamp)
 
+    # We store the hashed password (if hashing is used) so that the
+    # expensive bcrypt hashing doesn't need to be done at every request.
     return (participation,
-            json.dumps([username, password, make_timestamp(timestamp)])
+            json.dumps([username, correct_password, make_timestamp(timestamp)])
                 .encode("utf-8"))

--- a/cmstestsuite/unit_tests/server/contest/authentication_test.py
+++ b/cmstestsuite/unit_tests/server/contest/authentication_test.py
@@ -253,16 +253,7 @@ class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
         # Cookies are of no use if one cannot login by password.
         self.contest.allow_password_authentication = False
         self.assertFailure()
-
-        # To avoid hashing at every request, the cookie's password holds
-        # the plaintext/hashed password and is compared for equality.
-        # Thus it doesn't work with other methds.
         self.contest.allow_password_authentication = True
-        self.user.password = hash_password("mypass", method="bcrypt")
-        self.assertFailure()
-
-        self.user.password = hash_password("mypass", method="plaintext")
-        self.assertSuccessAndCookieRefreshed()
 
         # Cookies contain the password, which is validated every time.
         self.user.password = build_password("newpass")

--- a/cmstestsuite/unit_tests/server/contest/authentication_test.py
+++ b/cmstestsuite/unit_tests/server/contest/authentication_test.py
@@ -254,10 +254,12 @@ class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
         self.contest.allow_password_authentication = False
         self.assertFailure()
 
-        # The cookie works with all methods as it holds the plaintext password.
+        # To avoid hashing at every request, the cookie's password holds
+        # the plaintext/hashed password and is compared for equality.
+        # Thus it doesn't work with other methds.
         self.contest.allow_password_authentication = True
         self.user.password = hash_password("mypass", method="bcrypt")
-        self.assertSuccessAndCookieRefreshed()
+        self.assertFailure()
 
         self.user.password = hash_password("mypass", method="plaintext")
         self.assertSuccessAndCookieRefreshed()


### PR DESCRIPTION
The only drawback is that if admins change a user's password from plaintext to hashed or vice versa that user will have to log in again. Attackers knowing hashed passwords shouldn't be a problem as the server only accepts it if it's signed (together with a recent timestamp) with its secret key.

Fixes #1076.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1085)
<!-- Reviewable:end -->
