### PR TITLE
Show number of days left for long lasting contests.

### DIFF
--- a/cms/server/contest/static/cws_utils.js
+++ b/cms/server/contest/static/cws_utils.js
@@ -223,7 +223,7 @@ CMS.CWSUtils.prototype.format_timedelta = function(timedelta) {
     }
     else {
 	// otherwise only return the number of days.
-        return days + " days ";
+        return days + $("#translation_days").text();
     }
 };
 

--- a/cms/server/contest/static/cws_utils.js
+++ b/cms/server/contest/static/cws_utils.js
@@ -206,15 +206,25 @@ CMS.CWSUtils.prototype.format_timedelta = function(timedelta) {
         timedelta = 0;
     }
 
+
+    var days = Math.floor(timedelta / 86400);
+    timedelta %= 86400;
     var hours = Math.floor(timedelta / 3600);
     timedelta %= 3600;
     var minutes = Math.floor(timedelta / 60);
     timedelta %= 60;
     var seconds = Math.floor(timedelta);
 
-    return this.two_digits(hours) + ":"
-        + this.two_digits(minutes) + ":"
-        + this.two_digits(seconds);
+    if (days <= 2) {
+	// if less than 72 hours left, return the exact number of hours.
+        return this.two_digits(days * 24 + hours) + ":"
+            + this.two_digits(minutes) + ":"
+            + this.two_digits(seconds);
+    }
+    else {
+	// otherwise only return the number of days.
+        return days + " days ";
+    }
 };
 
 

--- a/cms/server/contest/static/cws_utils.js
+++ b/cms/server/contest/static/cws_utils.js
@@ -216,13 +216,13 @@ CMS.CWSUtils.prototype.format_timedelta = function(timedelta) {
     var seconds = Math.floor(timedelta);
 
     if (days <= 2) {
-	// if less than 72 hours left, return the exact number of hours.
+        // If less than 72 hours left, return the exact number of hours, minutes and seconds.
         return this.two_digits(days * 24 + hours) + ":"
             + this.two_digits(minutes) + ":"
             + this.two_digits(seconds);
     }
     else {
-	// otherwise only return the number of days.
+        // Otherwise only return the number of days.
         return days + $("#translation_days").text();
     }
 };

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -149,6 +149,9 @@ $(document).ready(function () {
         <div style="display: none" id="translation_time_left">
             {% trans %}Time left:{% endtrans %}
         </div>
+        <div style="display: none" id="translation_days">
+            {% trans %}days{% endtrans %}
+        </div>
         <!-- End -->
         <div id="main" class="container">
             <div class="row">


### PR DESCRIPTION
When a contest lasts for a couple of weeks, showing the exact number of seconds counting down is strange and distracting. This change keeps everything as it was if there are less than 72 hours left in a contest. However, when there is more time left it only displays the number of days left.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1094)
<!-- Reviewable:end -->
