### PR TITLE
Fix support for services connected via IPv6

### DIFF
--- a/cms/io/rpc.py
+++ b/cms/io/rpc.py
@@ -500,6 +500,7 @@ class RemoteServiceClient(RemoteServiceBase):
                              self._repr_remote(), host, port, error)
             else:
                 self.initialize(sock, self.remote_service_coord)
+                break
 
     def _run(self):
         """Maintain the connection up, if required.

--- a/cms/io/rpc.py
+++ b/cms/io/rpc.py
@@ -5,6 +5,7 @@
 # Copyright © 2010-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2013-2017 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2019 Edoardo Morassutto <edoardo.morassutto@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -478,8 +479,12 @@ class RemoteServiceClient(RemoteServiceBase):
 
         """
         try:
-            sock = gevent.socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.connect(self.remote_address)
+            # Find the family (AF_INET or AF_INET6) of the IPv4/6 address.
+            addresses = gevent.socket.getaddrinfo(
+                self.remote_address.ip, self.remote_address.port)
+            family, *rest, sockaddr = addresses[0]
+            sock = gevent.socket.socket(family, socket.SOCK_STREAM)
+            sock.connect(sockaddr)
         except OSError as error:
             logger.debug("Couldn't connect to %s: %s.",
                          self._repr_remote(), error)

--- a/cms/io/rpc.py
+++ b/cms/io/rpc.py
@@ -489,11 +489,11 @@ class RemoteServiceClient(RemoteServiceBase):
             logger.warning("Cannot resolve %s.", self.remote_address)
             raise
 
-        for family, *rest, sockaddr in addresses:
+        for family, type, proto, _canonname, sockaddr in addresses:
             try:
                 host, port, *rest = sockaddr
                 logger.debug("Trying to connect to %s at port %d.", host, port)
-                sock = gevent.socket.socket(family, socket.SOCK_STREAM)
+                sock = gevent.socket.socket(family, type, proto)
                 sock.connect(sockaddr)
             except OSError as error:
                 logger.debug("Couldn't connect to %s at %s port %d: %s.",

--- a/cms/io/service.py
+++ b/cms/io/service.py
@@ -157,15 +157,7 @@ class Service:
         connection.
 
         """
-        try:
-            # In case of IPv6 address is (ip, port, flow info, scope id).
-            ipaddr, port = address[:2]
-            addresses = gevent.socket.getaddrinfo(ipaddr, port)
-            *rest, sockaddr = addresses[0]
-            address = Address(sockaddr[0], sockaddr[1])
-        except OSError:
-            logger.warning("Unexpected error.", exc_info=True)
-            return
+        address = Address(address[0], address[1])
         remote_service = RemoteServiceServer(self, address)
         remote_service.handle(sock)
 

--- a/cms/io/service.py
+++ b/cms/io/service.py
@@ -5,6 +5,7 @@
 # Copyright © 2010-2016 Stefano Maggiolo <s.maggiolo@gmail.com>
 # Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
 # Copyright © 2013 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2019 Edoardo Morassutto <edoardo.morassutto@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -157,9 +158,11 @@ class Service:
 
         """
         try:
-            ipaddr, port = address
-            ipaddr = gevent.socket.gethostbyname(ipaddr)
-            address = Address(ipaddr, port)
+            # In case of IPv6 address is (ip, port, flow info, scope id).
+            ipaddr, port = address[:2]
+            addresses = gevent.socket.getaddrinfo(ipaddr, port)
+            *rest, sockaddr = addresses[0]
+            address = Address(sockaddr[0], sockaddr[1])
         except OSError:
             logger.warning("Unexpected error.", exc_info=True)
             return

--- a/cmstestsuite/unit_tests/io/rpc_test.py
+++ b/cmstestsuite/unit_tests/io/rpc_test.py
@@ -22,6 +22,7 @@
 
 """
 
+import socket
 import unittest
 from unittest.mock import Mock, patch
 
@@ -263,7 +264,8 @@ class TestRPC(unittest.TestCase):
         # event triggered.
         done_event.set()
         gevent.sleep()
-        getaddrinfo_mock.assert_called_once_with(self.host, self.port)
+        getaddrinfo_mock.assert_called_once_with(self.host, self.port,
+                                                 type=socket.SOCK_STREAM)
         connect_mock.assert_called_once_with((self.host, self.port))
 
     def test_autoreconnect1(self):

--- a/cmstestsuite/unit_tests/io/rpc_test.py
+++ b/cmstestsuite/unit_tests/io/rpc_test.py
@@ -3,6 +3,7 @@
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2014-2017 Luca Wehrstedt <luca.wehrstedt@gmail.com>
 # Copyright © 2015 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2019 Edoardo Morassutto <edoardo.morassutto@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -231,7 +232,14 @@ class TestRPC(unittest.TestCase):
         self.assertEqual(result.value, ["Hello", 42, "World"])
 
     @patch("cms.io.rpc.gevent.socket.socket")
-    def test_background_connect(self, socket_mock):
+    @patch("cms.io.rpc.gevent.socket.getaddrinfo")
+    def test_background_connect(self, getaddrinfo_mock, socket_mock):
+        # Calling getaddrinfo breaks the mocking of the socket, so it is mocked
+        # as well. It returns the addresses associated with the service, in
+        # this case just one.
+        getaddrinfo_mock.return_value = [
+            (gevent.socket.AF_INET, gevent.socket.SOCK_STREAM, 6, "",
+                (self.host, self.port))]
         # Patch the connect method of sockets so that it blocks until
         # we set the done_event (we will do so at the end of the test).
         connect_mock = socket_mock.return_value.connect
@@ -255,7 +263,8 @@ class TestRPC(unittest.TestCase):
         # event triggered.
         done_event.set()
         gevent.sleep()
-        connect_mock.assert_called_once_with(Address(self.host, self.port))
+        getaddrinfo_mock.assert_called_once_with(self.host, self.port)
+        connect_mock.assert_called_once_with((self.host, self.port))
 
     def test_autoreconnect1(self):
         client = self.get_client(ServiceCoord("Foo", 0), auto_retry=0.002)


### PR DESCRIPTION
Use the correct address family when connecting to the various RPC services.

The solution is basically the same suggested here:
https://github.com/cms-dev/cms/issues/157#issuecomment-463427954

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1141)
<!-- Reviewable:end -->
