### PR TITLE
Italian contest loader is able to load contests with no participants

### DIFF
--- a/cmscontrib/loaders/italy_yaml.py
+++ b/cmscontrib/loaders/italy_yaml.py
@@ -219,7 +219,7 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
 
         tasks = load(conf, None, ["tasks", "problemi"])
         participations = load(conf, None, ["users", "utenti"])
-        participations = [] if participations is None else participations;
+        participations = [] if participations is None else participations
         for p in participations:
             p["password"] = build_password(p["password"])
 

--- a/cmscontrib/loaders/italy_yaml.py
+++ b/cmscontrib/loaders/italy_yaml.py
@@ -219,6 +219,7 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
 
         tasks = load(conf, None, ["tasks", "problemi"])
         participations = load(conf, None, ["users", "utenti"])
+        participations = [] if participations is None else participations;
         for p in participations:
             p["password"] = build_password(p["password"])
 


### PR DESCRIPTION
Fixes #1192 (Italian contest loader fails with no participants)

Please, consider applying the patch to v1.4