### PR TITLE
add docker compose for dev and prod env

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,56 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:20.04
+
+RUN apt-get update
+RUN apt-get install -y \
+    build-essential \
+    cgroup-lite \
+    cppreference-doc-en-html \
+    fp-compiler \
+    git \
+    haskell-platform \
+    libcap-dev \
+    libcups2-dev \
+    libffi-dev \
+    libpq-dev \
+    libyaml-dev \
+    mono-mcs \
+    openjdk-8-jdk-headless \
+    php7.4-cli \
+    postgresql-client \
+    python2 \
+    python3-pip \
+    python3.8 \
+    python3.8-dev \
+    rustc \
+    sudo \
+    wait-for-it \
+    zip
+
+# Create cmsuser user with sudo privileges
+RUN useradd -ms /bin/bash cmsuser && \
+    usermod -aG sudo cmsuser
+# Disable sudo password
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+# Set cmsuser as default user
+USER cmsuser
+
+COPY --chown=cmsuser:cmsuser . /home/cmsuser/cms
+
+WORKDIR /home/cmsuser/cms
+EXPOSE 8888-8889
+
+RUN sudo pip3 install -r requirements.txt
+RUN sudo pip3 install -r dev-requirements.txt
+RUN sudo python3 setup.py install
+
+RUN sudo python3 prerequisites.py --yes --cmsuser=cmsuser install
+
+RUN sudo sed 's/cmsuser:your_password_here@localhost/postgres@db/' ./config/cms.conf.sample \
+    | sudo tee /usr/local/etc/cms-dev.conf
+
+RUN sudo cp /usr/local/etc/cms-dev.conf /usr/local/etc/cms.conf
+
+ENV LANG C.UTF-8
+
+CMD [""]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:20.04
+
+RUN apt-get update
+RUN apt-get install -y \
+    build-essential \
+    cgroup-lite \
+    cppreference-doc-en-html \
+    fp-compiler \
+    git \
+    haskell-platform \
+    libcap-dev \
+    libcups2-dev \
+    libffi-dev \
+    libpq-dev \
+    libyaml-dev \
+    mono-mcs \
+    openjdk-8-jdk-headless \
+    php7.4-cli \
+    postgresql-client \
+    python2 \
+    python3-pip \
+    python3.8 \
+    python3.8-dev \
+    rustc \
+    sudo \
+    wait-for-it \
+    zip
+
+# Create cmsuser user with sudo privileges
+RUN useradd -ms /bin/bash cmsuser && \
+    usermod -aG sudo cmsuser
+# Disable sudo password
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+# Set cmsuser as default user
+USER cmsuser
+
+COPY --chown=cmsuser:cmsuser . /home/cmsuser/cms
+
+WORKDIR /home/cmsuser/cms
+EXPOSE 8888-8889
+
+RUN sudo pip3 install -r requirements.txt
+RUN sudo pip3 install -r dev-requirements.txt
+RUN sudo python3 setup.py install
+
+RUN sudo python3 prerequisites.py --yes --cmsuser=cmsuser install
+
+RUN sudo sed 's/cmsuser:your_password_here@localhost/postgres@db/' ./config/cms.conf.sample \
+    | sudo tee /usr/local/etc/cms.conf
+
+ENV LANG C.UTF-8
+
+CMD [""]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ inside the repository:
 git submodule update --init
 ```
 
+Run With Docker Compose
+---------
+`docker compose -f docker-compose.dev.yml up -d`
+
+after the container `cms_dev`, `db` up
+
+enter the `cms_dev` container with `docker exec -it cms_dev bash`
+
+then run:
+
+`cmsAddAdmin <admin name>`
+
+it will print the password of the admin name
+
+browse <your_host_name>:8889, then use the admin name and the above password to login!
+
 
 Support
 -------

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,34 @@
+version: "3.3"
+services:
+  db:
+    container_name: db
+    image: postgres
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      # It would be nice here to support OSes that don't have /tmp
+      # See: https://github.com/docker/compose/issues/3344
+      - "/tmp/var_lib_postgresql_data:/var/lib/postgresql/data"
+  cms_dev:
+    container_name: cms_dev
+    build: 
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - 8888:8888
+      - 8889:8889
+    depends_on:
+      - "db"
+    environment:
+      CMS_CONFIG: /usr/local/etc/cms-dev.conf
+    volumes:
+      - "./codecov:/home/cmsuser/cms/codecov"
+    privileged: true
+    command: >
+      wait-for-it db:5432 -- sh -c "
+      createdb --host=db --username=postgres cmsdb ;
+      createdb --host=db --username=postgres cmsdbfortesting ;
+      cmsInitDB ;
+      sudo chown cmsuser:cmsuser ./codecov ;
+      cmsAdminWebServer
+      "

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,34 @@
+version: "3.3"
+services:
+  db:
+    container_name: db
+    image: postgres
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      # It would be nice here to support OSes that don't have /tmp
+      # See: https://github.com/docker/compose/issues/3344
+      - "/tmp/var_lib_postgresql_data:/var/lib/postgresql/data"
+  cms_prod:
+    container_name: cms_prod
+    build: 
+      context: .
+      dockerfile: Dockerfile.prod
+    ports:
+      - 8888:8888
+      - 8889:8889
+    depends_on:
+      - "db"
+    environment:
+      CMS_CONFIG: /usr/local/etc/cms.conf
+    volumes:
+      - "./codecov:/home/cmsuser/cms/codecov"
+    privileged: true
+    command: >
+      wait-for-it db:5432 -- sh -c "
+      createdb --host=db --username=postgres cmsdb ;
+      createdb --host=db --username=postgres cmsdbfortesting ;
+      cmsInitDB ;
+      sudo chown cmsuser:cmsuser ./codecov ;
+      cmsAdminWebServer
+      "


### PR DESCRIPTION
I wonder why this repo has no docker-compose for production(to run the admin-webServer just after you up a docker-compose) is there any issue cause there is no container for deployment config file

So I have added two docker compose file for development and production respectively.
I'm seeking your opinion for this commit, thanks