### PR TITLE
Replace most subprocess.call() invocations with check_call()

### DIFF
--- a/cms/service/PrintingService.py
+++ b/cms/service/PrintingService.py
@@ -130,11 +130,10 @@ class PrintingExecutor(Executor):
                        "--right-footer=",
                        "--center-title=" + filename,
                        "--left-title=" + timestr]
-                ret = subprocess.call(cmd, cwd=directory)
-                if ret != 0:
-                    raise Exception(
-                        "Failed to convert text file to ps with command: %s"
-                        "(error %d)" % (pretty_print_cmdline(cmd), ret))
+                try:
+                    subprocess.check_call(cmd, cwd=directory)
+                except subprocess.CalledProcessError as e:
+                    raise Exception("Failed to convert text file to ps") from e
 
                 if not os.path.exists(source_ps):
                     logger.warning("Unable to convert from text to ps.")
@@ -149,11 +148,10 @@ class PrintingExecutor(Executor):
                 cmd = ["ps2pdf",
                        "-sPAPERSIZE=%s" % config.paper_size.lower(),
                        source_ps]
-                ret = subprocess.call(cmd, cwd=directory)
-                if ret != 0:
-                    raise Exception(
-                        "Failed to convert ps file to pdf with command: %s"
-                        "(error %d)" % (pretty_print_cmdline(cmd), ret))
+                try:
+                    subprocess.check_call(cmd, cwd=directory)
+                except subprocess.CalledProcessError as e:
+                    raise Exception("Failed to convert ps file to pdf") from e
 
             # Find out number of pages
             with open(source_pdf, "rb") as file_:
@@ -184,11 +182,10 @@ class PrintingExecutor(Executor):
                    "-interaction",
                    "nonstopmode",
                    title_tex]
-            ret = subprocess.call(cmd, cwd=directory)
-            if ret != 0:
-                raise Exception(
-                    "Failed to create title page with command: %s"
-                    "(error %d)" % (pretty_print_cmdline(cmd), ret))
+            try:
+                subprocess.check_call(cmd, cwd=directory)
+            except subprocess.CalledProcessError as e:
+                raise Exception("Failed to create title page") from e
 
             with contextlib.closing(PdfFileMerger()) as pdfmerger:
                 pdfmerger.append(title_pdf)

--- a/cmscontrib/loaders/tps.py
+++ b/cmscontrib/loaders/tps.py
@@ -228,10 +228,13 @@ class TpsTaskLoader(TaskLoader):
         if os.path.exists(checker_src):
             logger.info("Checker found, compiling")
             checker_exe = os.path.join(checker_dir, "checker")
-            subprocess.call([
+            ret = subprocess.call([
                 "g++", "-x", "c++", "-std=gnu++14", "-O2", "-static",
                 "-o", checker_exe, checker_src
             ])
+            if ret != 0:
+                logger.critical("Could not compile checker")
+                return None
             digest = self.file_cacher.put_file_from_path(
                 checker_exe,
                 "Manager for task %s" % name)
@@ -283,10 +286,13 @@ class TpsTaskLoader(TaskLoader):
         if os.path.exists(manager_src):
             logger.info("Manager found, compiling")
             manager_exe = os.path.join(graders_dir, "manager")
-            subprocess.call([
+            ret = subprocess.call([
                 "g++", "-x", "c++", "-O2", "-static",
                 "-o", manager_exe, manager_src
             ])
+            if ret != 0:
+                logger.critical("Could not compile manager")
+                return None
             digest = self.file_cacher.put_file_from_path(
                 manager_exe,
                 "Manager for task %s" % name)

--- a/cmstaskenv/cmsMake.py
+++ b/cmstaskenv/cmsMake.py
@@ -104,11 +104,8 @@ def call(base_dir, args, stdin=None, stdout=None, stderr=None, env=None):
         env = {}
     env2 = copy.copy(os.environ)
     env2.update(env)
-    res = subprocess.call(args, stdin=stdin, stdout=stdout, stderr=stderr,
+    subprocess.check_call(args, stdin=stdin, stdout=stdout, stderr=stderr,
                           cwd=base_dir, env=env2)
-    if res != 0:
-        print("Subprocess returned with error", file=sys.stderr)
-        sys.exit(1)
 
 
 def detect_task_name(base_dir):

--- a/cmstestsuite/__init__.py
+++ b/cmstestsuite/__init__.py
@@ -56,8 +56,8 @@ def sh(cmdline, ignore_failure=False):
     if CONFIG["VERBOSITY"] >= 3:
         kwargs["stdout"] = subprocess.DEVNULL
         kwargs["stderr"] = subprocess.STDOUT
-    ret = subprocess.call(cmdline, **kwargs)
-    if not ignore_failure and ret != 0:
-        raise TestException(
-            "Execution failed with %d/%d. Tried to execute:\n%s\n" %
-            (ret & 0xff, ret >> 8, pretty_print_cmdline(cmdline)))
+    kwargs["check"] = not ignore_failure
+    try:
+        subprocess.run(cmdline, **kwargs)
+    except subprocess.CalledProcessError as e:
+        raise TestException("Execution failed") from e

--- a/cmstestsuite/coverage.py
+++ b/cmstestsuite/coverage.py
@@ -70,6 +70,6 @@ def send_coverage_to_codecov(flag):
     """Send the coverage report to Codecov with the given flag."""
     if CONFIG.get('COVERAGE', False):
         logger.info("Sending coverage results to codecov for flag %s." % flag)
-        subprocess.call(
+        subprocess.check_call(
             "bash -c 'bash <(curl -s https://codecov.io/bash) -c -F %s'" %
             flag, shell=True)


### PR DESCRIPTION
This ensures proper error handling. In some places manual error reporting is also replaced with Python chained exceptions.

Manual error handling is left in loaders because multiple other places also return `None` instead of raising an exception. It can be refactored too if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1128)
<!-- Reviewable:end -->
