### PR TITLE
Remove cmsComputeComplexity from setup.py's console script list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,6 @@ setup(
             "cmsAddTestcases=cmscontrib.AddTestcases:main",
             "cmsAddUser=cmscontrib.AddUser:main",
             "cmsCleanFiles=cmscontrib.CleanFiles:main",
-            "cmsComputeComplexity=cmscontrib.ComputeComplexity:main",
             "cmsDumpExporter=cmscontrib.DumpExporter:main",
             "cmsDumpImporter=cmscontrib.DumpImporter:main",
             "cmsDumpUpdater=cmscontrib.DumpUpdater:main",


### PR DESCRIPTION
cmsComputeComplexity was already removed in 2f36683, no reason to make a script to invoke it (throws ImportError upon usage anyway)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1109)
<!-- Reviewable:end -->
