### PR TITLE
Let all services share the file cache directory

### DIFF
--- a/cms/service/Worker.py
+++ b/cms/service/Worker.py
@@ -81,7 +81,7 @@ class Worker(Service):
                                     skip_user_tests=True, skip_print_jobs=True)
         for digest in files:
             try:
-                self.file_cacher.load(digest, if_needed=True)
+                self.file_cacher.cache_file(digest)
             except KeyError:
                 # No problem (at this stage) if we cannot find the
                 # file

--- a/prerequisites.py
+++ b/prerequisites.py
@@ -322,6 +322,9 @@ def install():
         makedir(_dir, root_pw, 0o755)
         _dir = os.path.join(_dir, "cms")
         makedir(_dir, cmsuser_pw, 0o770)
+    extra_dirs = [os.path.join(VAR_ROOT, "cache", "cms", "fs-cache-shared")]
+    for _dir in extra_dirs:
+        makedir(_dir, cmsuser_pw, 0o770)
 
     print("===== Copying Polygon testlib")
     path = os.path.join("cmscontrib", "loaders", "polygon", "testlib.h")
@@ -378,6 +381,10 @@ def uninstall():
             try_delete(os.path.join(USR_ROOT, "etc", conf_file_name))
 
     print("===== Deleting empty directories")
+    extra_dirs = [os.path.join(VAR_ROOT, "cache", "cms", "fs-cache-shared")]
+    for _dir in extra_dirs:
+        if os.listdir(_dir) == []:
+            try_delete(_dir)
     dirs = [os.path.join(VAR_ROOT, "log"),
             os.path.join(VAR_ROOT, "cache"),
             os.path.join(VAR_ROOT, "lib"),


### PR DESCRIPTION
Implement approach 2 from #1182.

Precaching is not re-enabled in this pull-request.

Services automatically create the shared cache directory if it doesn't exist yet, leading to potential race conditions (https://github.com/cms-dev/cms/issues/1182#issuecomment-850396088). The shared cache directory is also created by `prerequisites.py install`. (In fact, the same holds for `config.temp_dir` and `config.cache_dir`, which are also automatically created if they don't exist.) An alternative would be to fail and ask the admin to re-run `prerequisites.py install`.

In the original issue #154, Giovanni suggested an option to switch back to private caches. I could add an option to `cms.conf` if this is still desirable.