### PR TITLE
Fix DumpExporter if a user test didn't compile

### DIFF
--- a/cms/db/util.py
+++ b/cms/db/util.py
@@ -325,6 +325,7 @@ def enumerate_files(
             queries.append(user_test_result_q.join(UserTestResult.executables)
                            .with_entities(UserTestExecutable.digest))
             queries.append(user_test_result_q
+                           .filter(UserTestResult.output != None)
                            .with_entities(UserTestResult.output))
 
     if not skip_print_jobs:


### PR DESCRIPTION
@magula noticed that `cmsDumpExporter` fails with the following error if there's a user test that didn't compile:
```
Traceback (most recent call last):
  File "[...]/virtualenv/bin/cmsDumpExporter", line 33, in <module>
    sys.exit(load_entry_point('cms==1.5.dev0', 'console_scripts', 'cmsDumpExporter')())
  File "[...]/virtualenv/lib/python3.9/site-packages/cms-1.5.dev0-py3.9.egg/cmscontrib/DumpExporter.py", line 416, in main
    success = exporter.do_export()
  File "[...]/virtualenv/lib/python3.9/site-packages/cms-1.5.dev0-py3.9.egg/cmscontrib/DumpExporter.py", line 215, in do_export
    os.path.join(files_dir,
  File "/usr/lib/python3.9/posixpath.py", line 90, in join
    genericpath._check_arg_types('join', a, *p)
  File "/usr/lib/python3.9/genericpath.py", line 152, in _check_arg_types
    raise TypeError(f'{funcname}() argument must be str, bytes, or '
TypeError: join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
```
We should have `enumerate_files` return the output of a user test only if it's not `None`.