### PR TITLE
Instruct the browser to not cache files

### DIFF
--- a/cms/server/util.py
+++ b/cms/server/util.py
@@ -80,6 +80,7 @@ class FileHandlerMixin(RequestHandler):
         self.set_header(FileServerMiddleware.DIGEST_HEADER, digest)
         self.set_header(FileServerMiddleware.FILENAME_HEADER, filename)
         self.set_header("Content-Type", content_type)
+        self.set_header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
         self.finish()
 
 


### PR DESCRIPTION
This has been an issue in some contests, because some file (usually the PDF
statement) is updated by the admins and when users try to re-download it, they
still get the old file because of browser cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1138)
<!-- Reviewable:end -->
