### PR TITLE
Reload the admin/contest page only once once when the contest ends

### DIFF
--- a/cms/server/admin/static/aws_utils.js
+++ b/cms/server/admin/static/aws_utils.js
@@ -445,8 +445,10 @@ CMS.AWSUtils.prototype.two_digits = function(n) {
 
 /**
  * Update the remaining time showed in the "remaining" div.
+ *
+ * timer (int): handle for the timer that called this function, or -1 if none
  */
-CMS.AWSUtils.prototype.update_remaining_time = function() {
+CMS.AWSUtils.prototype.update_remaining_time = function(timer = -1) {
     // We assume this.phase always is the correct phase (since this
     // method also refreshes the page when the phase changes).
     var relevant_timestamp = null;
@@ -476,8 +478,8 @@ CMS.AWSUtils.prototype.update_remaining_time = function() {
     var countdown_sec =
         relevant_timestamp - this.timestamp - (now - this.first_date) / 1000;
     if (countdown_sec <= 0) {
+        clearInterval(timer);
         location.reload();
-        return;
     }
 
     $("#remaining_text").text(text);

--- a/cms/server/admin/templates/base.html
+++ b/cms/server/admin/templates/base.html
@@ -40,7 +40,7 @@ function init()
 
     {% if phase < 3 %}
     utils.update_remaining_time();
-    setInterval(function() { utils.update_remaining_time(); }, 1000);
+    var timer = setInterval(function() { utils.update_remaining_time(timer); }, 1000);
     {% endif %}
     utils.update_notifications();
     setInterval(function() { utils.update_notifications(); }, 15000);

--- a/cms/server/contest/static/cws_utils.js
+++ b/cms/server/contest/static/cws_utils.js
@@ -218,7 +218,7 @@ CMS.CWSUtils.prototype.format_timedelta = function(timedelta) {
 };
 
 
-CMS.CWSUtils.prototype.update_time = function(usaco_like_contest) {
+CMS.CWSUtils.prototype.update_time = function(usaco_like_contest, timer = -1) {
     var now = $.now() / 1000;
 
     // FIXME This may cause some problems around DST boundaries, as it
@@ -228,6 +228,12 @@ CMS.CWSUtils.prototype.update_time = function(usaco_like_contest) {
 
     var server_time = now - this.client_timestamp + this.server_timestamp;
 
+    var contest_url = this.contest_url();
+    var reload_overview = function() {
+        clearInterval(timer);
+        window.location.href = contest_url;
+    };
+
     // TODO consider possible null values of this.current_phase_begin
     // and this.current_phase_end (they mean -inf and +inf
     // respectively)
@@ -236,7 +242,7 @@ CMS.CWSUtils.prototype.update_time = function(usaco_like_contest) {
     case -2:
         // Contest hasn't started yet.
         if (server_time >= this.current_phase_end) {
-            window.location.href = this.contest_url();
+            reload_overview();
         }
         $("#countdown_label").text(
             $("#translation_until_contest_starts").text());
@@ -260,7 +266,7 @@ CMS.CWSUtils.prototype.update_time = function(usaco_like_contest) {
     case 0:
         // Contest is currently running.
         if (server_time >= this.current_phase_end) {
-            window.location.href = this.contest_url();
+            reload_overview();
         }
         $("#countdown_label").text($("#translation_time_left").text());
         $("#countdown").text(
@@ -270,7 +276,7 @@ CMS.CWSUtils.prototype.update_time = function(usaco_like_contest) {
         // User has already finished its time but contest hasn't
         // finished yet.
         if (server_time >= this.current_phase_end) {
-            window.location.href = this.contest_url();
+            reload_overview();
         }
         $("#countdown_label").text(
             $("#translation_until_contest_ends").text());
@@ -280,7 +286,7 @@ CMS.CWSUtils.prototype.update_time = function(usaco_like_contest) {
     case +2:
         // Contest has already finished but analysis mode hasn't started yet.
         if (server_time >= this.current_phase_end) {
-            window.location.href = this.contest_url();
+            reload_overview();
         }
         $("#countdown_label").text(
             $("#translation_until_analysis_starts").text());
@@ -290,7 +296,7 @@ CMS.CWSUtils.prototype.update_time = function(usaco_like_contest) {
     case +3:
         // Contest has already finished. Analysis mode is running.
         if (server_time >= this.current_phase_end) {
-            window.location.href = this.contest_url();
+            reload_overview();
         }
         $("#countdown_label").text(
             $("#translation_until_analysis_ends").text());

--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -32,8 +32,8 @@ var utils = new CMS.CWSUtils("{{ url() }}", "{{ contest_url() }}", "{{ contest.n
                              {{ actual_phase }});
 $(document).ready(function () {
     utils.update_time({% if contest.per_user_time is not none %}true{% else %}false{% endif %});
-    setInterval(function() {
-        utils.update_time({% if contest.per_user_time is not none %}true{% else %}false{% endif %});
+    var timer = setInterval(function() {
+        utils.update_time({% if contest.per_user_time is not none %}true{% else %}false{% endif %}, timer);
     }, 1000);
     utils.update_unread_count(0{% if page == "communication" %}, 0{% endif %});
     utils.update_notifications(true);


### PR DESCRIPTION
Previously the callback to update remaining time in both CWS and AWS would continue to fire every second even after the page reload was triggered. If the server was slow to respond, the reload would be issued again, resulting in an infinite loop and possibly DoS-ing the server.

Fix this by cancelling the update timer when a page reload is issued.

Fixes #1104. See the issue for additional discussion.

The return statement is removed so that the countdown stops at 00:00 and not at 00:01.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1105)
<!-- Reviewable:end -->
