### PR TITLE
Adding C++17 to the default list of allowed programming language

### DIFF
--- a/cms/db/contest.py
+++ b/cms/db/contest.py
@@ -79,7 +79,7 @@ class Contest(Base):
     languages = Column(
         ARRAY(String),
         nullable=False,
-        default=["C11 / gcc", "C++11 / g++", "Pascal / fpc"])
+        default=["C11 / gcc", "C++11 / g++", "Pascal / fpc", "C++17 / g++"])
 
     # Whether contestants allowed to download their submissions.
     submissions_download_allowed = Column(

--- a/cms/db/contest.py
+++ b/cms/db/contest.py
@@ -79,7 +79,7 @@ class Contest(Base):
     languages = Column(
         ARRAY(String),
         nullable=False,
-        default=["C11 / gcc", "C++11 / g++", "Pascal / fpc", "C++17 / g++"])
+        default=["C11 / gcc", "C++17 / g++", "Pascal / fpc"])
 
     # Whether contestants allowed to download their submissions.
     submissions_download_allowed = Column(


### PR DESCRIPTION
C++17 offers a variety of great features which would benefit competitive programmers in the long run (such as Structured bindings, std::optional, std::clamp, std::gcd and std::lcm among other). Unfortunately, the default list of allowed programming languages to be used in a contest does not contain the option to use C++17. This commit will simply add the C++17 option.