### PR TITLE
Upgrade to isolate v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM ubuntu:20.04
 
-RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     cgroup-lite \
     cppreference-doc-en-html \

--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -1076,7 +1076,7 @@ class IsolateSandbox(SandboxBase):
         if self.box_id is not None:
             res += ["--box-id=%d" % self.box_id]
         if self.cgroup:
-            res += ["--cg", "--cg-timing"]
+            res += ["--cg"]
         if self.chdir is not None:
             res += ["--chdir=%s" % self.chdir]
         for src, dest, options in self.dirs:

--- a/config/isolate.conf.sample
+++ b/config/isolate.conf.sample
@@ -1,0 +1,28 @@
+# This is a configuration file for Isolate
+
+# All sandboxes are created under this directory.
+# To avoid symlink attacks, this directory and all its ancestors
+# must be writeable only to root.
+box_root = /var/local/lib/isolate
+
+# Directory where lock files are created.
+lock_root = /run/isolate/locks
+
+# Control group under which we place our subgroups
+# Either an explicit path to a subdirectory in cgroupfs, or "auto:file" to read
+# the path from "file", where it is put by isolate-cg-helper.
+cg_root = /sys/fs/cgroup
+
+# Block of UIDs and GIDs reserved for sandboxes
+first_uid = 60000
+first_gid = 60000
+num_boxes = 1000
+
+# Only root can create new sandboxes (default: 0=everybody can)
+#restricted_init = 1
+
+# Per-box settings of the set of allowed CPUs and NUMA nodes
+# (see linux/Documentation/cgroups/cpusets.txt for precise syntax)
+
+#box0.cpus = 4-7
+#box0.mems = 1

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   testdb:
     image: postgres
@@ -19,6 +17,7 @@ services:
     volumes:
       - "./codecov:/home/cmsuser/cms/codecov"
     privileged: true
+    cgroup: host
     command: >
       wait-for-it testdb:5432 -- sh -c "
       dropdb --host=testdb --username=postgres cmsdbfortesting ;

--- a/prerequisites.py
+++ b/prerequisites.py
@@ -226,7 +226,7 @@ def install_isolate():
 
     print("===== Copying isolate config to /usr/local/etc/")
     makedir(os.path.join(USR_ROOT, "etc"), root, 0o755)
-    copyfile(os.path.join(".", "isolate", "default.cf"),
+    copyfile(os.path.join(".", "config", "isolate.conf.sample"),
              os.path.join(USR_ROOT, "etc", "isolate"),
              root, 0o640, group=cmsuser_grp)
 


### PR DESCRIPTION
In order to upgrade to isolate v2 we need to:

- [x] Switch the Github Actions runner from 20.04 to at least 22.04, where ubuntu seems to drop the unsupported "unified cgroups" hierarchy and only provides the new cgroup v2. It might make sense to just go with 24.04 since anyway we only use this to call docker, but let's keep 22.04 for now to be conservative.
- [x] Add `cgroup: host` to the docker-compose file to run the container in the host's cgroup namespace ([docs](https://docs.docker.com/reference/cli/docker/container/create/#options:~:text=cgroupns)).
- [x] Currently isolate is installed by `prerequisites.py` with default settings. In the default settings, isolate expects `/run/isolate/cgroup` to exist. This normally gets created by `isolate-cg-keeper`, which is what the `isolate.service` systemd unit is meant for. If we want users to install and enable that unit, then we should add it to the documentation (and possibly make `prerequisites.py` install the unit). I'm not sure however if it's really needed to run that, since just running `echo /sys/fs/cgroup > /run/isolate/group` manually seems to also work. Maybe we can instead configure isolate to always use `/sys/fs/cgroup` (I think we can do it by changing the default configuration in `/usr/local/etc/isolate`) and document this instead? We need to figure out which of these approaches are OK, and add it to the documentation.
    **UPDATE:** After discussion with @veluca93, we decided to create a local `./config/isolate.conf.sample` file (alongside the `cms.conf.sample`, `nginx.conf.sample`, etc) with `cg_root` overridden to `/sys/fs/cgroup`, and install that file as part of the `prerequisites.py install` step instead of the default isolate config file.

Fixes #1257