### PR TITLE
Replacing spaces in cookies with _

### DIFF
--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -138,7 +138,7 @@ class ContestHandler(BaseHandler):
             user logged in for the running contest.
 
         """
-        cookie_name = self.contest.name + "_login"
+        cookie_name = self.contest.name.replace(" ", "_") + "_login"
         cookie = self.get_secure_cookie(cookie_name)
 
         try:


### PR DESCRIPTION
This solves, Issue #1099, contests with spaces gives server error 500.
This is because the the cookie can not contain spaces.
This is simply fixed by replacing all spaces with underscores in the name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1146)
<!-- Reviewable:end -->
