### PR TITLE
Better default Nginx configuration

### DIFF
--- a/config/nginx.conf.sample
+++ b/config/nginx.conf.sample
@@ -6,8 +6,8 @@ user www-data;
 pid /run/nginx.pid;
 
 # Raise the three following values if you expect a very high load.
-worker_processes 4;
-worker_rlimit_nofile 1024;
+worker_processes auto;
+worker_rlimit_nofile 1024;  # You can increase this up to 4096 (for more than that you need to run as root)
 events {
     worker_connections 768;
     multi_accept on;
@@ -35,10 +35,10 @@ http {
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
     # Group the ContestWebServers to load balance the users' requests
-    # on them. The "ip_hash" option is necessary for the notifications
-    # to work.
+    # on them. The "hash" option is necessary for the notifications
+    # to work (default would be round robin).
     upstream cws {
-        ip_hash;
+        hash $remote_addr;
         keepalive 500;
         server 127.0.0.1:8888;
         # Insert other CWSs here.


### PR DESCRIPTION
Use hash  instead if ip_hash because the latter only considers the first three octets of the IP address, and in usual settings those octects have a low variability

Also increased worker_processes from 4 to auto as it's better and the (new?) default on Ubuntu