### PR TITLE
Call super().prepare() before raising HTTPError in choose_contest()

### DIFF
--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -106,6 +106,7 @@ class ContestHandler(BaseHandler):
                 # render_params in this class assumes the contest is loaded,
                 # so we cannot call it without a fully defined contest. Luckily
                 # the one from the base class is enough to display a 404 page.
+                super().prepare()
                 self.r_params = super().render_params()
                 raise tornado.web.HTTPError(404)
         else:


### PR DESCRIPTION
If `choose_contest()` raises an exception (for example, contest doesn't exist), then the server will try to render an error template in `write_error()`. The template needs an `url` parameter, which is assigned in `CommonRequestHandler.prepare()`, so we need to call this function beforehand.

Partially fixes #1069.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1103)
<!-- Reviewable:end -->
