### PR TITLE
Fix Updater 41 filename schema regex expression

### DIFF
--- a/cmscontrib/updaters/update_41.py
+++ b/cmscontrib/updaters/update_41.py
@@ -96,7 +96,7 @@ class Updater:
             self.bad_filenames.append("%s.%s" % (class_, attr))
 
     def check_filename_schema(self, class_, attr, schema):
-        if not re.match('^[A-Za-z0-9_.-]+(\.%%l)?$', schema) \
+        if not re.match('^[A-Za-z0-9_.-]+(\.%l)?$', schema) \
                 or schema in {'.', '..'}:
             self.bad_filename_schemas.append("%s.%s" % (class_, attr))
 


### PR DESCRIPTION
Almost everywhere filename schema is defined with '%%' because it is used with string formatting operator. In this use case the double '%%' is not needed and causes problems with updating exported dump.