### PR TITLE
Optimize queue_status in AWS

### DIFF
--- a/cms/io/triggeredservice.py
+++ b/cms/io/triggeredservice.py
@@ -99,8 +99,10 @@ class Executor(metaclass=ABCMeta):
 
         item (QueueItem): the item to remove.
 
+        return (QueueEntry): the corresponding queue entry.
+
         """
-        self._operation_queue.remove(item)
+        return self._operation_queue.remove(item)
 
     def _pop(self, wait=False):
         """Extract (and return) the first element in the queue.

--- a/cms/io/triggeredservice.py
+++ b/cms/io/triggeredservice.py
@@ -101,6 +101,17 @@ class Executor(metaclass=ABCMeta):
 
         """
         self._operation_queue.remove(item)
+        self.removing(item)
+
+    def removing(self, item):
+        """This function is called right after the given item has been
+        removed from the queue. We need this call-back to update cumulative
+        "statistics" of the queue status.
+
+        item (QueueItem): the item that was removed.
+
+        """
+        pass
 
     def run(self):
         """Monitor the queue, and dispatch operations when available.
@@ -115,12 +126,14 @@ class Executor(metaclass=ABCMeta):
         while True:
             # Wait for the queue to be non-empty.
             to_execute = [self._operation_queue.pop(wait=True)]
+            self.removing(to_execute[0].item)
             if self._batch_executions:
                 max_operations = self.max_operations_per_batch()
                 while not self._operation_queue.empty() and (
                         max_operations == 0 or
                         len(to_execute) < max_operations):
                     to_execute.append(self._operation_queue.pop())
+                    self.removing(to_execute[-1].item)
 
             assert len(to_execute) > 0, "Expected at least one element."
             if self._batch_executions:

