### PR TITLE
Fix misc issues regarding user tests with graders

### DIFF
--- a/cms/grading/Job.py
+++ b/cms/grading/Job.py
@@ -378,6 +378,15 @@ class CompilationJob(Job):
                     managers[manager_filename] = \
                         dataset.managers[manager_filename]
 
+        # Copy header files from dataset.
+        # FIXME This bypasses get_auto_managers() logic
+        if language is not None:
+            for manager_filename in dataset.managers:
+                if any(manager_filename.endswith(header)
+                       for header in language.header_extensions):
+                    managers[manager_filename] = \
+                        dataset.managers[manager_filename]
+
         return CompilationJob(
             operation=operation,
             task_type=dataset.task_type,

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -302,8 +302,10 @@ class UserTestFileHandler(FileHandler):
 
         if stored_filename in user_test.files:
             digest = user_test.files[stored_filename].digest
-        elif stored_filename in user_test.managers:
-            digest = user_test.managers[stored_filename].digest
+        elif filename in user_test.managers:
+            # Graders are not stored with the .%l suffix
+            # Instead, the original name is used
+            digest = user_test.managers[filename].digest
         else:
             raise tornado_web.HTTPError(404)
         self.sql_session.close()


### PR DESCRIPTION
- This PR primarily fixes the issue described in #1153 where header files cannot be found for user tests

This implementation re-uses the same header files as that for actual submissions. (Assumption: Task authors typically do not have different implementations for public and private header files.)

- This PR also allows for graders for user tests to be downloaded. Previously, a HTTP 404 will be encountered when contestants select the option to download grader files from their user tests.

It seems that graders are not stored with the `.%l` suffix (Eg: `grader.%l`) but the original extension (Eg: `grader.cpp`) instead. Hence, this PR introduces an additional check for the original filename before declaring HTTP 404.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1172)
<!-- Reviewable:end -->
