### PR TITLE
Let PdfFileMerger open the files to be merged itself

### DIFF
--- a/cms/service/PrintingService.py
+++ b/cms/service/PrintingService.py
@@ -190,13 +190,11 @@ class PrintingExecutor(Executor):
                     "(error %d)" % (pretty_print_cmdline(cmd), ret))
 
             pdfmerger = PdfFileMerger()
-            with open(title_pdf, "rb") as file_:
-                pdfmerger.append(file_)
-            with open(source_pdf, "rb") as file_:
-                pdfmerger.append(file_)
+            pdfmerger.append(title_pdf)
+            pdfmerger.append(source_pdf)
             result = os.path.join(directory, "document.pdf")
-            with open(result, "wb") as file_:
-                pdfmerger.write(file_)
+            pdfmerger.write(result)
+            pdfmerger.close()
 
             try:
                 printer_connection = cups.Connection()

--- a/cms/service/PrintingService.py
+++ b/cms/service/PrintingService.py
@@ -21,6 +21,7 @@
 
 """
 
+import contextlib
 import cups
 import logging
 import os
@@ -189,12 +190,11 @@ class PrintingExecutor(Executor):
                     "Failed to create title page with command: %s"
                     "(error %d)" % (pretty_print_cmdline(cmd), ret))
 
-            pdfmerger = PdfFileMerger()
-            pdfmerger.append(title_pdf)
-            pdfmerger.append(source_pdf)
-            result = os.path.join(directory, "document.pdf")
-            pdfmerger.write(result)
-            pdfmerger.close()
+            with contextlib.closing(PdfFileMerger()) as pdfmerger:
+                pdfmerger.append(title_pdf)
+                pdfmerger.append(source_pdf)
+                result = os.path.join(directory, "document.pdf")
+                pdfmerger.write(result)
 
             try:
                 printer_connection = cups.Connection()


### PR DESCRIPTION
`PrintingService` currently doesn't work. With the fix mentioned in PR #1150, a file is printed, but it only contains empty pages.

It seems that `PdfFileMerger` is used in a way that raises unspecified behavior: The input files are opened and appended to the `pdfmerger`, and then closed again before `pdfmerger.write(...)` is called. This way, `pdfmerger.write` probably tries to read the appended files, but is unable to. I suppose that in previous versions of `PdfFileMerger` the appended files were already read into memory when `append` was called, and that the implementation has changed.

To fix this, we could keep the files open until calling `pdfmerger.write(...)`. But as `pdfmerger` is able to open files itself, the proposed change just gives it the paths to the files and calls `pdfmerger.close()` in the end, so `pdfmerger` should close all files again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1151)
<!-- Reviewable:end -->
