### PR TITLE
ProxyService support for different contest RWS

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -44,5 +44,6 @@ Kārlis Seņko <karlis3p70l1ij@gmail.com>
 Peyman Jabbarzade Ganje <peyman.jabarzade@gmail.com>
 Valentin Rosca <rosca.valentin2012@gmail.com>
 Alexander Kernozhitsky <sh200105@mail.ru>
+Pēteris Pakalns <peterispakalns@gmail.com>
 And many other people that didn't write code, but provided useful
 comments, suggestions and feedback. :-)

--- a/cms/conf.py
+++ b/cms/conf.py
@@ -149,7 +149,7 @@ class Config:
         self.admin_cookie_duration = 10 * 60 * 60  # 10 hours
 
         # ProxyService.
-        self.rankings = ["http://usern4me:passw0rd@localhost:8890/"]
+        self.rankings = [[1, "http://usern4me:passw0rd@localhost:8890/"]]
         self.https_certfile = None
 
         # PrintingService

--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -366,10 +366,18 @@ class ProxyService(TriggeredService):
                         "score_mode": task.score_mode,
                     }
 
-                self.enqueue(ProxyOperation(contest_id ,ProxyExecutor.CONTEST_TYPE, contests))
-                self.enqueue(ProxyOperation(contest_id, ProxyExecutor.TEAM_TYPE, teams))
-                self.enqueue(ProxyOperation(contest_id, ProxyExecutor.USER_TYPE, users))
-                self.enqueue(ProxyOperation(contest_id, ProxyExecutor.TASK_TYPE, tasks))
+                self.enqueue(ProxyOperation(contest_id,
+                                            ProxyExecutor.CONTEST_TYPE,
+                                            contests))
+                self.enqueue(ProxyOperation(contest_id,
+                                            ProxyExecutor.TEAM_TYPE,
+                                            teams))
+                self.enqueue(ProxyOperation(contest_id,
+                                            ProxyExecutor.USER_TYPE,
+                                            users))
+                self.enqueue(ProxyOperation(contest_id,
+                                            ProxyExecutor.TASK_TYPE,
+                                            tasks))
 
     def operations_for_score(self, submission):
         """Send the score for the given submission to all rankings.

--- a/cms/service/ResourceService.py
+++ b/cms/service/ResourceService.py
@@ -179,10 +179,6 @@ class ResourceService(Service):
         self._prev_cpu_times = self._get_cpu_times()
         # Sorted list of ServiceCoord running in the same machine
         self._local_services = self._find_local_services()
-        if "ProxyService" in (s.name for s in self._local_services) and \
-                self.contest_id is None:
-            logger.warning("Will not run ProxyService "
-                           "since it requires a contest id.")
         # Dict service with bool to mark if we will restart them.
         self._will_restart = dict((service,
                                    None if not self.autorestart else True)
@@ -222,10 +218,7 @@ class ResourceService(Service):
         matcher = ProcessMatcher()
         for service in self._local_services:
             # We let the user start logservice and resourceservice.
-            if service.name == "LogService" or \
-                    service.name == "ResourceService" or \
-                    (self.contest_id is None and
-                     service.name == "ProxyService"):
+            if service.name in ("LogService", "ResourceService"):
                 continue
 
             # If the user specified not to restart some service, we
@@ -462,10 +455,6 @@ class ResourceService(Service):
         except ValueError:
             logger.error("Unable to decode service string.")
         name = service[:idx]
-
-        # ProxyService requires contest_id
-        if self.contest_id is None and name == "ProxyService":
-            return None
 
         try:
             shard = int(service[idx + 1:])

--- a/cmstestsuite/programstarter.py
+++ b/cmstestsuite/programstarter.py
@@ -244,7 +244,7 @@ class Program:
 
     def _check_ranking_web_server(self):
         """Health checker for RWS."""
-        url = urlsplit(self.cms_config["rankings"][0])
+        url = urlsplit(self.cms_config["rankings"][0][1])
         sock = socket.socket()
         sock.connect((url.hostname, url.port))
         sock.close()

--- a/cmstestsuite/testrunner.py
+++ b/cmstestsuite/testrunner.py
@@ -299,7 +299,7 @@ class TestRunner:
             self.ps.start("EvaluationService", contest=self.contest_id)
         self.ps.wait()
 
-        self.ps.start("ProxyService", contest=self.contest_id)
+        self.ps.start("ProxyService")
         for shard in range(self.workers):
             self.ps.start("Worker", shard)
 

--- a/cmstestsuite/unit_tests/service/ProxyServiceTest.py
+++ b/cmstestsuite/unit_tests/service/ProxyServiceTest.py
@@ -33,6 +33,7 @@ import gevent
 # Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
+from cms.conf import config
 from cms.service.ProxyService import ProxyService
 from cmscommon.constants import SCORE_MODE_MAX
 
@@ -76,6 +77,8 @@ class TestProxyService(DatabaseMixin, unittest.TestCase):
 
         self.session.commit()
 
+        config.rankings[0][0] = self.contest.id
+
     def new_sr_unscored(self):
         submission = self.add_submission(task=self.task,
                                          participation=self.participation)
@@ -96,7 +99,7 @@ class TestProxyService(DatabaseMixin, unittest.TestCase):
 
     def test_startup(self):
         """Test that data is sent in the right order at startup."""
-        ProxyService(0, self.contest.id)
+        ProxyService(0)
 
         gevent.sleep(0.1)
 

--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -151,12 +151,14 @@
 
     "_section": "ScoringService",
 
-    "_help": "List of URLs (with embedded username and password) of the",
+    "_help": "List of [contest id, URL] tuples.",
+    "_help": "Contest id specifies which contest scores to send.",
+    "_help": "URL (with embedded username and password) of the",
     "_help": "RWSs where the scores are to be sent. Don't include the",
     "_help": "load balancing proxy (if any), just the backends. If any",
     "_help": "of them uses HTTPS specify a file with the certificates",
     "_help": "you trust.",
-    "rankings": ["http://usern4me:passw0rd@localhost:8890/"],
+    "rankings": [[1, "http://usern4me:passw0rd@localhost:8890/"]],
     "https_certfile": null,
 
 

--- a/scripts/cmsProxyService
+++ b/scripts/cmsProxyService
@@ -39,8 +39,7 @@ def main():
     """
     test_db_connection()
     success = default_argument_parser("Ranking relayer for CMS.",
-                                      ProxyService,
-                                      ask_contest=ask_for_contest).run()
+                                      ProxyService).run()
     return 0 if success is True else 1
 
 


### PR DESCRIPTION
ProxyService only supports one parallel contest when sending initial data to listed RWS. After that, it sends all submission changes (even from different contests). These changes are discarded by RWS because of data inconsistency.

This pull request adds support to ProxyService for sending scores to multiple RWS where each of them can show a different subset of contests.
This request fixes the problem where ProxyService sends unrelated contest submissions to RWS.

Additionally, this allows to easily set up RW servers for multiple contests that are run in parallel and keep their data unmerged if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1102)
<!-- Reviewable:end -->
