### PR TITLE
Fix ProxyService team.code encoding for user

### DIFF
--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -350,7 +350,8 @@ class ProxyService(TriggeredService):
                     users[encode_id(user.username)] = {
                         "f_name": user.first_name,
                         "l_name": user.last_name,
-                        "team": team.code if team is not None else None,
+                        "team": encode_id(team.code)
+                                if team is not None else None,
                     }
                     if team is not None:
                         teams[encode_id(team.code)] = {


### PR DESCRIPTION
Fix inconsistent team.code encoding in ProxyService.

It breaks if `team.code` has `_`  or any other non digit, non letter character.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1117)
<!-- Reviewable:end -->
