### PR TITLE
Fix RWS with score mode MAX_SUBTASK

### DIFF
--- a/cmsranking/Scoring.py
+++ b/cmsranking/Scoring.py
@@ -4,6 +4,7 @@
 # Copyright © 2011-2013 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2018 William Di Luigi <williamdiluigi@gmail.com>
+# Copyright © 2019 Luca Chiodini <luca@chiodini.org>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -119,7 +120,7 @@ class Score:
                          for submission in self._submissions.values()),
                         default=0.0)
         elif self._score_mode == SCORE_MODE_MAX_SUBTASK:
-            scores_by_submission = (map(float, s.extra or [])
+            scores_by_submission = (map(float, s.extra or [s.score])
                                     for s in self._submissions.values())
             scores_by_subtask = zip_longest(*scores_by_submission,
                                             fillvalue=0.0)


### PR DESCRIPTION
Tasks with a score type that was not group (i.e., without subtasks)
were not handled correctly.

We consider them as having one subtask (as already done elsewhere in
CMS).

**Important note**
I think that the proposed change can work in the event of an unscored submission (which should have 0 as score), but please double-check what is being done inside those lines. Feel free to modify them as needed.
They were disputed since their introduction and have led to a number of subtle bugs in these last months. :joy:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1111)
<!-- Reviewable:end -->
