### PR TITLE
Fix +4 phase computation and add more phase tests

### DIFF
--- a/cms/server/contest/phase_management.py
+++ b/cms/server/contest/phase_management.py
@@ -175,6 +175,8 @@ def compute_actual_phase(timestamp, contest_start, contest_stop,
                 actual_phase = +3
             elif analysis_stop < timestamp:
                 current_phase_begin = analysis_stop
+                if actual_stop is not None:
+                    current_phase_begin = max(analysis_stop, actual_stop)
                 current_phase_end = None
                 actual_phase = +4
             else:

--- a/cmstestsuite/unit_tests/server/contest/phase_management_test.py
+++ b/cmstestsuite/unit_tests/server/contest/phase_management_test.py
@@ -178,6 +178,8 @@ class TestComputeActualPhase(unittest.TestCase):
              ("4", -1, "6", 0, "14"))
         test("4", "12", None, None, None, None, "2", "2",
              ("4", -1, "6", 0, "16"))
+        test("4", "8", None, None, None, None, "5", "0",
+             ("4", -1, "9", 0, "13"))
 
         # Almost identical, with starting_time set to make sure it
         # doesn't affect anything.
@@ -189,6 +191,8 @@ class TestComputeActualPhase(unittest.TestCase):
              ("4", -1, "6", 0, "14"))
         test("4", "12", None, None, None, "7", "2", "2",
              ("4", -1, "6", 0, "16"))
+        test("4", "8", None, None, None, "7", "5", "0",
+             ("4", -1, "9", 0, "13"))
 
         # Test analysis mode. Almost identical to above
         test("4", "12", "17", "20", None, None, "0", "0",
@@ -199,6 +203,8 @@ class TestComputeActualPhase(unittest.TestCase):
              ("4", -1, "6", 0, "14", 2, "17", 3, "20"))
         test("4", "12", "17", "20", None, None, "2", "2",
              ("4", -1, "6", 0, "16", 2, "17", 3, "20"))
+        test("4", "8", "17", "20", None, None, "5", "0",
+             ("4", -1, "9", 0, "13", 2, "17", 3, "20"))
         test("4", "12", "17", "20", None, "7", "0", "0",
              ("4", 0, "12", 2, "17", 3, "20"))
         test("4", "12", "17", "20", None, "7", "0", "2",
@@ -207,14 +213,24 @@ class TestComputeActualPhase(unittest.TestCase):
              ("4", -1, "6", 0, "14", 2, "17", 3, "20"))
         test("4", "12", "17", "20", None, "7", "2", "2",
              ("4", -1, "6", 0, "16", 2, "17", 3, "20"))
+        test("4", "8", "17", "20", None, "7", "5", "0",
+             ("4", -1, "9", 0, "13", 2, "17", 3, "20"))
 
-        # Test for overlapping of contest and analysis for this users
+        # Test for overlapping of contest and analysis for this user
         test("4", "12", "12", "20", None, None, "2", "0",
              ("4", -1, "6", 0, "14", 3, "20"))
         test("4", "12", "12", "20", None, None, "0", "2",
              ("4", 0, "14", 3, "20"))
         test("4", "12", "12", "20", None, None, "1", "1",
              ("4", -1, "5", 0, "14", 3, "20"))
+        test("4", "8", "8", "12", None, None, "0", "5",
+             ("4", 0, "13"))
+        test("4", "8", "8", "12", None, None, "5", "0",
+             ("4", -1, "9", 0, "13"))
+        test("4", "8", "8", "12", None, None, "9", "0",
+             ("4", -1, "13", 0, "17"))
+        test("4", "8", "8", "16", None, None, "5", "1",
+             ("4", -1, "9", 0, "14", 3, "16"))
 
     @staticmethod
     def test_usaco_like():


### PR DESCRIPTION
This PR adds phase computation tests that check abnormally long delays/extensions, and fixes a related phase computation bug.

Related old discussion: https://gitter.im/cms-dev/cms?at=5bfa90ffced7003fe18261c9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1133)
<!-- Reviewable:end -->
