### PR TITLE
Fix typo in the AddSubmission script

### DIFF
--- a/cmscontrib/AddSubmission.py
+++ b/cmscontrib/AddSubmission.py
@@ -154,7 +154,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Adds a submission to a contest in CMS.")
     parser.add_argument("-c", "--contest-id", action="store", type=int,
-                        help="id of contest where to add the user")
+                        help="id of contest where to add the submission")
     parser.add_argument("-f", "--file", action="append", type=utf8_decoder,
                         help="in the form <name>:<file>, where name is the "
                         "name as required by CMS, and file is the name of "


### PR DESCRIPTION
Edit help message of the `--contest-id` argument

The name of the script is "Add Submission" but there is "id of contest where to add the user" in the help message. So I thought that would've been a mistake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cms-dev/cms/1178)
<!-- Reviewable:end -->
