### PR TITLE
Enable automatic precaching

### DIFF
--- a/scripts/cmsEvaluationService
+++ b/scripts/cmsEvaluationService
@@ -26,7 +26,7 @@ import logging
 import sys
 
 from cms import ConfigError, default_argument_parser
-from cms.db import test_db_connection
+from cms.db import ask_for_contest, test_db_connection
 from cms.service.EvaluationService import EvaluationService
 
 
@@ -40,7 +40,8 @@ def main():
     test_db_connection()
     success = default_argument_parser(
         "Submission's compiler and evaluator for CMS.",
-        EvaluationService).run()
+        EvaluationService,
+        ask_contest=ask_for_contest).run()
     return 0 if success is True else 1
 
 


### PR DESCRIPTION
Following the discussion in #1182, this enables automatic precaching of files for the contest specified when starting ES.

Automatic precaching had already been implemented, but didn't take place because ES ignored the `contest_id`. Not ignoring it has several side-effects. (See the commit message for ef99ab0189a1a90c2d576b2882f4f8ef79e15be0.) To re-initiate precaching, you should restart the workers.

Using a file lock, we ensure that on each machine only one worker precaches at any time. (All other workers skip precaching.)

Precaching can take a nontrivial amount of time. (My laptop needs ~1min for ~2.5GB. I don't know how the duration increases if there are workers on many different machines.)