### PR TITLE
Ignore wrong contest submissions in ProxyService

### DIFF
--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -480,9 +480,10 @@ class ProxyService(TriggeredService):
             # ScoringService sent us a submission of another contest, they
             # do not know about our contest_id in multicontest setup.
             if submission.task.contest_id != self.contest_id:
-                logger.debug("Ignoring submission %s of contest %d "
-                             "(this ProxyService considers contest %d only)",
-                             submission.id, submission.task.contest_id, self.contest_id)
+                logger.debug("Ignoring submission %d of contest %d "
+                             "(this ProxyService considers contest %d only).",
+                             submission.id, submission.task.contest_id,
+                             self.contest_id)
                 return
 
             if submission.participation.hidden:
@@ -523,9 +524,10 @@ class ProxyService(TriggeredService):
             # ScoringService sent us a submission of another contest, they
             # do not know about our contest_id in multicontest setup.
             if submission.task.contest_id != self.contest_id:
-                logger.debug("Ignoring submission %s of contest %d "
-                             "(this ProxyService considers contest %d only)",
-                             submission.id, submission.task.contest_id, self.contest_id)
+                logger.debug("Ignoring submission %d of contest %d "
+                             "(this ProxyService considers contest %d only).",
+                             submission.id, submission.task.contest_id,
+                             self.contest_id)
                 return
 
             if submission.participation.hidden:
@@ -565,9 +567,10 @@ class ProxyService(TriggeredService):
             # This ProxyService may focus on a different contest, and it should
             # ignore this update.
             if task.contest_id != self.contest_id:
