### PR TITLE
Fix cmsImportContest when multiple IPs are provided

### DIFF
--- a/cmscontrib/ImportContest.py
+++ b/cmscontrib/ImportContest.py
@@ -291,7 +291,7 @@ class ContestImporter:
         if "hidden" in new_p:
             args["hidden"] = new_p["hidden"]
         if "ip" in new_p and new_p["ip"] is not None:
-            args["ip"] = [ipaddress.ip_network(new_p["ip"])]
+            args["ip"] = list(map(ipaddress.ip_network, new_p["ip"].split(",")))
         if "password" in new_p:
             args["password"] = new_p["password"]
 


### PR DESCRIPTION
The cmsImportContest command fails when some participations specify multiple IPs separated by comma

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1147)
<!-- Reviewable:end -->
