### PR TITLE
Improve evaluation messages

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -81,7 +81,7 @@ __all__ = [
 
 # Instantiate or import these objects.
 
-version = 42
+version = 43
 
 engine = create_engine(config.database, echo=config.database_debug,
                        pool_timeout=60, pool_recycle=120)

--- a/cms/grading/steps/evaluation.py
+++ b/cms/grading/steps/evaluation.py
@@ -62,23 +62,27 @@ EVALUATION_MESSAGES = MessageCollection([
     HumanMessage("walltimeout",
                  N_("Execution timed out (wall clock limit exceeded)"),
                  N_("Your submission used too much total time. This might "
-                    "be triggered by undefined code, or buffer overflow, "
-                    "for example. Note that in this case the CPU time "
-                    "visible in the submission details might be much smaller "
-                    "than the time limit.")),
+                    "happen if your submission is waiting for an event "
+                    "(e.g., a timer) or has entered undefined behavior. "
+                    "Note that in this case the CPU time visible in "
+                    "the submission details might be much smaller than "
+                    "the time limit.")),
     HumanMessage("signal",
-                 N_("Execution killed (could be triggered by violating memory "
-                    "limits)"),
+                 N_("Execution killed (runtime error)"),
                  N_("The evaluation was killed by a signal. "
-                    "Among other things, this might be caused by exceeding "
-                    "the memory limit. Note that if this is the reason, "
-                    "the memory usage visible in the submission details is "
-                    "the usage before the allocation that caused the "
+                    "Among other things, this might be caused by undefined "
+                    "behavior (e.g., out-of-bounds array access) or by "
+                    "exceeding the memory limit. Note that in the latter "
+                    "case the memory usage visible in the submission details "
+                    "is the usage before the allocation that caused the "
                     "signal.")),
     HumanMessage("returncode",
-                 N_("Execution failed because the return code was nonzero"),
-                 N_("Your submission failed because it exited with a return "
-                    "code different from 0.")),
+                 N_("Execution failed with non-zero exit code "
+                    "(could be caused by exception)"),
+                 N_("Your submission failed because it returned an exit "
+                    "code other than 0. In some programming languages "
+                    "this might be caused by an unhandled exception "
+                    "(e.g., <code>NullPointerException</code>).")),
 ])
 
 

--- a/cms/locale/cms.pot
+++ b/cms/locale/cms.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Contest Management System 1.5.dev0\n"
 "Report-Msgid-Bugs-To: contestms@googlegroups.com\n"
-"POT-Creation-Date: 2019-02-23 11:44+0100\n"
+"POT-Creation-Date: 2019-08-28 19:13+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -119,26 +119,30 @@ msgid "Execution timed out (wall clock limit exceeded)"
 msgstr ""
 
 msgid ""
-"Your submission used too much total time. This might be triggered by "
-"undefined code, or buffer overflow, for example. Note that in this case the "
-"CPU time visible in the submission details might be much smaller than the "
-"time limit."
+"Your submission used too much total time. This might happen if your "
+"submission is waiting for an event (e.g., a timer) or has entered undefined "
+"behavior. Note that in this case the CPU time visible in the submission "
+"details might be much smaller than the time limit."
 msgstr ""
 
-msgid "Execution killed (could be triggered by violating memory limits)"
+msgid "Execution killed (runtime error)"
 msgstr ""
 
 msgid ""
 "The evaluation was killed by a signal. Among other things, this might be "
-"caused by exceeding the memory limit. Note that if this is the reason, the "
-"memory usage visible in the submission details is the usage before the "
-"allocation that caused the signal."
+"caused by undefined behavior (e.g., out-of-bounds array access) or by "
+"exceeding the memory limit. Note that in the latter case the memory usage "
+"visible in the submission details is the usage before the allocation that "
+"caused the signal."
 msgstr ""
 
-msgid "Execution failed because the return code was nonzero"
+msgid "Execution failed with non-zero exit code (could be caused by exception)"
 msgstr ""
 
-msgid "Your submission failed because it exited with a return code different from 0."
+msgid ""
+"Your submission failed because it returned an exit code other than 0. In "
+"some programming languages this might be caused by an unhandled exception "
+"(e.g., <code>NullPointerException</code>)."
 msgstr ""
 
 msgid "Execution completed successfully"
@@ -853,39 +857,6 @@ msgstr ""
 msgid "Standard error"
 msgstr ""
 
-msgid "None"
-msgstr ""
-
-msgid "Download"
-msgstr ""
-
-msgid "Played"
-msgstr ""
-
-msgid "Play!"
-msgstr ""
-
-msgid "Wait..."
-msgstr ""
-
-msgid "No tokens"
-msgstr ""
-
-msgid "Public score"
-msgstr ""
-
-msgid "Total score"
-msgstr ""
-
-msgid "Score"
-msgstr ""
-
-msgid "Token"
-msgstr ""
-
-msgid "no submissions"
-msgstr ""
-
 #, python-format
 msgid "%(name)s (%(short_name)s) <small>description</small>"
 msgstr ""
@@ -1024,6 +995,9 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+msgid "Download"
+msgstr ""
+
 msgid "Submit a test"
 msgstr ""
 