-                logger.debug("Ignoring dataset change for task %d of contest %d "
-                             "(this ProxyService considers contest %d only)",
-                             task_id, task.contest.id, self.contest_id)
+                logger.debug("Ignoring dataset change for task %d of contest "
+                             "%d (this ProxyService considers contest %d "
+                             "only).", task_id, task.contest.id,
+                             self.contest_id)
                 return
 
             logger.info("Dataset update for task %d (dataset now is %d).",

--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -9,6 +9,7 @@
 # Copyright © 2015 Luca Versari <veluca93@gmail.com>
 # Copyright © 2015 William Di Luigi <williamdiluigi@gmail.com>
 # Copyright © 2016 Amir Keivan Mohtashami <akmohtashami97@gmail.com>
+# Copyright © 2019 Edoardo Morassutto <edoardo.morassutto@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -386,6 +387,10 @@ class ProxyService(TriggeredService):
         queues for them to be sent to rankings.
 
         """
+        # ScoringService sent us a submission of another contest.
+        if submission.task.contest_id != self.contest_id:
+            return []
+
         submission_result = submission.get_result()
 
         # Data to send to remote rankings.
@@ -422,6 +427,9 @@ class ProxyService(TriggeredService):
         queues for them to be sent to rankings.
 
         """
+        # ScoringService sent us a submission of another contest.
+        if submission.task.contest_id != self.contest_id:
+            return []
         # Data to send to remote rankings.
         submission_id = "%d" % submission.id
         submission_data = {

--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -387,10 +387,6 @@ class ProxyService(TriggeredService):
         queues for them to be sent to rankings.
 
         """
-        # ScoringService sent us a submission of another contest.
-        if submission.task.contest_id != self.contest_id:
-            return []
-
         submission_result = submission.get_result()
 
         # Data to send to remote rankings.
@@ -427,9 +423,6 @@ class ProxyService(TriggeredService):
         queues for them to be sent to rankings.
 
         """
-        # ScoringService sent us a submission of another contest.
-        if submission.task.contest_id != self.contest_id:
-            return []
         # Data to send to remote rankings.
         submission_id = "%d" % submission.id
         submission_data = {
@@ -496,6 +489,11 @@ class ProxyService(TriggeredService):
                             submission_id)
                 return
 
+            # ScoringService sent us a submission of another contest, they
+            # do not know about our contest_id in multicontest setup.
+            if submission.task.contest_id != self.contest_id:
+                return
+
             # Update RWS.
             for operation in self.operations_for_score(submission):
                 self.enqueue(operation)
@@ -529,6 +527,11 @@ class ProxyService(TriggeredService):
                 logger.info("[submission_tokened] Token for submission %d "
                             "not sent because the submission is not official.",
                             submission_id)
+                return
+
+            # ScoringService sent us a submission of another contest, they
+            # do not know about our contest_id in multicontest setup.
+            if submission.task.contest_id != self.contest_id:
                 return
 
             # Update RWS.

--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -477,6 +477,14 @@ class ProxyService(TriggeredService):
                              "unexistent submission id %s.", submission_id)
                 raise KeyError("Submission not found.")
 
+            # ScoringService sent us a submission of another contest, they
+            # do not know about our contest_id in multicontest setup.
+            if submission.task.contest_id != self.contest_id:
+                logger.debug("Ignoring submission %s of contest %d "
+                             "(this ProxyService considers contest %d only)",
+                             submission.id, submission.task.contest_id, self.contest_id)
+                return
+
             if submission.participation.hidden:
                 logger.info("[submission_scored] Score for submission %d "
                             "not sent because the participation is hidden.",
@@ -487,11 +495,6 @@ class ProxyService(TriggeredService):
                 logger.info("[submission_scored] Score for submission %d "
                             "not sent because the submission is not official.",
                             submission_id)
-                return
-
-            # ScoringService sent us a submission of another contest, they
-            # do not know about our contest_id in multicontest setup.
-            if submission.task.contest_id != self.contest_id:
                 return
 
             # Update RWS.
@@ -517,6 +520,14 @@ class ProxyService(TriggeredService):
                              "unexistent submission id %s.", submission_id)
                 raise KeyError("Submission not found.")
 
+            # ScoringService sent us a submission of another contest, they
+            # do not know about our contest_id in multicontest setup.
+            if submission.task.contest_id != self.contest_id:
+                logger.debug("Ignoring submission %s of contest %d "
+                             "(this ProxyService considers contest %d only)",
+                             submission.id, submission.task.contest_id, self.contest_id)
+                return
+
             if submission.participation.hidden:
                 logger.info("[submission_tokened] Token for submission %d "
                             "not sent because participation is hidden.",
@@ -527,11 +538,6 @@ class ProxyService(TriggeredService):
                 logger.info("[submission_tokened] Token for submission %d "
                             "not sent because the submission is not official.",
                             submission_id)
-                return
-
-            # ScoringService sent us a submission of another contest, they
-            # do not know about our contest_id in multicontest setup.
-            if submission.task.contest_id != self.contest_id:
                 return
 
             # Update RWS.
@@ -555,6 +561,14 @@ class ProxyService(TriggeredService):
         with SessionGen() as session:
             task = Task.get_from_id(task_id, session)
             dataset = task.active_dataset
+
+            # This ProxyService may focus on a different contest, and it should
+            # ignore this update.
+            if task.contest_id != self.contest_id:
+                logger.debug("Ignoring dataset change for task %d of contest %d "
+                             "(this ProxyService considers contest %d only)",
+                             task_id, task.contest.id, self.contest_id)
+                return
 
             logger.info("Dataset update for task %d (dataset now is %d).",
                         task.id, dataset.id)


### PR DESCRIPTION
When you are running cms with more than a contest (ie multicontest) ProxyService can be notified by ScoringService of new submissions of any contest, ignoring the `-c X` flag of PS. This will lead to `Inconsistent Data` errors in RWS due to submissions of the wrong contest (bad user, bad task, ...). This is especially bad because the wrong submission can be sent with other valid submissions, and RWS drop them all.

The proposed fix just ignores those submissions from ProxyService since ScoringService has no way to know which contest PS is bound to.

Related to https://github.com/cms-dev/cms/pull/1102 but less intrusive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1142)
<!-- Reviewable:end -->
