### PR TITLE
Allow setting separate time limit for interpreted languages

### DIFF
--- a/cms/db/task.py
+++ b/cms/db/task.py
@@ -386,6 +386,10 @@ class Dataset(Base):
         Float,
         CheckConstraint("time_limit > 0"),
         nullable=True)
+    time_limit_interpreted = Column(
+        Float,
+        CheckConstraint("time_limit_interpreted > 0"),
+        nullable=True)
     memory_limit = Column(
         BigInteger,
         CheckConstraint("memory_limit > 0"),

--- a/cms/grading/language.py
+++ b/cms/grading/language.py
@@ -93,6 +93,13 @@ class Language(metaclass=ABCMeta):
         return False
 
     @property
+    def is_interpreted(self):
+        """Whether the language is interpreted and should be graded with the
+        interpreted language time limit (when such a limit is specified).
+        """
+        return False
+
+    @property
     def object_extension(self):
         """Default object extension for the language."""
         return self.object_extensions[0] \

--- a/cms/grading/languages/php.py
+++ b/cms/grading/languages/php.py
@@ -45,6 +45,11 @@ class Php(Language):
         """See Language.executable_extension."""
         return ".php"
 
+    @property
+    def is_interpreted(self):
+        """See Language.is_interpreted."""
+        return True
+
     def get_compilation_commands(self,
                                  source_filenames, executable_filename,
                                  for_evaluation=True):

--- a/cms/grading/languages/python2_cpython.py
+++ b/cms/grading/languages/python2_cpython.py
@@ -50,6 +50,11 @@ class Python2CPython(CompiledLanguage):
         """See Language.executable_extension."""
         return ".zip"
 
+    @property
+    def is_interpreted(self):
+        """See Language.is_interpreted."""
+        return True
+
     def get_compilation_commands(self,
                                  source_filenames, executable_filename,
                                  for_evaluation=True):

--- a/cms/grading/languages/python3_cpython.py
+++ b/cms/grading/languages/python3_cpython.py
@@ -51,6 +51,11 @@ class Python3CPython(CompiledLanguage):
         # Defined in PEP 441 (https://www.python.org/dev/peps/pep-0441/).
         return ".pyz"
 
+    @property
+    def is_interpreted(self):
+        """See Language.is_interpreted."""
+        return True
+
     def get_compilation_commands(self,
                                  source_filenames, executable_filename,
                                  for_evaluation=True):

--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -296,7 +296,7 @@ class Batch(TaskType):
         box_success, evaluation_success, stats = evaluation_step(
             sandbox,
             commands,
-            job.time_limit,
+            job.effective_time_limit(),
             job.memory_limit,
             writable_files=files_allowing_write,
             stdin_redirect=stdin_redirect,

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -247,7 +247,7 @@ class TwoSteps(TaskType):
         first = evaluation_step_before_run(
             first_sandbox,
             first_command,
-            job.time_limit,
+            job.effective_time_limit(),
             job.memory_limit,
             dirs_map={fifo_dir: ("/fifo", "rw")},
             stdin_redirect=TwoSteps.INPUT_FILENAME,
@@ -270,7 +270,7 @@ class TwoSteps(TaskType):
         second = evaluation_step_before_run(
             second_sandbox,
             second_command,
-            job.time_limit,
+            job.effective_time_limit(),
             job.memory_limit,
             dirs_map={fifo_dir: ("/fifo", "rw")},
             stdout_redirect=TwoSteps.OUTPUT_FILENAME,

--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -390,21 +390,22 @@ class BaseHandler(CommonRequestHandler):
             raise ValueError("Submission format not recognized.")
         dest["submission_format"] = format_
 
-    def get_time_limit(self, dest, field):
+    def get_time_limit(self, dest, field, field_name="time_limit"):
         """Parse the time limit.
 
         Read the argument with the given name and use its value to set
-        the "time_limit" item of the given dictionary.
+        the given item of the given dictionary.
 
         dest (dict): a place to store the result.
         field (string): the name of the argument to use.
+        field_name (string): name of the key to store the result at.
 
         """
         value = self.get_argument(field, None)
         if value is None:
             return
         if len(value) == 0:
-            dest["time_limit"] = None
+            dest[field_name] = None
         else:
             try:
                 value = float(value)
@@ -412,7 +413,7 @@ class BaseHandler(CommonRequestHandler):
                 raise ValueError("Can't cast %s to float." % value)
             if not 0 <= value < float("+inf"):
                 raise ValueError("Time limit out of range.")
-            dest["time_limit"] = value
+            dest[field_name] = value
 
     def get_memory_limit(self, dest, field):
         """Parse the memory limit.

--- a/cms/server/admin/handlers/dataset.py
+++ b/cms/server/admin/handlers/dataset.py
@@ -136,6 +136,7 @@ class CloneDatasetHandler(BaseHandler):
                 return
 
             self.get_time_limit(attrs, "time_limit")
+            self.get_time_limit(attrs, "time_limit_interpreted", "time_limit_interpreted")
             self.get_memory_limit(attrs, "memory_limit")
             self.get_task_type(attrs, "task_type", "TaskTypeOptions_")
             self.get_score_type(attrs, "score_type", "score_type_parameters")

--- a/cms/server/admin/handlers/task.py
+++ b/cms/server/admin/handlers/task.py
@@ -174,6 +174,7 @@ class TaskHandler(BaseHandler):
                 attrs = dataset.get_attrs()
 
                 self.get_time_limit(attrs, "time_limit_%d" % dataset.id)
+                self.get_time_limit(attrs, "time_limit_interpreted_%d" % dataset.id, "time_limit_interpreted")
                 self.get_memory_limit(attrs, "memory_limit_%d" % dataset.id)
                 self.get_task_type(attrs, "task_type_%d" % dataset.id,
                                    "TaskTypeOptions_%d_" % dataset.id)
@@ -418,6 +419,7 @@ class AddDatasetHandler(BaseHandler):
                 return
 
             self.get_time_limit(attrs, "time_limit")
+            self.get_time_limit(attrs, "time_limit_interpreted", "time_limit_interpreted")
             self.get_memory_limit(attrs, "memory_limit")
             self.get_task_type(attrs, "task_type", "TaskTypeOptions_")
             self.get_score_type(attrs, "score_type", "score_type_parameters")

--- a/cms/server/admin/templates/add_dataset.html
+++ b/cms/server/admin/templates/add_dataset.html
@@ -59,6 +59,13 @@ You are cloning the dataset "{{ original_dataset.description }}".
     </tr>
     <tr>
       <td>
+        <span class="info" title="Total maximum time for each evaluation when using an interpreted language, in seconds."></span>
+  Interpreted lang. time limit
+      </td>
+      <td><input type="text" name="time_limit_interpreted_{{ dataset.id }}" value="{{ 1 if original_dataset is none else original_dataset.time_limit_interpreted or "" }}"/> second(s)</td>
+    </tr>
+    <tr>
+      <td>
         <span class="info" title="Total maximum memory usage for each evaluation, in MiB (2^20 bytes)."></span>
         Memory limit
       </td>

--- a/cms/server/admin/templates/task.html
+++ b/cms/server/admin/templates/task.html
@@ -348,6 +348,13 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
         </tr>
         <tr>
           <td>
+            <span class="info" title="Total maximum time for each evaluation when using an interpreted language, in seconds."></span>
+	    Interpreted lang. time limit
+          </td>
+          <td><input type="text" name="time_limit_interpreted_{{ dataset.id }}" value="{{ dataset.time_limit_interpreted if dataset.time_limit_interpreted is not none else "" }}"/> second(s)</td>
+        </tr>
+        <tr>
+          <td>
             <span class="info" title="Total maximum memory usage for each evaluation, in MiB (2^20 bytes)."></span>
             Memory limit
           </td>

--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -196,6 +196,7 @@
             <th>{% trans %}Task{% endtrans %}</th>
             <th>{% trans %}Name{% endtrans %}</th>
             <th>{% trans %}Time limit{% endtrans %}</th>
+            <th>{% trans %}Interpreted language time limit{% endtrans %}</th>
             <th>{% trans %}Memory limit{% endtrans %}</th>
             <th>{% trans %}Type{% endtrans %}</th>
             <th>{% trans %}Files{% endtrans %}</th>
@@ -213,6 +214,13 @@
             <td>
     {% if t_iter.active_dataset.time_limit is not none %}
         {{ t_iter.active_dataset.time_limit|format_duration(length="long") }}
+    {% else %}
+        {% trans %}N/A{% endtrans %}
+    {% endif %}
+            </td>
+            <td>
+    {% if t_iter.active_dataset.time_limit_interpreted is not none %}
+        {{ t_iter.active_dataset.time_limit_interpreted|format_duration(length="long") }}
     {% else %}
         {% trans %}N/A{% endtrans %}
     {% endif %}

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -103,6 +103,12 @@
             <td colspan="2">{{ task.active_dataset.time_limit|format_duration(length="long") }}</td>
         </tr>
 {% endif %}
+{% if task.active_dataset.time_limit_interpreted is not none %}
+        <tr>
+            <th>{% trans %}Interpreted language time limit{% endtrans %}</th>
+            <td colspan="2">{{ task.active_dataset.time_limit_interpreted|format_duration(length="long") }}</td>
+        </tr>
+{% endif %}
 {% if task.active_dataset.memory_limit is not none %}
         <tr>
             <th>{% trans %}Memory limit{% endtrans %}</th>


### PR DESCRIPTION
This allows setting a different (presumably higher) per-task time limit for some languages. This is mainly intended to make competing in Python viable without giving C++ users an advantage.

If a task doesn't have the interpreted language time limit set, the default time limit will be used instead. The set of interpreted languages is currently hardcoded as Python  (2/3) and PHP.

I made this as a pull request directly because it's what we already use for Estonian olympiads, but admittedly it's not as configurable as it could be (mainly the list of which languages count as "interpreted"). The set of interpreted languages needs to be carefully chosen to make sure all such languages have roughly the same performance, otherwise competing in one language might be impossible, or in another language asymptotically bad solutions might get through the tests. Realistically it should be all of the slow languages that the jury has written example solutions for, with the time limit set accordingly to make all of them pass.

This makes me think that perhaps the set of languages should be a contest-specific setting, or at the very least something in cms.conf. But feedback is of course welcome.