--- a/cms/server/admin/static/aws_utils.js
+++ b/cms/server/admin/static/aws_utils.js
@@ -537,7 +537,7 @@ CMS.AWSUtils.prototype.repr_job = function(job) {
             + ' the <a href="' + this.url("submission", job["object_id"], job["dataset_id"]) + '">result</a>'
             + ' of <a href="' + this.url("submission", job["object_id"]) + '">submission ' + job["object_id"] + '</a>'
             + ' on <a href="' + this.url("dataset", job["dataset_id"]) + '">dataset ' + job["dataset_id"] + '</a>'
-            + (job["multiplicity"]
+            + (job_type == 'Evaluating' && job["multiplicity"]
                ? " [" + job["multiplicity"] + " time(s) in queue]"
                : "")
             + (job["testcase_codename"]

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -40,6 +40,7 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
 from cms import ServiceCoord, get_service_shards
+from cmscommon.datetime import make_timestamp
 from cms.db import SessionGen, Digest, Dataset, Evaluation, Submission, \
     SubmissionResult, Testcase, UserTest, UserTestResult, get_submissions, \
     get_submission_results, get_datasets_to_judge
@@ -78,6 +79,14 @@ class EvaluationExecutor(Executor):
 
         # Lock used to guard the currently executing operations
         self._current_execution_lock = gevent.lock.RLock()
+
+
+        # As evaluate operations are split by testcases, there are too
+        # many entries in the queue to display, so we just take only one
+        # operation of each (type, object_id, dataset_id) tuple.
+        # This dictionary maps any such tuple to a "queue entry" (lacking
+        # the testcase codename) and keeps track of multiplicity.
+        self.queue_status_cumulative = dict()
 
         for i in range(get_service_shards("Worker")):
             worker = ServiceCoord("Worker", i)
@@ -142,6 +151,19 @@ class EvaluationExecutor(Executor):
                     self._currently_executing = []
                     break
 
+    def enqueue(self, item, priority=None, timestamp=None):
+        if super().enqueue(item, priority, timestamp):
+            # Add the item to the cumulative status dictionary.
+            key = item.short_key()
+            if key in self.queue_status_cumulative:
+                self.queue_status_cumulative[key]["item"]["multiplicity"] += 1
+            else:
+                item_entry = item.to_dict()
+                del item_entry["testcase_codename"]
+                item_entry["multiplicity"] = 1
+                entry = {"item": item_entry, "priority": priority, "timestamp": make_timestamp(timestamp)}
+                self.queue_status_cumulative[key] = entry
+
     def dequeue(self, operation):
         """Remove an item from the queue.
 
@@ -160,6 +182,13 @@ class EvaluationExecutor(Executor):
                         del self._currently_executing[i]
                         return
             raise
+
+    def removing(self, operation):
+        # Remove the item from the cumulative status dictionary.
+        key = operation.short_key()
+        self.queue_status_cumulative[key]["item"]["multiplicity"] -= 1
+        if self.queue_status_cumulative[key]["item"]["multiplicity"] == 0:
+            del self.queue_status_cumulative[key]
 
 
 def with_post_finish_lock(func):
@@ -1002,17 +1031,6 @@ class EvaluationService(TriggeredService):
         return ([QueueEntry]): the list with the queued elements.
 
         """
-        entries = super().queue_status()[0]
-        entries_by_key = dict()
-        for entry in entries:
-            key = (str(entry["item"]["type"]),
-                   str(entry["item"]["object_id"]),
-                   str(entry["item"]["dataset_id"]))
-            if key in entries_by_key:
-                entries_by_key[key]["item"]["multiplicity"] += 1
-            else:
-                entries_by_key[key] = entry
-                entries_by_key[key]["item"]["multiplicity"] = 1
         return sorted(
-            entries_by_key.values(),
+            self.get_executor().queue_status_cumulative.values(),
             key=lambda x: (x["priority"], x["timestamp"]))

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -177,7 +177,7 @@ class EvaluationExecutor(Executor):
         """
         try:
             super().dequeue(operation)
-            self.removing(operation)
+            self.remove_from_cumulative_status(operation)
         except KeyError:
             with self._current_execution_lock:
                 for i in range(len(self._currently_executing)):
@@ -188,10 +188,10 @@ class EvaluationExecutor(Executor):
 
     def _pop(self, wait=False):
         operation = super()._pop(wait=wait)
-        self.removing(operation.item)
+        self.remove_from_cumulative_status(operation.item)
         return operation
 
-    def removing(self, operation):
+    def remove_from_cumulative_status(self, operation):
         # Remove the item from the cumulative status dictionary.
         key = operation.short_key()
         self.queue_status_cumulative[key]["item"]["multiplicity"] -= 1

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -152,7 +152,8 @@ class EvaluationExecutor(Executor):
                     break
 
     def enqueue(self, item, priority=None, timestamp=None):
-        if super().enqueue(item, priority, timestamp):
+        success = super().enqueue(item, priority, timestamp)
+        if success:
             # Add the item to the cumulative status dictionary.
             key = item.short_key()
             if key in self.queue_status_cumulative:
@@ -163,6 +164,7 @@ class EvaluationExecutor(Executor):
                 item_entry["multiplicity"] = 1
                 entry = {"item": item_entry, "priority": priority, "timestamp": make_timestamp(timestamp)}
                 self.queue_status_cumulative[key] = entry
+        return success
 
     def dequeue(self, operation):
         """Remove an item from the queue.

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -151,7 +151,7 @@ class EvaluationExecutor(Executor):
                     self._currently_executing = []
                     break
 
-    def enqueue(self, item, priority=None, timestamp=None):
+    def enqueue(self, item, priority, timestamp):
         success = super().enqueue(item, priority, timestamp)
         if success:
             # Add the item to the cumulative status dictionary.

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -1026,12 +1026,8 @@ class EvaluationService(TriggeredService):
         the first queue.
 
         As evaluate operations are split by testcases, there are too
-        many entries in the queue to display, so we just take only one
-        operation of each (type, object_id, dataset_id)
-        tuple. Generally, we will see only one evaluate operation for
-        each submission in the queue status with the number of
-        testcase which will be evaluated next. Moreover, we pass also
-        the number of testcases in the queue.
+        many entries in the queue to display, so we collect entries with the
+        same (type, object_id, dataset_id) tuple.
 
         The entries are then ordered by priority and timestamp (the
         same criteria used to look at what to complete next).

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -177,6 +177,7 @@ class EvaluationExecutor(Executor):
         """
         try:
             super().dequeue(operation)
+            self.removing(operation)
         except KeyError:
             with self._current_execution_lock:
                 for i in range(len(self._currently_executing)):
@@ -184,6 +185,11 @@ class EvaluationExecutor(Executor):
                         del self._currently_executing[i]
                         return
             raise
+
+    def _pop(self, wait=False):
+        operation = super()._pop(wait=wait)
+        self.removing(operation.item)
+        return operation
 
     def removing(self, operation):
         # Remove the item from the cumulative status dictionary.

--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -80,10 +80,9 @@ class EvaluationExecutor(Executor):
         # Lock used to guard the currently executing operations
         self._current_execution_lock = gevent.lock.RLock()
 
-
         # As evaluate operations are split by testcases, there are too
         # many entries in the queue to display, so we just take only one
-        # operation of each (type, object_id, dataset_id) tuple.
+        # operation of each (type, object_id, dataset_id, priority) tuple.
         # This dictionary maps any such tuple to a "queue entry" (lacking
         # the testcase codename) and keeps track of multiplicity.
         self.queue_status_cumulative = dict()
@@ -1027,7 +1026,9 @@ class EvaluationService(TriggeredService):
 
         As evaluate operations are split by testcases, there are too
         many entries in the queue to display, so we collect entries with the
-        same (type, object_id, dataset_id) tuple.
+        same (type, object_id, dataset_id, priority) tuple.
+        Generally, we will see only one evaluate operation for each submission
+        in the queue status.
 
         The entries are then ordered by priority and timestamp (the
         same criteria used to look at what to complete next).

--- a/cms/service/esoperations.py
+++ b/cms/service/esoperations.py
@@ -557,3 +557,12 @@ class ESOperation(QueueItem):
             "dataset_id": self.dataset_id,
             "testcase_codename": self.testcase_codename
         }
+
+    def short_key(self):
+        """Return a short tuple (type, object_id, dataset_id) that omits
+        the testcase codename.
+
+        """
+        return (str(self.type_),
+                str(self.object_id),
+                str(self.dataset_id))


### PR DESCRIPTION
Any instance of the AWS overview page in a browser calls the ``queue_status()`` RPC function of the evaluation service once every 5 seconds.

The function returns a list of entries in the queue, but collects evaluations of the same submission on the same dataset for different testcases:

> Evaluating the result of submission 1 on dataset 1 [16 time(s) in queue]

Currently, the collection process is performed from scratch every time ``queue_status`` is called by looping over all entries in the queue. The running time of ``queue_status()`` is therefore roughly proportional to the number of entries in the queue. This can be substantial when (re-)evaluating many submissions for tasks with many testcases. (In a test, we observed running times of about 0.5s for 100 submissions with 1000 test cases each. Note that since the function is called by every browser every 5 seconds, opening the AWS overview page on 10 tabs can therefore exhaust the evaluation service and slow down evaluation.)

We propose to not perform the collection process every time ``queue_status`` is called, but every time an item is added to or removed from the queue. The running time of ``queue_status`` is then roughly proportional to the number of entries in the collected table (the size of the output sent over the network). So the running time decreases by a factor of roughly the number of testcases.

For simplicity, we no longer keep track of the testcase numbers for each (submission,dataset) pair. Previously, the queue on AWS also listed one enqueued testcase for each such group. However, since queue entries were processed in heap order, the displayed testcase was only guaranteed to be the lowest-numbered one for the first queue entry. We didn't find displaying such a "random" testcase particularly useful. If desired, one could keep track of the lowest-numbered testcase for each (submission,dataset) pair by using a separate priority queue for each such pair (instead of only keeping track of the "multiplicity").

Remark: The function ``_missing_operations`` also appears to have running time essentially proportional to the size of the queue, but at least it is only called once every 117 seconds by ES.

**Acknowledgements:** The occasionally large running time was noticed by @t-lenz. The proposal was developed together with @magula.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1170)
<!-- Reviewable:end -->