@@ -1050,5 +1024,35 @@ msgid "Test details"
 msgstr ""
 
 msgid "Evaluation outcome"
+msgstr ""
+
+msgid "Wait..."
+msgstr ""
+
+msgid "None"
+msgstr ""
+
+msgid "Public score"
+msgstr ""
+
+msgid "Total score"
+msgstr ""
+
+msgid "Score"
+msgstr ""
+
+msgid "Token"
+msgstr ""
+
+msgid "no submissions"
+msgstr ""
+
+msgid "Played"
+msgstr ""
+
+msgid "Play!"
+msgstr ""
+
+msgid "No tokens"
 msgstr ""
 

--- a/cms/server/contest/templates/documentation.html
+++ b/cms/server/contest/templates/documentation.html
@@ -56,7 +56,7 @@
     {% for message in EVALUATION_MESSAGES.all() %}
     <tr>
       <td><em>{{ _(message.message) }}</em></td>
-      <td>{{ _(message.help_text) }}</td>
+      <td>{{ _(message.help_text)|safe }}</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/cmscontrib/updaters/update_43.py
+++ b/cmscontrib/updaters/update_43.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2019 Andrey Vihrov <andrey.vihrov@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A class to update a dump created by CMS.
+
+Used by DumpImporter and DumpUpdater.
+
+This updater adjusts evaluation messages in submission results.
+
+"""
+
+MESSAGES = {
+    "Execution killed (could be triggered by violating memory limits)":
+        "Execution killed (runtime error)",
+    "Execution failed because the return code was nonzero":
+        "Execution failed with non-zero exit code "
+        "(could be caused by exception)"
+}
+
+class Updater:
+
+    def __init__(self, data):
+        assert data["_version"] == 42
+        self.objs = data
+
+    @staticmethod
+    def update_text(text):
+        if text[0] in MESSAGES:
+            assert len(text) == 1
+            text[0] = MESSAGES[text[0]]
+
+    def run(self):
+        for k, v in self.objs.items():
+            if k.startswith("_"):
+                continue
+            elif v["_class"] == "Evaluation":
+                self.update_text(v["text"])
+            elif v["_class"] == "SubmissionResult":
+                for details in ["public_score_details", "score_details"]:
+                    if details in v and v[details] is not None:
+                        for st in v[details]:
+                            for t in st["testcases"]:
+                                self.update_text(t["text"])
+
+        return self.objs

--- a/cmstestsuite/Test.py
+++ b/cmstestsuite/Test.py
@@ -111,13 +111,6 @@ class CheckTimeoutWall(CheckAbstractEvaluationFailure):
             "Execution timed out (wall clock limit exceeded)")
 
 
-class CheckForbiddenSyscall(CheckAbstractEvaluationFailure):
-    def __init__(self, syscall_name=''):
-        CheckAbstractEvaluationFailure.__init__(
-            self, "executed a forbidden syscall",
-            "Execution killed because of forbidden syscall %s" % syscall_name)
-
-
 class CheckSignal(CheckAbstractEvaluationFailure):
     def __init__(self):
         CheckAbstractEvaluationFailure.__init__(

--- a/cmstestsuite/Test.py
+++ b/cmstestsuite/Test.py
@@ -119,17 +119,18 @@ class CheckForbiddenSyscall(CheckAbstractEvaluationFailure):
 
 
 class CheckSignal(CheckAbstractEvaluationFailure):
-    def __init__(self, signal_number):
+    def __init__(self):
         CheckAbstractEvaluationFailure.__init__(
             self, "died on a signal",
-            "Execution killed with signal %s" % signal_number)
+            "Execution killed (runtime error)")
 
 
 class CheckNonzeroReturn(CheckAbstractEvaluationFailure):
     def __init__(self):
         CheckAbstractEvaluationFailure.__init__(
             self, "nonzero return",
-            "Execution failed because the return code was nonzero")
+            "Execution failed with non-zero exit code "
+            "(could be caused by exception)")
 
 
 class Test:


### PR DESCRIPTION
There are two main problems with the current evaluation messages:

1. For the "Execution killed" message, exceeding the memory limit is by far not the most common cause of this outcome. The much more common case of undefined behavior/crash is not mentioned.
2. For the "non-zero exit code" message, the most common cause is from an unhandled exception being thrown in a language such as Java or Python. But the help text doesn't mention this at all, and the contestant is confused. (We get a lot of questions about this in our national olympiad.)

This pull request improves these evaluation messages and help texts to match the most common causes. For the "Execution killed" message, I picked the "runtime error" hint as a concise and easily understandable variant. The "wall clock limit exceeded" message help text is also updated.

These changes should be discussed and possibly improved — in particular the evaluation messages themselves, as they are mentioned in IOI contest rules. _Perhaps somebody from ISC/ITC should check these._

In some natural languages, the words "execution" and "runtime" will translate to the same word. So one optional thing to consider is simplifying "Execution killed (runtime error)" to just "Runtime error". Or rephrasing this text in some other way. On the other hand, this message should match the similar compilation outcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1134)
<!-- Reviewable:end -->
