### PR TITLE
Set up Jinja whitespace control in Babel mapping

### DIFF
--- a/babel_mapping.cfg
+++ b/babel_mapping.cfg
@@ -7,6 +7,10 @@
 [python: server/contest/submission/*.py]
 [python: service/*.py]
 [jinja2: server/contest/templates/*.html]
-trimmed: 1
+trimmed = 1
+trim_blocks = 1
+lstrip_blocks = 1
 [jinja2: server/contest/templates/macro/*.html]
-trimmed: 1
+trimmed = 1
+trim_blocks = 1
+lstrip_blocks = 1

--- a/cms/locale/cms.pot
+++ b/cms/locale/cms.pot
@@ -1,22 +1,22 @@
 # Translations template for Contest Management System.
-# Copyright (C) 2020 CMS development group
+# Copyright (C) 2021 CMS development group
 # This file is distributed under the same license as the Contest Management
 # System project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Contest Management System 1.5.dev0\n"
 "Report-Msgid-Bugs-To: contestms@googlegroups.com\n"
-"POT-Creation-Date: 2020-02-24 15:23+0100\n"
+"POT-Creation-Date: 2021-02-08 16:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.8.0\n"
+"Generated-By: Babel 2.6.0\n"
 
 msgid "N/A"
 msgstr ""
@@ -853,39 +853,6 @@ msgstr ""
 msgid "Standard error"
 msgstr ""
 
-msgid "None"
-msgstr ""
-
-msgid "Download"
-msgstr ""
-
-msgid "Played"
-msgstr ""
-
-msgid "Play!"
-msgstr ""
-
-msgid "Wait..."
-msgstr ""
-
-msgid "No tokens"
-msgstr ""
-
-msgid "Public score"
-msgstr ""
-
-msgid "Total score"
-msgstr ""
-
-msgid "Score"
-msgstr ""
-
-msgid "Token"
-msgstr ""
-
-msgid "no submissions"
-msgstr ""
-
 #, python-format
 msgid "%(name)s (%(short_name)s) <small>description</small>"
 msgstr ""
@@ -1024,6 +991,9 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+msgid "Download"
+msgstr ""
+
 msgid "Submit a test"
 msgstr ""
 
@@ -1050,6 +1020,36 @@ msgid "Test details"
 msgstr ""
 
 msgid "Evaluation outcome"
+msgstr ""
+
+msgid "Wait..."
+msgstr ""
+
+msgid "None"
+msgstr ""
+
+msgid "Public score"
+msgstr ""
+
+msgid "Total score"
+msgstr ""
+
+msgid "Score"
+msgstr ""
+
+msgid "Token"
+msgstr ""
+
+msgid "no submissions"
+msgstr ""
+
+msgid "Played"
+msgstr ""
+
+msgid "Play!"
+msgstr ""
+
+msgid "No tokens"
 msgstr ""
 
 msgid "Invalid file"


### PR DESCRIPTION
The `lstrip_blocks` environment parameter affects Jinja parsing mode, see pallets/jinja#748. Hence we need to use the same whitespace control parameters as in the actual CMS code.

Fixes #1096.

I also changed the mapping file to use the conventional INI file syntax for better source highlighting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1130)
<!-- Reviewable:end -->
