### PR TITLE
Fix task submission language option re-enable when reset

### DIFF
--- a/cms/server/contest/static/cws_utils.js
+++ b/cms/server/contest/static/cws_utils.js
@@ -339,6 +339,13 @@ CMS.CWSUtils.prototype.switch_lang = function() {
 };
 
 CMS.CWSUtils.filter_languages = function(options, inputs) {
+    // Remove all disable if reset button is pressed
+		if (inputs === undefined) {
+        return options.each(function(i, option) {
+            $(option).removeAttr('disabled');
+        });
+    }
+
     var exts = [];
     for (var i = 0; i < inputs.length; i++) {
         exts.push('.' + inputs[i].value.match(/[^.]*$/)[0]);

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -270,7 +270,9 @@ $(document).ready(function () {
                 <div class="control-group">
                     <div class="controls">
                         <button type="submit" class="btn btn-success">{% trans %}Submit{% endtrans %}</button>
-                        <button type="reset" class="btn">{% trans %}Reset{% endtrans %}</button>
+												<button type="reset" class="btn" 
+																onclick="CMS.CWSUtils.filter_languages($(this).parents('form').find('select[name=language] option'),
+																undefined)">{% trans %}Reset{% endtrans %}</button>
                     </div>
                 </div>
             </fieldset>


### PR DESCRIPTION
Language list will be disable when a file is selected, but will not re-enable when `reset` button is pressed.
This commit add a event listener on the button which calls `CMS.CWSUtils.filter_languages` to reset language list.