### PR TITLE
Codecov: collect test analytics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,16 +25,26 @@ jobs:
         run: |
           docker compose -p cms -f docker-compose.test.yml run --rm testcms
 
-      - uses: codecov/codecov-action@v4
-        env:
-            CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: ./codecov/junit.xml
+          flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload unit test coverage results to Codecov
+        uses: codecov/codecov-action@v4
+        if: ${{ !cancelled() }}
         with:
           files: ./codecov/unittests.xml
           flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
-      - uses: codecov/codecov-action@v4
-        env:
-            CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload functional test coverage results to Codecov
+        uses: codecov/codecov-action@v4
+        if: ${{ !cancelled() }}
         with:
           files: ./codecov/functionaltests.xml
           flags: functionaltests
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/_cms-test-internal.sh
+++ b/_cms-test-internal.sh
@@ -6,7 +6,7 @@ dropdb --host=testdb --username=postgres cmsdbfortesting
 createdb --host=testdb --username=postgres cmsdbfortesting
 cmsInitDB
 
-pytest --cov . --cov-report xml:codecov/unittests.xml
+pytest --cov . --cov-report xml:codecov/unittests.xml --junitxml=codecov/junit.xml -o junit_family=legacy
 UNIT=$?
 
 dropdb --host=testdb --username=postgres cmsdbfortesting


### PR DESCRIPTION
https://docs.codecov.com/docs/test-analytics#failed-test-reporting

This enables Codecov to report failed tests directly in the PR, avoiding us from having to open the github action to see what failed (at least for unit tests).

For an example, see edit history of this comment: https://github.com/wil93/cms/pull/8#issuecomment-2481249006 