### PR TITLE
testlib: backport fix for #1056

### DIFF
--- a/cmscontrib/loaders/polygon/testlib.h
+++ b/cmscontrib/loaders/polygon/testlib.h
@@ -55,6 +55,9 @@
  *   - Add the "CMS_VERBOSE_FEEDBACK" conditional macro to enable
  *     testlib-style messages
  *   - Interactors are not supported
+ *
+ * Backports:
+ *   - 1bcfacc3a97667b38a3aef9d95b97edc6a9db688 (MikeMirzayanov/testlib#79)
  */
 
 /* NOTE: This file contains testlib library for C++.
@@ -79,6 +82,7 @@
  */
 
 const char* latestFeatures[] = {
+                          "Fixed issue #79: fixed missed guard against repeated header include",
                           "Fixed stringstream repeated usage issue",
                           "Fixed compilation in g++ (for std=c++03)",
                           "Batch of println functions (support collections, iterator ranges)",
@@ -4564,8 +4568,6 @@ NORETURN void expectedButFound<long double>(TResult result, long double expected
     __testlib_expectedButFound(result, double(expected), double(found), prepend.c_str());
 }
 
-#endif
-
 #if __cplusplus > 199711L || defined(_MSC_VER)
 template <typename T>
 struct is_iterable
@@ -4754,4 +4756,5 @@ void println(const A& a, const B& b, const C& c, const D& d, const E& e, const F
     __testlib_print_one(g);
     std::cout << std::endl;
 }
+#endif
 #endif


### PR DESCRIPTION
There is no newer stable testlib version, but we can backport the patch separately.

Fixes #1056. Upstream issue MikeMirzayanov/testlib#79.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1127)
<!-- Reviewable:end -->
