### PR TITLE
Make PrintingService translatable

### DIFF
--- a/babel_mapping.cfg
+++ b/babel_mapping.cfg
@@ -5,6 +5,7 @@
 [python: server/contest/*.py]
 [python: server/contest/handlers/*.py]
 [python: server/contest/submission/*.py]
+[python: service/*.py]
 [jinja2: server/contest/templates/*.html]
 trimmed: 1
 [jinja2: server/contest/templates/macro/*.html]

--- a/cms/locale/cms.pot
+++ b/cms/locale/cms.pot
@@ -1,22 +1,22 @@
 # Translations template for Contest Management System.
-# Copyright (C) 2019 CMS development group
+# Copyright (C) 2020 CMS development group
 # This file is distributed under the same license as the Contest Management
 # System project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Contest Management System 1.5.dev0\n"
 "Report-Msgid-Bugs-To: contestms@googlegroups.com\n"
-"POT-Creation-Date: 2019-02-23 11:44+0100\n"
+"POT-Creation-Date: 2020-02-24 15:23+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.4.0\n"
+"Generated-By: Babel 2.8.0\n"
 
 msgid "N/A"
 msgstr ""
@@ -1050,5 +1050,14 @@ msgid "Test details"
 msgstr ""
 
 msgid "Evaluation outcome"
+msgstr ""
+
+msgid "Invalid file"
+msgstr ""
+
+msgid "Print job has too many pages"
+msgstr ""
+
+msgid "Sent to printer"
 msgstr ""
 


### PR DESCRIPTION
There are strings in `PrintingService` that appear in the contestant interface and are already marked translatable. However, `babel_mappings` doesn't recognize `service/` so far.

This change lets `babel_mappings` include `service/*.py`.

It might be better to only include `service/PrintingService.py` or to refactor `PrintingService` so the strings are somewhere else, in a more appropriate place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1152)
<!-- Reviewable:end -->
