### PR TITLE
Add Language.executable_extension property

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -81,7 +81,7 @@ __all__ = [
 
 # Instantiate or import these objects.
 
-version = 43
+version = 44
 
 engine = create_engine(config.database, echo=config.database_debug,
                        pool_timeout=60, pool_recycle=120)

--- a/cms/grading/language.py
+++ b/cms/grading/language.py
@@ -98,6 +98,11 @@ class Language(metaclass=ABCMeta):
         return self.object_extensions[0] \
             if len(self.object_extensions) > 0 else None
 
+    @property
+    def executable_extension(self):
+        """Executable file extension for this language (including the dot)."""
+        return ""
+
     @abstractmethod
     def get_compilation_commands(self,
                                  source_filenames, executable_filename,

--- a/cms/grading/languages/csharp_mono.py
+++ b/cms/grading/languages/csharp_mono.py
@@ -44,6 +44,11 @@ class CSharpMono(Language):
         return [".cs"]
 
     @property
+    def executable_extension(self):
+        """See Language.executable_extension."""
+        return ".exe"
+
+    @property
     def requires_multithreading(self):
         """See Language.requires_multithreading."""
         return True

--- a/cms/grading/languages/java_jdk.py
+++ b/cms/grading/languages/java_jdk.py
@@ -48,6 +48,11 @@ class JavaJDK(Language):
         return [".java"]
 
     @property
+    def executable_extension(self):
+        """See Language.executable_extension."""
+        return ".jar" if JavaJDK.USE_JAR else ".zip"
+
+    @property
     def requires_multithreading(self):
         """See Language.requires_multithreading."""
         return True
@@ -67,8 +72,9 @@ class JavaJDK(Language):
             return [compile_command, jar_command]
         else:
             zip_command = ["/bin/sh", "-c",
-                           " ".join(["zip", "-r", "-", "*.class", ">",
-                                     shell_quote(executable_filename)])]
+                           " ".join(["zip",
+                                     shell_quote(executable_filename),
+                                     "*.class"])]
             return [compile_command, zip_command]
 
     def get_evaluation_commands(

--- a/cms/grading/languages/php.py
+++ b/cms/grading/languages/php.py
@@ -40,11 +40,20 @@ class Php(Language):
         """See Language.source_extensions."""
         return [".php"]
 
+    @property
+    def executable_extension(self):
+        """See Language.executable_extension."""
+        return ".php"
+
     def get_compilation_commands(self,
                                  source_filenames, executable_filename,
                                  for_evaluation=True):
         """See Language.get_compilation_commands."""
-        return [["/bin/cp", source_filenames[0], executable_filename]]
+        if source_filenames[0] != executable_filename:
+            return [["/bin/cp", source_filenames[0], executable_filename]]
+        else:
+            # We need at least one command to collect execution stats.
+            return [["/bin/true"]]
 
     def get_evaluation_commands(
             self, executable_filename, main=None, args=None):

--- a/cms/grading/languages/python2_cpython.py
+++ b/cms/grading/languages/python2_cpython.py
@@ -45,11 +45,15 @@ class Python2CPython(CompiledLanguage):
         """See Language.source_extensions."""
         return [".py"]
 
+    @property
+    def executable_extension(self):
+        """See Language.executable_extension."""
+        return ".zip"
+
     def get_compilation_commands(self,
                                  source_filenames, executable_filename,
                                  for_evaluation=True):
         """See Language.get_compilation_commands."""
-        zip_filename = "%s.zip" % executable_filename
 
         commands = []
         files_to_package = []
@@ -64,10 +68,8 @@ class Python2CPython(CompiledLanguage):
             else:
                 files_to_package.append(pyc_filename)
 
-        # zip does not support writing to a file without extension.
-        commands.append(["/usr/bin/zip", "-r", zip_filename]
+        commands.append(["/usr/bin/zip", executable_filename]
                         + files_to_package)
-        commands.append(["/bin/mv", zip_filename, executable_filename])
 
         return commands
 

--- a/cms/grading/languages/python3_cpython.py
+++ b/cms/grading/languages/python3_cpython.py
@@ -45,11 +45,16 @@ class Python3CPython(CompiledLanguage):
         """See Language.source_extensions."""
         return [".py"]
 
+    @property
+    def executable_extension(self):
+        """See Language.executable.extension."""
+        # Defined in PEP 441 (https://www.python.org/dev/peps/pep-0441/).
+        return ".pyz"
+
     def get_compilation_commands(self,
                                  source_filenames, executable_filename,
                                  for_evaluation=True):
         """See Language.get_compilation_commands."""
-        zip_filename = "%s.zip" % executable_filename
 
         commands = []
         files_to_package = []
@@ -64,10 +69,8 @@ class Python3CPython(CompiledLanguage):
             else:
                 files_to_package.append(pyc_filename)
 
-        # zip does not support writing to a file without extension.
-        commands.append(["/usr/bin/zip", "-r", zip_filename]
+        commands.append(["/usr/bin/zip", executable_filename]
                         + files_to_package)
-        commands.append(["/bin/mv", zip_filename, executable_filename])
 
         return commands
 

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -119,7 +119,7 @@ class TwoSteps(TaskType):
                     source_filenames.append(header_filename)
 
             # Get compilation command and compile.
-            executable_filename = "manager"
+            executable_filename = "manager" + language.executable_extension
             commands = language.get_compilation_commands(
                 source_filenames, executable_filename)
             res[language.name] = commands
@@ -179,7 +179,7 @@ class TwoSteps(TaskType):
                     job.managers[header_filename].digest
 
         # Get compilation command.
-        executable_filename = "manager"
+        executable_filename = "manager" + language.executable_extension
         commands = language.get_compilation_commands(
             source_filenames, executable_filename)
 

--- a/cmscontrib/updaters/update_44.py
+++ b/cmscontrib/updaters/update_44.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2019 Andrey Vihrov <andrey.vihrov@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A class to update a dump created by CMS.
+
+Used by DumpImporter and DumpUpdater.
+
+This updater adds file name extensions to relevant executables.
+
+Note:
+  - File descriptions are not updated.
+  - Out-of-tree languages should be added to LANG_EXT manually.
+  - Custom use of USE_JAR = False should be reflected in this updater.
+
+"""
+
+USE_JAR = True
+
+LANG_EXT = {
+    "C# / Mono": ".exe",
+    "Java / JDK": ".jar" if USE_JAR else ".zip",
+    "PHP": ".php",
+    "Python 2 / CPython": ".zip",
+    "Python 3 / CPython": ".pyz",
+}
+
+class Updater:
+
+    def __init__(self, data):
+        assert data["_version"] == 43
+        self.objs = data
+
+    def run(self):
+        for k, v in self.objs.items():
+            if k.startswith("_"):
+                continue
+            if v["_class"] == "Executable":
+                s = self.objs[v["submission"]]
+                l = s["language"]
+                sr = self.objs[v["submission_result"]]
+
+                del sr["executables"][v["filename"]]
+                v["filename"] += LANG_EXT.get(l, "")
+                sr["executables"][v["filename"]] = k
+
+        return self.objs

--- a/cmstestsuite/unit_tests/grading/tasktypes/BatchTest.py
+++ b/cmstestsuite/unit_tests/grading/tasktypes/BatchTest.py
@@ -53,7 +53,7 @@ class TestGetCompilationCommands(TaskTypeTestMixin, unittest.TestCase):
             "L1": fake_compilation_commands(
                 COMPILATION_COMMAND_1, ["foo.l1"], "foo"),
             "L2": fake_compilation_commands(
-                COMPILATION_COMMAND_2, ["foo.l2"], "foo"),
+                COMPILATION_COMMAND_2, ["foo.l2"], "foo.ext"),
         })
 
     def test_grader(self):
@@ -63,7 +63,7 @@ class TestGetCompilationCommands(TaskTypeTestMixin, unittest.TestCase):
             "L1": fake_compilation_commands(
                 COMPILATION_COMMAND_1, ["foo.l1", "grader.l1"], "foo"),
             "L2": fake_compilation_commands(
-                COMPILATION_COMMAND_2, ["foo.l2", "grader.l2"], "foo"),
+                COMPILATION_COMMAND_2, ["foo.l2", "grader.l2"], "foo.ext"),
         })
 
     def test_alone_two_files(self):
@@ -73,7 +73,7 @@ class TestGetCompilationCommands(TaskTypeTestMixin, unittest.TestCase):
             "L1": fake_compilation_commands(
                 COMPILATION_COMMAND_1, ["foo.l1", "bar.l1"], "bar_foo"),
             "L2": fake_compilation_commands(
-                COMPILATION_COMMAND_2, ["foo.l2", "bar.l2"], "bar_foo"),
+                COMPILATION_COMMAND_2, ["foo.l2", "bar.l2"], "bar_foo.ext"),
         })
 
     def test_grader_two_files(self):
@@ -87,7 +87,7 @@ class TestGetCompilationCommands(TaskTypeTestMixin, unittest.TestCase):
             "L2": fake_compilation_commands(
                 COMPILATION_COMMAND_2,
                 ["foo.l2", "bar.l2", "grader.l2"],
-                "bar_foo"),
+                "bar_foo.ext"),
         })
 
 

--- a/cmstestsuite/unit_tests/grading/tasktypes/CommunicationTest.py
+++ b/cmstestsuite/unit_tests/grading/tasktypes/CommunicationTest.py
@@ -55,7 +55,7 @@ class TestGetCompilationCommands(TaskTypeTestMixin, unittest.TestCase):
             "L1": fake_compilation_commands(
                 COMPILATION_COMMAND_1, ["stub.l1", "foo.l1"], "foo"),
             "L2": fake_compilation_commands(
-                COMPILATION_COMMAND_2, ["stub.l2", "foo.l2"], "foo"),
+                COMPILATION_COMMAND_2, ["stub.l2", "foo.l2"], "foo.ext"),
         })
 
     def test_two_processes(self):
@@ -67,7 +67,7 @@ class TestGetCompilationCommands(TaskTypeTestMixin, unittest.TestCase):
             "L1": fake_compilation_commands(
                 COMPILATION_COMMAND_1, ["stub.l1", "foo.l1"], "foo"),
             "L2": fake_compilation_commands(
-                COMPILATION_COMMAND_2, ["stub.l2", "foo.l2"], "foo"),
+                COMPILATION_COMMAND_2, ["stub.l2", "foo.l2"], "foo.ext"),
         })
 
     def test_many_files(self):
@@ -81,7 +81,7 @@ class TestGetCompilationCommands(TaskTypeTestMixin, unittest.TestCase):
                 "bar_foo"),
             "L2": fake_compilation_commands(
                 COMPILATION_COMMAND_2, ["stub.l2", "foo.l2", "bar.l2"],
-                "bar_foo"),
+                "bar_foo.ext"),
         })
 
     def test_no_stub(self):
@@ -93,7 +93,7 @@ class TestGetCompilationCommands(TaskTypeTestMixin, unittest.TestCase):
             "L1": fake_compilation_commands(
                 COMPILATION_COMMAND_1, ["foo.l1"], "foo"),
             "L2": fake_compilation_commands(
-                COMPILATION_COMMAND_2, ["foo.l2"], "foo"),
+                COMPILATION_COMMAND_2, ["foo.l2"], "foo.ext"),
         })
 
     def test_std_io(self):
@@ -105,7 +105,7 @@ class TestGetCompilationCommands(TaskTypeTestMixin, unittest.TestCase):
             "L1": fake_compilation_commands(
                 COMPILATION_COMMAND_1, ["stub.l1", "foo.l1"], "foo"),
             "L2": fake_compilation_commands(
-                COMPILATION_COMMAND_2, ["stub.l2", "foo.l2"], "foo"),
+                COMPILATION_COMMAND_2, ["stub.l2", "foo.l2"], "foo.ext"),
         })
 
 

--- a/cmstestsuite/unit_tests/grading/tasktypes/tasktypetestutils.py
+++ b/cmstestsuite/unit_tests/grading/tasktypes/tasktypetestutils.py
@@ -39,14 +39,16 @@ def fake_evaluation_commands(base, exe, main=None, args=None):
 
 
 def make_language(name, source_extensions, header_extensions,
-                  compilation_command, evaluation_command):
+                  executable_extension, compilation_command,
+                  evaluation_command):
     """Create a language (actually a MagicMock) with the given data."""
     language = MagicMock()
     language.configure_mock(name=name,
                             source_extensions=source_extensions,
                             source_extension=source_extensions[0],
                             header_extensions=header_extensions,
-                            header_extension=header_extensions[0])
+                            header_extension=header_extensions[0],
+                            executable_extension=executable_extension)
     language.get_compilation_commands.side_effect = \
         functools.partial(fake_compilation_commands, compilation_command)
     language.get_evaluation_commands.side_effect = \
@@ -59,9 +61,9 @@ COMPILATION_COMMAND_1 = ["comp", "comm1"]
 COMPILATION_COMMAND_2 = ["comp", "comm2"]
 EVALUATION_COMMAND_1 = ["run1"]
 EVALUATION_COMMAND_2 = ["run2"]
-LANG_1 = make_language("L1", [".l1"], [".hl1"],
+LANG_1 = make_language("L1", [".l1"], [".hl1"], "",
                        COMPILATION_COMMAND_1, EVALUATION_COMMAND_1)
-LANG_2 = make_language("L2", [".l2"], [".hl2"],
+LANG_2 = make_language("L2", [".l2"], [".hl2"], ".ext",
                        COMPILATION_COMMAND_2, EVALUATION_COMMAND_2)
 
 


### PR DESCRIPTION
This property allows to simplify language compilation commands in multiple cases. The compilation commands presented to the user are also easier to understand.

The initial motivation for this change was to be able to use [`python3 -m zipapp`](https://docs.python.org/3/library/zipapp.html) instead of manual archiving for the Python 3 language. Currently this doesn't work, however, because from [PEP 441](https://www.python.org/dev/peps/pep-0441/#a-new-python-zip-application-extension) there must be a `__main__.py` file in the archive, and `zipapp` [enforces](https://github.com/python/cpython/blob/b16e382c446d76ede22780b15c75f43c5f132e25/Lib/zipapp.py#L112-L117) this. But these changes are still useful for multiple other languages.

A couple of notes:
1. The `.pyz` extension is specified in [PEP 441](https://www.python.org/dev/peps/pep-0441/).
1. This code doesn't work if there are multiple source files, but no grader:
   https://github.com/cms-dev/cms/blob/d4c9e926bd52d8022069c417b206b0882ef4d1ba/cms/grading/tasktypes/Batch.py#L256-L257
    I think it could query the task object instead. Perhaps a new issue can be opened.
1. The PHP language plugin shows that it may be useful to have an `InterpretedLanguage` subclass without compilation commands. Currently a language with empty compilation commands fails here:
    https://github.com/cms-dev/cms/blob/d4c9e926bd52d8022069c417b206b0882ef4d1ba/cms/grading/steps/utils.py#L88-L89
    because `stats` is `None`. On the other hand, it is not clear how this can be reconciled with the case of multiple source files.
1. Logically, each language type plugin should implement its own updater function, so that the updater script can query all plugins, including out-of-tree ones. As this is overkill, the updater just has a hardcoded list of languages instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1139)
<!-- Reviewable:end -->
