### PR TITLE
Show original IP address of requests in AWS logs

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -147,6 +147,7 @@ class Config:
         self.admin_listen_address = ""
         self.admin_listen_port = 8889
         self.admin_cookie_duration = 10 * 60 * 60  # 10 hours
+        self.admin_num_proxies_used = None
 
         # ProxyService.
         self.rankings = ["http://usern4me:passw0rd@localhost:8890/"]

--- a/cms/server/admin/server.py
+++ b/cms/server/admin/server.py
@@ -53,6 +53,7 @@ class AdminWebServer(WebService):
                              ("cms.server.admin", "static")],
             "cookie_secret": hex_to_bin(config.secret_key),
             "debug": config.tornado_debug,
+            "num_proxies_used": config.admin_num_proxies_used,
             "auth_middleware": AWSAuthMiddleware,
             "rpc_enabled": True,
             "rpc_auth": self.is_rpc_authorized,

--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -147,6 +147,12 @@
     "_help": "The duration is refreshed on every manual request.",
     "admin_cookie_duration": 36000,
 
+    "_help": "The number of proxies that will be crossed before AWS gets",
+    "_help": "the request. This is used to determine the request's real",
+    "_help": "source IP address. For example, if you're using nginx as",
+    "_help": "a proxy, you will likely want to set this value to 1.",
+    "admin_num_proxies_used": 0,
+
 
 
     "_section": "ScoringService",


### PR DESCRIPTION
See also the previous discussion: https://gitter.im/cms-dev/cms?at=5bfa905597a8982b9a606c79

For now I implemented a bare-bones approach with the hidden config setting. It can be developed further:
- Either by documenting the new setting in `cms.conf`
- Or by refactoring `num_proxies_used` to include both CWS and AWS

I can rework this PR if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1131)
<!-- Reviewable:end -->
