### PR TITLE
Fix sidebar "Testing" link not being active when on testing page

### DIFF
--- a/cms/server/contest/templates/contest.html
+++ b/cms/server/contest/templates/contest.html
@@ -196,7 +196,7 @@ $(document).ready(function () {
                             </li>
     {% if actual_phase == 0 or participation.unrestricted %}{# FIXME maybe >= 0? #}
         {% if testing_enabled %}
-                            <li{% if page == "testing" %} class="active"{% endif %}>
+                            <li{% if page == "test_interface" %} class="active"{% endif %}>
                                 <a href="{{ contest_url("testing") }}">{% trans %}Testing{% endtrans %}</a>
                             </li>
         {% endif %}


### PR DESCRIPTION
When clicking on the "Testing" link on the sidebar in CWS, it doesn't get highlighted as the current page. Fixed by testing for the right name in templates/contest.html (the name coming from [here](https://github.com/cms-dev/cms/blob/7db9aa1ec7f29a9463614ff5a3f37b38d426cf5c/cms/server/contest/templates/test_interface.html#L3)).