### PR TITLE
Telegram Bot for notifying new questions

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -142,6 +142,8 @@ class Config:
         # necessary to change it.
         # [1] http://freedesktop.org/wiki/Software/shared-mime-info
         self.shared_mime_info_prefix = "/usr"
+        self.telegram_bot_token = None
+        self.telegram_bot_chat_id = None
 
         # AdminWebServer.
         self.admin_listen_address = ""
@@ -201,6 +203,13 @@ class Config:
 
         # Attempt to load a config file.
         self._load(paths)
+
+        if bool(self.telegram_bot_token) ^ bool(self.telegram_bot_chat_id):
+            raise ConfigError("Both telegram_bot_token and telegram_bot_chat_id "
+                              "should be set or left null")
+        if self.telegram_bot_chat_id:
+            if type(self.telegram_bot_chat_id) != int:
+                raise ConfigError("telegram_bot_chat_id should be an integer")
 
         # If the configuration says to print detailed log on stdout,
         # change the log configuration.

--- a/cms/server/contest/communication.py
+++ b/cms/server/contest/communication.py
@@ -29,6 +29,10 @@
 
 import logging
 
+import gevent
+import requests
+
+from cms import config
 from cms.db import Question, Announcement, Message
 from cmscommon.datetime import make_timestamp
 
@@ -55,6 +59,49 @@ class UnacceptableQuestion(Exception):
         self.subject = subject
         self.text = text
         self.text_params = text_params
+
+
+def send_telegram_message(content):
+    """Send a message as the Telegram bot with the specified content.
+    """
+    api_url = "https://api.telegram.org/bot{}/sendMessage" \
+        .format(config.telegram_bot_token)
+    body = {"chat_id": config.telegram_bot_chat_id,
+            "text": content,
+            "parse_mode": "HTML"}
+    res = requests.post(api_url, data=body)
+    if res.status_code != 200:
+        logger.warn("Failed to send Telegram notification: %s", res.json())
+    else:
+        logger.debug("Telegram notification sent for the question")
+
+
+def send_telegram_question_notification(question):
+    """Craft and send a Telegram message with the question content.
+
+    This is a no-op if the bot is not configured.
+
+    This also takes care of formatting the message to be sent, escaping
+    it and making sure it doesn't exceed the bot message size limit
+    (4096 bytes).
+
+    The message is sent in a different greenlet, so that it doesn't
+    block the caller if the network is slow.
+    """
+    if not config.telegram_bot_token or not config.telegram_bot_chat_id:
+        return
+    trim = lambda s, n: s[:n] + "…" if len(s) > n else s
+    escape = lambda t: t.replace("<", "&lt;").replace(">", "&gt;")
+    message = """<b>New question</b>
+From: <code>{username}</code>
+Subject: <i>{subject}</i>
+
+{text}
+""".format(
+        username=trim(escape(question.participation.user.username), 50),
+        subject=trim(escape(question.subject), 100),
+        text=trim(escape(question.text), 3000))
+    gevent.spawn(send_telegram_message, message)
 
 
 def accept_question(sql_session, participation, timestamp, subject, text):
@@ -99,6 +146,11 @@ def accept_question(sql_session, participation, timestamp, subject, text):
     sql_session.add(question)
 
     logger.info("Question submitted by user %s.", participation.user.username)
+
+    try:
+        send_telegram_question_notification(question)
+    except Exception as e:
+        logger.exception("Error occurred while sending Telegram notification")
 
     return question
 

--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -133,6 +133,13 @@
     "_help": "STL documentation path in the system (exposed in CWS).",
     "stl_path": "/usr/share/cppreference/doc/html/",
 
+    "_help": "Telegram bot configuration for posting notifications for the",
+    "_help": "questions. The token is a string obtained from @BotFather and",
+    "_help": "the chat_id (an int) is the chat id of a conversation where the",
+    "_help": "bot has access to: a chat where the user started the bot or a",
+    "_help": "channel where the bot has been authorized.",
+    "telegram_bot_token": null,
+    "telegram_bot_chat_id": null,
 
 
     "_section": "AdminWebServer",


### PR DESCRIPTION
During a contest it might be useful to be notified on the smartphone when a new question arrives. This is especially true for long contests where keeping the admin page open is not really feasible.

This patch sends a Telegram message to a chat when a new question arrives and it is approved (i.e. not too long). It just uses "requests" for interacting with the Telgram API, avoiding additional dependencies and it's disabled by default. The actual notification is sent in a separate greenlet avoiding to slow down the request handler if the Internet connection or the Telegram servers are slow.

To enable the bot you have to set the Telegram token and the chat id in cms.conf (`telegram_bot_token` and `telegram_bot_chat_id`).

----

This has been tested by the Italian Olympiads team for many competitions, at least at 2 national rounds and at 10 OIS rounds (olympiads in team). Needless to say that the contest web servers should have access to Internet in order to send the messages.

![image](https://user-images.githubusercontent.com/6685454/145684775-106ad848-e174-40a9-a0a4-7c3be9685f0c.png)
