### PR TITLE
Add support for importing score_precision in italian_yaml

### DIFF
--- a/cmscontrib/loaders/italy_yaml.py
+++ b/cmscontrib/loaders/italy_yaml.py
@@ -447,6 +447,9 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
                     "Attachment %s for task %s" % (filename, name))
                 args["attachments"][filename] = Attachment(filename, digest)
 
+        # Score precision.
+        load(conf, args, "score_precision")
+
         task = Task(**args)
 
         args = {}


### PR DESCRIPTION
This adds support for `score_precision: 1` in task.yaml.