### PR TITLE
Add support for ephemeral services.

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -22,11 +22,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import errno
+import ipaddress
 import json
 import logging
 import os
+import socket
 import sys
 from collections import namedtuple
+from contextlib import closing
 
 from .log import set_detailed_logs
 
@@ -44,6 +47,7 @@ class ServiceCoord(namedtuple("ServiceCoord", "name shard")):
     service (thus identifying it).
 
     """
+
     def __repr__(self):
         return "%s,%d" % (self.name, self.shard)
 
@@ -51,6 +55,75 @@ class ServiceCoord(namedtuple("ServiceCoord", "name shard")):
 class ConfigError(Exception):
     """Exception for critical configuration errors."""
     pass
+
+
+class EphemeralServiceConfig:
+    """Configuration of an ephemeral service. An ephemeral service is a
+    normal service whose shard is chosen depending on its address and
+    port. The port is assigned inside a range and the address must be
+    inside the subnet.
+    """
+    EPHEMERAL_SHARD_OFFSET = 10000
+
+    def __init__(self, subnet, min_port, max_port):
+        self.subnet = ipaddress.ip_network(subnet)
+        self.min_port = min_port
+        self.max_port = max_port
+        if min_port > max_port:
+            raise ConfigError("Invalid port range: [%s, %s]"
+                              % (min_port, max_port))
+
+    def get_shard(self, address, port):
+        """Get the ephemeral shard for a service given its address and port.
+
+        address (IPv4Address|IPv6Address): address of the service.
+        port (int): port of the service.
+
+        return (int): shard of the service
+        """
+        if address not in self.subnet:
+            raise ValueError("The address is not inside the subnet")
+        host_id = int(address) & int(self.subnet.hostmask)
+        num_ports = self.max_port - self.min_port + 1
+        shard = host_id * num_ports + (port - self.min_port)
+        return shard + self.EPHEMERAL_SHARD_OFFSET
+
+    def get_address(self, shard):
+        """Get the address and port of a service given its shard.
+
+        shard (int): shard of the service
+
+        return (Address): address and port of the service
+        """
+        shard -= self.EPHEMERAL_SHARD_OFFSET
+        num_ports = self.max_port - self.min_port + 1
+        port_offset = shard % num_ports
+        host_id = (shard - port_offset) // num_ports
+
+        port = self.min_port + port_offset
+        addr = self.subnet.network_address + host_id
+        if addr not in self.subnet:
+            raise ValueError("The shard is not valid")
+        return Address(str(addr), port)
+
+    def find_free_port(self, address):
+        """Find the first open port.
+
+        address (IPv4Address|IPv6Address): local address to bind to
+        """
+        if address.version == 4:
+            family = socket.AF_INET
+        else:
+            family = socket.AF_INET6
+        for port in range(self.min_port, self.max_port+1):
+            with closing(socket.socket(family, socket.SOCK_STREAM)) as sock:
+                try:
+                    sock.bind((str(address), port))
+                    return port
+                except socket.error:
+                    continue
+        raise ValueError("No free port found in range [%s, %s] "
+                         "for address %s" % (minport, maxport, address))
 
 
 class AsyncConfig:
@@ -69,6 +142,7 @@ class AsyncConfig:
     """
     core_services = {}
     other_services = {}
+    ephemeral_services = {}  # type: dict[str, EphemeralServiceConfig]
 
 
 async_config = AsyncConfig()
@@ -81,6 +155,7 @@ class Config:
     directory for information on the meaning of the fields.
 
     """
+
     def __init__(self):
         """Default values for configuration, plus decide if this
         instance is running from the system path or from the source
@@ -250,6 +325,19 @@ class Config:
                 coord = ServiceCoord(service, shard_number)
                 self.async_config.other_services[coord] = Address(*shard)
         del data["other_services"]
+
+        if 'ephemeral_services' in data:
+            for service_name in data['ephemeral_services']:
+                if service_name.startswith("_"):
+                    continue
+                service = data["ephemeral_services"][service_name]
+                self.async_config.ephemeral_services[service_name] = \
+                    EphemeralServiceConfig(
+                        service["subnet"],
+                        service["min_port"],
+                        service["max_port"],
+                )
+            del data["ephemeral_services"]
 
         # Put everything else in self.
         for key, value in data.items():

--- a/cms/io/web_service.py
+++ b/cms/io/web_service.py
@@ -106,6 +106,8 @@ class WebService(Service):
         if num_proxies_used > 0:
             self.wsgi_app = ProxyFix(self.wsgi_app, num_proxies_used)
 
+        logger.info("%s listening on '%s' at port %d",
+            type(self).__name__, listen_address, listen_port)
         self.web_server = WSGIServer((listen_address, listen_port), self)
 
     def __call__(self, environ, start_response):

--- a/cms/server/contest/server.py
+++ b/cms/server/contest/server.py
@@ -45,6 +45,7 @@ from cms import ConfigError, ServiceCoord, config
 from cms.io import WebService
 from cms.locale import get_translations
 from cms.server.contest.jinja2_toolbox import CWS_ENVIRONMENT
+from cms.util import is_shard_ephemeral
 from cmscommon.binary import hex_to_bin
 from .handlers import HANDLERS
 from .handlers.base import ContestListHandler
@@ -73,8 +74,12 @@ class ContestWebServer(WebService):
         }
 
         try:
