### PR TITLE
Fix bug that misidentified submissions in CWS autorefresh feature

### DIFF
--- a/cms/server/contest/templates/submission_table.html
+++ b/cms/server/contest/templates/submission_table.html
@@ -51,16 +51,18 @@
         </tr>
     </thead>
     <tbody>
-    {% if submission_table_submissions|length == 0 %}
+    {% if submissions|length == 0 %}
         <tr>
             <td colspan="{{ num_cols }}" class="no_submissions">{% trans %}no submissions{% endtrans %}</td>
         </tr>
     {% else %}
-        {% for s in submission_table_submissions|sort(attribute="timestamp")|reverse %}
-            {# loop.revindex is broken: https://github.com/pallets/jinja/issues/794 #}
-            {% set s_idx = submissions|length - loop.index0 %}
-            {% set sr = s.get_result(s.task.active_dataset) or undefined %}
-            {% include "submission_row.html" %}
+        {% for s in submissions|sort(attribute="timestamp")|reverse %}
+            {% if s.official == submission_table_official %}
+                {# loop.revindex is broken: https://github.com/pallets/jinja/issues/794 #}
+                {% set s_idx = submissions|length - loop.index0 %}
+                {% set sr = s.get_result(s.task.active_dataset) or undefined %}
+                {% include "submission_row.html" %}
+            {% endif %}
         {% endfor %}
     {% endif %}
     </tbody>

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -331,14 +331,14 @@ $(document).ready(function () {
 
 {% set show_date = not submissions|map(attribute="timestamp")|all("today") %}
 
-{% set submission_table_submissions = submissions|rejectattr("official")|list %}
-{% if submission_table_submissions|length > 0 %}
+{% if submissions|rejectattr("official")|list|length > 0 %}
 <h3>{% trans %}Unofficial submissions{% endtrans %}</h3>
+  {% set submission_table_official = false %}
   {% include "submission_table.html" %}
 <h3>{% trans %}Official submissions{% endtrans %}</h3>
 {% endif %}
 
-{% set submission_table_submissions = submissions|selectattr("official")|list %}
+{% set submission_table_official = true %}
 {% include "submission_table.html" %}
 
 <div class="modal fade hide wide" id="submission_detail">


### PR DESCRIPTION
That feature relies on the submissions being named with their position
in the chronological list of submissions of the user. After the split
between official and unofficial lists, the positions were all wrong
since they were computed independently.

Fixes #1107.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1108)
<!-- Reviewable:end -->
