### PR TITLE
Don't open title page input file in binary mode in PrintingService

### DIFF
--- a/cms/service/PrintingService.py
+++ b/cms/service/PrintingService.py
@@ -173,7 +173,7 @@ class PrintingExecutor(Executor):
             # Add the title page
             title_tex = os.path.join(directory, "title_page.tex")
             title_pdf = os.path.join(directory, "title_page.pdf")
-            with open(title_tex, "wb") as f:
+            with open(title_tex, "w") as f:
                 f.write(self.jinja2_env.get_template("title_page.tex")
                         .render(user=user, filename=filename,
                                 timestr=timestr,


### PR DESCRIPTION
`PrintingService` currently doesn't work. When someone uses it to print something, the compilation of (or rather the rendering of the template of) the title page will fail. As far as I can tell, the reason for this comes from the transition from Tornado to Jinja2:

Jinja2 templates render to strings (unlike the previously used Tornado templates, which render to bytes). So we shouldn't open the output file in binary mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1150)
<!-- Reviewable:end -->
