### PR TITLE
Add no-users option to DumpImporter and DumpExporter

### DIFF
--- a/cms/db/util.py
+++ b/cms/db/util.py
@@ -274,8 +274,8 @@ def get_datasets_to_judge(task):
 
 def enumerate_files(
         session, contest=None,
-        skip_submissions=False, skip_user_tests=False, skip_print_jobs=False,
-        skip_generated=False):
+        skip_submissions=False, skip_user_tests=False, skip_users=False,
+        skip_print_jobs=False, skip_generated=False):
     """Enumerate all the files (by digest) referenced by the
     contest.
 
@@ -302,7 +302,7 @@ def enumerate_files(
     queries.append(dataset_q.join(Dataset.testcases)
                    .with_entities(Testcase.output))
 
-    if not skip_submissions:
+    if not skip_submissions and not skip_users:
         submission_q = task_q.join(Task.submissions)
         queries.append(submission_q.join(Submission.files)
                        .with_entities(File.digest))
@@ -312,7 +312,7 @@ def enumerate_files(
                            .join(SubmissionResult.executables)
                            .with_entities(Executable.digest))
 
-    if not skip_user_tests:
+    if not skip_user_tests and not skip_users:
         user_test_q = task_q.join(Task.user_tests)
         queries.append(user_test_q.with_entities(UserTest.input))
         queries.append(user_test_q.join(UserTest.files)
@@ -328,7 +328,7 @@ def enumerate_files(
                            .filter(UserTestResult.output != None)
                            .with_entities(UserTestResult.output))
 
-    if not skip_print_jobs:
+    if not skip_print_jobs and not skip_users:
         queries.append(contest_q.join(Contest.participations)
                        .join(Participation.printjobs)
                        .with_entities(PrintJob.digest))

--- a/cmscontrib/DumpExporter.py
+++ b/cmscontrib/DumpExporter.py
@@ -47,6 +47,7 @@ from cms import rmtree, utf8_decoder
 from cms.db import version as model_version, Codename, Filename, \
     FilenameSchema, FilenameSchemaArray, Digest, SessionGen, Contest, User, \
     Task, Submission, UserTest, SubmissionResult, UserTestResult, PrintJob, \
+    Admin, Message, Question, Announcement, Participation, \
     enumerate_files
 from cms.db.filecacher import FileCacher
 from cmscommon.datetime import make_timestamp
@@ -136,15 +137,18 @@ class DumpExporter:
 
     def __init__(self, contest_ids, export_target,
                  dump_files, dump_model, skip_generated,
-                 skip_submissions, skip_user_tests, skip_print_jobs):
+                 skip_submissions, skip_user_tests, skip_users, skip_print_jobs):
         if contest_ids is None:
             with SessionGen() as session:
                 contests = session.query(Contest).all()
                 self.contests_ids = [contest.id for contest in contests]
-                users = session.query(User).all()
-                self.users_ids = [user.id for user in users]
-                tasks = session.query(Task)\
-                    .filter(Task.contest_id.is_(None)).all()
+                if not skip_users:
+                  users = session.query(User).all()
+                  self.users_ids = [user.id for user in users]
+                  tasks = session.query(Task)\
+                      .filter(Task.contest_id.is_(None)).all()
+                else:
+                  self.user_ids = []
                 self.tasks_ids = [task.id for task in tasks]
         else:
             # FIXME: this is ATM broken, because if you export a contest, you
@@ -158,6 +162,7 @@ class DumpExporter:
         self.skip_generated = skip_generated
         self.skip_submissions = skip_submissions
         self.skip_user_tests = skip_user_tests
+        self.skip_users = skip_users
         self.skip_print_jobs = skip_print_jobs
         self.export_target = export_target
 
@@ -208,6 +213,7 @@ class DumpExporter:
                         session, contest,
                         skip_submissions=self.skip_submissions,
                         skip_user_tests=self.skip_user_tests,
+                        skip_users=self.skip_users,
                         skip_print_jobs=self.skip_print_jobs,
                         skip_generated=self.skip_generated)
                     for file_ in files:
@@ -306,6 +312,7 @@ class DumpExporter:
             val = getattr(obj, prp.key)
             data[prp.key] = encode_value(col.type, val)
 
+        user_related_classes = [User, Admin, UserTest, Submission, PrintJob, Message, Question, Announcement, Participation]
         for prp in cls._rel_props:
             other_cls = prp.mapper.class_
 
@@ -316,6 +323,15 @@ class DumpExporter:
             # Skip user_tests if requested
             if self.skip_user_tests and other_cls is UserTest:
                 continue
+
+            if self.skip_users:
+                skip = False
+                for rel_class in user_related_classes:
+                    if other_cls is rel_class:
+                        skip = True
+                        break                 
+                if skip:
+                  continue
 
             # Skip print jobs if requested
             if self.skip_print_jobs and other_cls is PrintJob:
@@ -397,6 +413,8 @@ def main():
                         help="don't export submissions")
     parser.add_argument("-U", "--no-user-tests", action="store_true",
                         help="don't export user tests")
+    parser.add_argument("-X", "--no-users", action="store_true",
+                        help="don't export users")
     parser.add_argument("-P", "--no-print-jobs", action="store_true",
                         help="don't export print jobs")
     parser.add_argument("export_target", action="store",
@@ -412,6 +430,7 @@ def main():
                             skip_generated=args.no_generated,
                             skip_submissions=args.no_submissions,
                             skip_user_tests=args.no_user_tests,
+                            skip_users=args.no_users,
                             skip_print_jobs=args.no_print_jobs)
     success = exporter.do_export()
     return 0 if success is True else 1

--- a/cmscontrib/DumpExporter.py
+++ b/cmscontrib/DumpExporter.py
@@ -47,8 +47,7 @@ from cms import rmtree, utf8_decoder
 from cms.db import version as model_version, Codename, Filename, \
     FilenameSchema, FilenameSchemaArray, Digest, SessionGen, Contest, User, \
     Task, Submission, UserTest, SubmissionResult, UserTestResult, PrintJob, \
-    Admin, Message, Question, Announcement, Participation, \
-    enumerate_files
+    Announcement, Participation, enumerate_files
 from cms.db.filecacher import FileCacher
 from cmscommon.datetime import make_timestamp
 from cmscommon.digest import path_digest
@@ -143,10 +142,10 @@ class DumpExporter:
                 contests = session.query(Contest).all()
                 self.contests_ids = [contest.id for contest in contests]
                 if not skip_users:
-                  users = session.query(User).all()
-                  self.users_ids = [user.id for user in users]
+                    users = session.query(User).all()
+                    self.users_ids = [user.id for user in users]
                 else:
-                  self.users_ids = []
+                    self.users_ids = []
                 tasks = session.query(Task)\
                     .filter(Task.contest_id.is_(None)).all()
                 self.tasks_ids = [task.id for task in tasks]
@@ -312,7 +311,6 @@ class DumpExporter:
             val = getattr(obj, prp.key)
             data[prp.key] = encode_value(col.type, val)
 
-        user_related_classes = [User, Admin, UserTest, Submission, PrintJob, Message, Question, Announcement, Participation]
         for prp in cls._rel_props:
             other_cls = prp.mapper.class_
 
@@ -326,12 +324,14 @@ class DumpExporter:
 
             if self.skip_users:
                 skip = False
-                for rel_class in user_related_classes:
+                # User-related classes reachable from root
+                for rel_class in [Participation, Submission, UserTest,
+                                  Announcement]:
                     if other_cls is rel_class:
                         skip = True
-                        break                 
+                        break
                 if skip:
-                  continue
+                    continue
 
             # Skip print jobs if requested
             if self.skip_print_jobs and other_cls is PrintJob:

--- a/cmscontrib/DumpExporter.py
+++ b/cmscontrib/DumpExporter.py
@@ -145,10 +145,10 @@ class DumpExporter:
                 if not skip_users:
                   users = session.query(User).all()
                   self.users_ids = [user.id for user in users]
-                  tasks = session.query(Task)\
-                      .filter(Task.contest_id.is_(None)).all()
                 else:
-                  self.user_ids = []
+                  self.users_ids = []
+                tasks = session.query(Task)\
+                    .filter(Task.contest_id.is_(None)).all()
                 self.tasks_ids = [task.id for task in tasks]
         else:
             # FIXME: this is ATM broken, because if you export a contest, you

--- a/cmscontrib/DumpImporter.py
+++ b/cmscontrib/DumpImporter.py
@@ -50,7 +50,7 @@ from cms import utf8_decoder
 from cms.db import version as model_version, Codename, Filename, \
     FilenameSchema, FilenameSchemaArray, Digest, SessionGen, Contest, \
     Submission, SubmissionResult, User, Participation, UserTest, \
-    UserTestResult, PrintJob, init_db, drop_db, enumerate_files
+    UserTestResult, PrintJob, Announcement, init_db, drop_db, enumerate_files
 from cms.db.filecacher import FileCacher
 from cmscommon.archive import Archive
 from cmscommon.datetime import make_datetime
@@ -234,7 +234,6 @@ class DumpImporter:
                 for id_, data in self.datas.items():
                     if not id_.startswith("_"):
                         self.objs[id_] = self.import_object(data)
-                    
 
                 for k, v in list(self.objs.items()):
 
@@ -248,7 +247,8 @@ class DumpImporter:
 
                     # Skip users if requested
                     elif self.skip_users and \
-                        isinstance(v, (User, Participation, Submission, UserTest)):
+                            isinstance(v, (User, Participation, Submission,
+                                           UserTest, Announcement)):
                         del self.objs[k]
 
                     # Skip print jobs if requested
@@ -259,7 +259,7 @@ class DumpImporter:
                     elif self.skip_generated and \
                             isinstance(v, (SubmissionResult, UserTestResult)):
                         del self.objs[k]
-                
+
                 for id_, data in self.datas.items():
                     if not id_.startswith("_") and id_ in self.objs:
                         self.add_relationships(data, self.objs[id_])
@@ -278,7 +278,7 @@ class DumpImporter:
                     # It could have been removed by request
                     if id_ not in self.objs:
                         continue
-                    
+
                     obj = self.objs[id_]
                     session.add(obj)
                     session.flush()
@@ -292,7 +292,6 @@ class DumpImporter:
                             skip_print_jobs=self.skip_print_jobs,
                             skip_users=self.skip_users,
                             skip_generated=self.skip_generated)
-                        
 
                 session.commit()
             else:

--- a/cmstestsuite/unit_tests/cmscontrib/DumpExporterTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/DumpExporterTest.py
@@ -85,7 +85,7 @@ class TestDumpExporter(DatabaseMixin, FileSystemMixin, unittest.TestCase):
         super().tearDown()
 
     def do_export(self, contest_ids, dump_files=True, skip_generated=False,
-                  skip_submissions=False):
+                  skip_submissions=False, skip_users=False):
         """Create an exporter and call do_export in a convenient way"""
         r = DumpExporter(
             contest_ids,
@@ -95,7 +95,7 @@ class TestDumpExporter(DatabaseMixin, FileSystemMixin, unittest.TestCase):
             skip_generated=skip_generated,
             skip_submissions=skip_submissions,
             skip_user_tests=False,
-            skip_users=False,
+            skip_users=skip_users,
             skip_print_jobs=False).do_export()
         dump_path = os.path.join(self.target, "contest.json")
         try:
@@ -270,6 +270,25 @@ class TestDumpExporter(DatabaseMixin, FileSystemMixin, unittest.TestCase):
         self.assertNotInDump(SubmissionResult)
         self.assertFileNotInDump(self.exe_digest)
 
+    def test_skip_users(self):
+        """Test skipping users.
+
+        Should not export users and depending objects.
+        Should still export contest, tasks and their depending objects.
+        
+        """
+        self.assertTrue(self.do_export(None, skip_users=True))
+
+        self.assertInDump(Statement, digest=self.st_digest)
+        self.assertFileInDump(self.st_digest, self.st_content)
+
+        self.assertNotInDump(User)
+        self.assertNotInDump(Participation)
+        self.assertNotInDump(Submission)
+        self.assertNotInDump(SubmissionResult)
+        self.assertFileNotInDump(self.file_digest)
+        self.assertFileNotInDump(self.exe_digest)
+    
 
 if __name__ == "__main__":
     unittest.main()

--- a/cmstestsuite/unit_tests/cmscontrib/DumpExporterTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/DumpExporterTest.py
@@ -95,6 +95,7 @@ class TestDumpExporter(DatabaseMixin, FileSystemMixin, unittest.TestCase):
             skip_generated=skip_generated,
             skip_submissions=skip_submissions,
             skip_user_tests=False,
+            skip_users=False,
             skip_print_jobs=False).do_export()
         dump_path = os.path.join(self.target, "contest.json")
         try:

--- a/cmstestsuite/unit_tests/cmscontrib/DumpExporterTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/DumpExporterTest.py
@@ -275,7 +275,7 @@ class TestDumpExporter(DatabaseMixin, FileSystemMixin, unittest.TestCase):
 
         Should not export users and depending objects.
         Should still export contest, tasks and their depending objects.
-        
+
         """
         self.assertTrue(self.do_export(None, skip_users=True))
 
@@ -288,7 +288,7 @@ class TestDumpExporter(DatabaseMixin, FileSystemMixin, unittest.TestCase):
         self.assertNotInDump(SubmissionResult)
         self.assertFileNotInDump(self.file_digest)
         self.assertFileNotInDump(self.exe_digest)
-    
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
At the moment, when exporting a contest using `cmsDumpExporter`, there is no option to omit information related to users during the export.
Thus, any user which is related to the contest (participants, admin, etc..) will also be included in the dump file. When importing this dump file into another CMS instance, `cmsDumpImporter` will attempt to create these users. If existing users with the same username exists, this will result in database `IntegrityError`, causing the import to fail.


This PR introduces the option to export a contest without any user information via `cmsDumpExporter`. (i.e. Just the tasks itself).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1165)
<!-- Reviewable:end -->
