### PR TITLE
Listen on IPv4 only by default.

### DIFF
--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -140,7 +140,7 @@
     "_help": "Listening HTTP address and port for the AWS. If you access",
     "_help": "it through a proxy running on the same host you could put",
     "_help": "127.0.0.1 here for additional security.",
-    "admin_listen_address": "",
+    "admin_listen_address": "0.0.0.0",
     "admin_listen_port":    8889,
 
     "_help": "Login cookie duration for admins in seconds.",


### PR DESCRIPTION
Listening on the empty address allows connections on both ipv4 and ipv6 and  AdminWebServer gets confused about the IP change caused by i.e. nginx.