### PR TITLE
Upgrade gevent and greenlet

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,3 @@
-name: cms
 version: "3.3"
 
 services:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,3 +1,4 @@
+name: cms
 version: "3.3"
 
 services:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,9 @@ netifaces>=0.10,<0.11  # https://bitbucket.org/al45tair/netifaces/src/
 pycryptodomex>=3.6,<3.7  # https://github.com/Legrandin/pycryptodome/blob/master/Changelog.rst
 psutil>=5.5,<5.6  # https://github.com/giampaolo/psutil/blob/master/HISTORY.rst
 requests>=2.22,<2.23  # https://pypi.python.org/pypi/requests
-# Slightly higher version for Python 3.8 support
-gevent>=1.5,<1.6  # http://www.gevent.org/changelog.html
-# Limit greenlet version for binary compatibility with gevent 1.5 wheels
-greenlet<0.4.17
-werkzeug>=0.16,<0.17  # https://github.com/pallets/werkzeug/blob/master/CHANGES
+gevent==20.12.0  # http://www.gevent.org/changelog.html
+# Limit greenlet version for binary compatibility with gevent 20.12 wheels
+greenlet==1.0.0werkzeug>=0.16,<0.17  # https://github.com/pallets/werkzeug/blob/master/CHANGES
 patool>=1.12,<1.13  # https://github.com/wummel/patool/blob/master/doc/changelog.txt
 bcrypt>=3.1,<3.2  # https://github.com/pyca/bcrypt/
 chardet>=3.0,<3.1  # https://pypi.python.org/pypi/chardet

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,8 @@ psutil>=5.5,<5.6  # https://github.com/giampaolo/psutil/blob/master/HISTORY.rst
 requests>=2.22,<2.23  # https://pypi.python.org/pypi/requests
 gevent==20.12.0  # http://www.gevent.org/changelog.html
 # Limit greenlet version for binary compatibility with gevent 20.12 wheels
-greenlet==1.0.0werkzeug>=0.16,<0.17  # https://github.com/pallets/werkzeug/blob/master/CHANGES
+greenlet==1.0.0
+werkzeug>=0.16,<0.17  # https://github.com/pallets/werkzeug/blob/master/CHANGES
 patool>=1.12,<1.13  # https://github.com/wummel/patool/blob/master/doc/changelog.txt
 bcrypt>=3.1,<3.2  # https://github.com/pyca/bcrypt/
 chardet>=3.0,<3.1  # https://pypi.python.org/pypi/chardet


### PR DESCRIPTION
Updating these two to the oldest versions that still successfully build on a Mac M1, mostly just for ease of testing, so I don't have to spin up a linux VM every time. (I still have issues with `fp-compiler` but that isn't critical).