-            listen_address = config.contest_listen_address[shard]
-            listen_port = config.contest_listen_port[shard]
+            if is_shard_ephemeral(shard):
+                index = 0
+            else:
+                index = shard
+            listen_address = config.contest_listen_address[index]
+            listen_port = config.contest_listen_port[index]
         except IndexError:
             raise ConfigError("Wrong shard number for %s, or missing "
                               "address/port configuration. Please check "

--- a/cms/service/Worker.py
+++ b/cms/service/Worker.py
@@ -30,6 +30,7 @@ import time
 
 import gevent.lock
 
+from cms import ServiceCoord
 from cms.db import SessionGen, Contest, enumerate_files
 from cms.db.filecacher import FileCacher, TombstoneError
 from cms.grading import JobException
@@ -63,6 +64,13 @@ class Worker(Service):
         self._number_execution = 0
 
         self._fake_worker_time = fake_worker_time
+
+        self.evaluation_service = self.connect_to(
+            ServiceCoord("EvaluationService", 0),
+            on_connect=self.on_es_connection)
+
+    def on_es_connection(self, address):
+        self.evaluation_service.add_worker(coord=self._my_coord)
 
     @rpc_method
     def precache_files(self, contest_id):

--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -124,8 +124,7 @@
     "_help": "in core_services. If you access them through a proxy (acting",
     "_help": "as a load balancer) running on the same host you could put",
     "_help": "127.0.0.1 here for additional security.",
-    "_help": "When using ephemeral services only the first address and port",
-    "_help": "are used",
+    "_help": "Ephemeral instances of cws will use the first address and port.",
     "contest_listen_address": [""],
     "contest_listen_port":    [8888],
 

--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -15,6 +15,7 @@
     "cmsuser": "cmsuser",
 
 
+
     "_section": "AsyncLibrary",
 
     "core_services":
@@ -52,6 +53,24 @@
     {
         "TestFileCacher":    [["localhost", 27501]]
     },
+
+    "ephemeral_services":
+    {
+        "Worker":
+        {
+            "subnet": "127.0.0.0/8",
+            "min_port": 26000,
+            "max_port": 26999
+        },
+        "ContestWebServer":
+        {
+            "subnet": "127.0.0.0/8",
+            "min_port": 21000,
+            "max_port": 21000
+        }
+    },
+
+
 
     "_section": "Database",
 
@@ -105,6 +124,8 @@
     "_help": "in core_services. If you access them through a proxy (acting",
     "_help": "as a load balancer) running on the same host you could put",
     "_help": "127.0.0.1 here for additional security.",
+    "_help": "When using ephemeral services only the first address and port",
+    "_help": "are used",
     "contest_listen_address": [""],
     "contest_listen_port":    [8888],
 

--- a/docs/Running CMS.rst
+++ b/docs/Running CMS.rst
@@ -99,7 +99,10 @@ After LogService is running, you can start ResourceService on each machine invol
 The flag ``-a`` informs ResourceService that it has to start all other services, and we have omitted again the shard number since, even if ResourceService is replicated, there must be only one of it in each machine. If you have a funny network configuration that confuses CMS, just give explicitly the shard number. In any case, ResourceService will ask you the contest to load, and will start all the other services. You should start see logs flowing in the LogService terminal.
 
 When maintaining a static list of services becomes too difficult, you can use ephemeral services.
-After configuring them in :file:`cms.conf`, you can start them by invoking the service directly without specifying a shard number, as it will be automatically assigned by the service itself.
+Ephemeral services are an alternative to static services which allows cms to dinamically start, discover and stop services as needed.
+Currently only cmsWorker and cmsContestWebServer are supported.
+After configuring them in :file:`cms.conf`, you can start them by invoking the service directly without specifying a shard number,
+as it will be automatically computed by the formula ``10000 + (service_address - subnet.min_address) * num_ports + (service_port - min_port)``.
 For example to start a Worker:
 
 .. sourcecode:: bash

--- a/docs/Running CMS.rst
+++ b/docs/Running CMS.rst
@@ -98,6 +98,14 @@ After LogService is running, you can start ResourceService on each machine invol
 
 The flag ``-a`` informs ResourceService that it has to start all other services, and we have omitted again the shard number since, even if ResourceService is replicated, there must be only one of it in each machine. If you have a funny network configuration that confuses CMS, just give explicitly the shard number. In any case, ResourceService will ask you the contest to load, and will start all the other services. You should start see logs flowing in the LogService terminal.
 
+When maintaining a static list of services becomes too difficult, you can use ephemeral services.
+After configuring them in :file:`cms.conf`, you can start them by invoking the service directly without specifying a shard number, as it will be automatically assigned by the service itself.
+For example to start a Worker:
+
+.. sourcecode:: bash
+
+    cmsWorker
+
 Note that it is your duty to keep CMS's configuration synchronized among the machines.
 
 You should now be able to start exploring the admin interface, by default at http://localhost:8889/. The interface is accessible with an admin account, which you need to create first using the AddAdmin command, for example:

--- a/docs/Running CMS.rst
+++ b/docs/Running CMS.rst
@@ -106,6 +106,8 @@ For example to start a Worker:
 
     cmsWorker
 
+When using both ephemeral and static services, cmsResourceService will start only the static ones.
+
 Note that it is your duty to keep CMS's configuration synchronized among the machines.
 
 You should now be able to start exploring the admin interface, by default at http://localhost:8889/. The interface is accessible with an admin account, which you need to create first using the AddAdmin command, for example:


### PR DESCRIPTION
Ephemeral services are services that are not fixed in the configuration file, but dynamically added as they connect. This is especially useful in a setup in which cmsWorker/cmsContestWebServer are scaled dynamically, as one might do when configuring CMS for running on cloud services.