### PR TITLE
Install a SIGTERM handler in addition to SIGINT

### DIFF
--- a/cms/io/service.py
+++ b/cms/io/service.py
@@ -78,6 +78,7 @@ class Service:
 
     def __init__(self, shard=0):
         signal.signal(signal.SIGINT, lambda unused_x, unused_y: self.exit())
+        signal.signal(signal.SIGTERM, lambda unused_x, unused_y: self.exit())
 
         self.name = self.__class__.__name__
         self.shard = shard

--- a/cmsranking/RankingWebServer.py
+++ b/cmsranking/RankingWebServer.py
@@ -24,6 +24,7 @@ import os
 import pprint
 import re
 import shutil
+import signal
 import time
 from datetime import datetime
 
@@ -621,6 +622,10 @@ def main():
             (config.bind_address, config.https_port), wsgi_app,
             certfile=config.https_certfile, keyfile=config.https_keyfile)
         servers.append(https_server)
+
+    def sigterm_handler(*_):
+        raise KeyboardInterrupt
+    signal.signal(signal.SIGTERM, sigterm_handler)
 
     try:
         gevent.joinall(list(gevent.spawn(s.serve_forever) for s in servers))


### PR DESCRIPTION
This allows cleanly terminating CMS by sending it SIGTERM, which is what e.g. Docker or systemd do.

I ran into this while using docker-compose, which when asked to stop a container will send it SIGTERM, then wait 10 seconds, and then send SIGKILL. I think terminating CMS via SIGKILL isn't particuarly nice (and also I don't like waiting 10 seconds every time I want to restart a container).