### PR TITLE
Prometheus exporter

### DIFF
--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -48,7 +48,8 @@
 
     "other_services":
     {
-        "TestFileCacher":    [["localhost", 27501]]
+        "TestFileCacher":    [["localhost", 27501]],
+        "PrometheusExporter":   [["localhost", 27502]]
         },
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,6 @@ pyyaml>=5.3,<5.4  # http://pyyaml.org/wiki/PyYAML
 # Only for printing:
 pycups>=1.9,<1.10  # https://pypi.python.org/pypi/pycups
 PyPDF2>=1.26,<1.27  # https://github.com/mstamy2/PyPDF2/blob/master/CHANGELOG
+
+# Only for cmsPrometheusExporter
+prometheus-client>=0.7,<0.8  # https://pypi.org/project/prometheus-client

--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ setup(
             "cmsRemoveUser=cmscontrib.RemoveUser:main",
             "cmsSpoolExporter=cmscontrib.SpoolExporter:main",
             "cmsMake=cmstaskenv.cmsMake:main",
+            "cmsPrometheusExporter=cmscontrib.PrometheusExporter:main",
         ],
         "cms.grading.tasktypes": [
             "Batch=cms.grading.tasktypes.Batch:Batch",


### PR DESCRIPTION
Add a new command: `cmsPrometheusExporter`

This will start a new HTTP server that listens on a port (defaults to 8811) for requests to /metrics. At this endpoint many metrics about a contest (or all contests) are exposed for Prometheus to be collected. Those metrics consider both system values (queue status, connected workers, ...) and contest values (submissions, users, questions, ...)

This exporter works by executing simple queries to the database, and obtains the queue information asking Evaluation Service.

The metrics exposed may leak information about the contest, so it's important to secure this endpoint (for example using a reverse proxy, or binding localhost).

With this exporter it's possible to build interactive and real-time dashboard for monitoring the status of the contest. For example, you can find [**here**](https://snapshot.raintank.io/dashboard/snapshot/0J29w0KruEiymy6zV30beX98aRG6njiX?orgId=2) the dashboard we used at OII 2020, and [**here**](https://snapshot.raintank.io/dashboard/snapshot/JngCBt71ZOJhiyEUC7yxZhS3guZmZYYi?orgId=2) the one used at an OIS round.
Those dashboards are built using Grafana, and we configured it also for sending telegram notifications when something wrong was happening (e.g. queue too long, see image below).

![image](https://user-images.githubusercontent.com/6685454/145689028-a4b59d45-5371-41d7-b008-e77d3ca17602.png)
