### PR TITLE
BugFix: Italian contest exporter and communication tasks

### DIFF
--- a/cmscontrib/loaders/italy_yaml.py
+++ b/cmscontrib/loaders/italy_yaml.py
@@ -629,7 +629,7 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
                     logger.info("Task type Communication")
                     args["task_type"] = "Communication"
                     args["task_type_parameters"] = \
-                        [num_processes, "stub", "fifo_io"]
+                        [num_processes, "alone", "std_io"]
                     digest = self.file_cacher.put_file_from_path(
                         path,
                         "Manager for task %s" % task.name)
@@ -643,6 +643,8 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
                                 stub_name,
                                 "Stub for task %s and language %s" % (
                                     task.name, lang.name))
+                            args["task_type_parameters"] = \
+                                [num_processes, "stub", "fifo_io"]
                             args["managers"] += [
                                 Manager(
                                     "stub%s" % lang.source_extension, digest)]


### PR DESCRIPTION
Fixes #1195 (Italian contest exporter misconfigure some communication tasks)

Please, consider applying the patch to v1.4

When the task is a communication task and it has no stubs,
exporter assumes "alone" and "std_io".
It only changes its mind to "stub" and "fifo_io" when a stub of
any language is found.