### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt update -y
-          sudo apt install -y \
+          sudo apt-get update -y
+          sudo apt-get install -y \
             build-essential \
             php7.4-cli \
             haskell-platform \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,22 +37,23 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: >-
-          sudo apt install -y
-          build-essential
-          php7.4-cli
-          haskell-platform
-          fp-compiler
-          python2.7
-          cppreference-doc-en-html
-          cgroup-lite
-          libcap-dev
-          python-dev
-          libpq-dev
-          libcups2-dev
-          libyaml-dev
-          rustc
-          mono-mcs
+        run: |
+          sudo apt update -y
+          sudo apt install -y \
+            build-essential \
+            php7.4-cli \
+            haskell-platform \
+            fp-compiler \
+            python2.7 \
+            cppreference-doc-en-html \
+            cgroup-lite \
+            libcap-dev \
+            python-dev \
+            libpq-dev \
+            libcups2-dev \
+            libyaml-dev \
+            rustc \
+            mono-mcs
 
       - name: Install requirements
         run: |


### PR DESCRIPTION
`apt install` may fail without a prior `apt update`.

If you accept this, this commit may also be cherry-picked in #1141 #1142 and #1198.