### PR TITLE
Make clients revalidate files

### DIFF
--- a/cms/server/file_middleware.py
+++ b/cms/server/file_middleware.py
@@ -2,6 +2,7 @@
 
 # Contest Management System - http://cms-dev.github.io/
 # Copyright © 2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2021 Manuel Gundlach <manuel.gundlach@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -21,9 +22,6 @@ from werkzeug.wrappers import Response, Request
 from werkzeug.wsgi import responder, wrap_file
 
 from cms.db.filecacher import FileCacher, TombstoneError
-
-
-SECONDS_IN_A_YEAR = 365 * 24 * 60 * 60
 
 
 class FileServerMiddleware:
@@ -105,7 +103,7 @@ class FileServerMiddleware:
             response.headers.add(
                 "Content-Disposition", "attachment", filename=filename)
         response.set_etag(digest)
-        response.cache_control.max_age = SECONDS_IN_A_YEAR
+        response.cache_control.no_cache = True
         response.cache_control.private = True
         response.response = \
             wrap_file(environ, fobj, buffer_size=FileCacher.CHUNK_SIZE)


### PR DESCRIPTION
We've noticed that when an admin changes a task statement during a contest (e.g. through the web interface), a contestant who has already downloaded the respective statement will regularly still get served the old version by his browser. The same probably holds for attachments as well.

This is because `FileServerMiddleware` sets the response headers such that a client should assume the file sent to be persistent, i.e. it doesn't change for a year and the client doesn't have to ask whether it's changed until then.

With this change, the client is told to always ask whether the file was changed (revalidate) instead of just using the cached file (by setting the `no-cache` flag and `max-age=0`, [reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Requiring_revalidation)). This affects all files that are served through `FileServerMiddleware`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1149)
<!-- Reviewable:end -->
