### PR TITLE
Remove non-installed instructions from docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -28,13 +28,11 @@ If instead you have found a possible bug, please go ahead filing the issue using
 
 ### Logs
 
-[Please attach relevant logs of the component(s) that caused the problem; you can find them in /var/local/log/cms/ (if CMS was running
-installed) or in ./log (if it was running from the local copy).]
+[Please attach relevant logs of the component(s) that caused the problem; you can find them in /var/local/log/cms/.]
 
 ### System Information
 
 **CMS version:** [master, or a specific version]
-**Was CMS installed:** [yes or no]
-**Using a virtualenv:** [yes or no]
+**How was CMS installed:** [virtualenv, docker, ...?]
 **Postgres version:** [if relevant]
 **Distribution and version:** [if relevant]

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -12,8 +12,7 @@ or write on the **support mailing list**
 
 To help with the troubleshooting, you can upload on some online
 pastebin the relevant **log files**, that you can find in
-/var/local/log/cms/ (if CMS was running installed) or in ./log (if it
-was running from the local copy).
+`/var/local/log/cms/`.
 
 If you encountered a bug, please file an
 [issue](https://github.com/cms-dev/cms/issues) on **GitHub** following

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ required (you can see the archives on [Google
 Groups](https://groups.google.com/forum/#!forum/contestms-support)).
 
 To help with the troubleshooting, you can upload on some online pastebin the
-relevant **log files**, that you can find in `/var/local/log/cms/` (if CMS was
-running installed) or in ./log (if it was running from the local copy).
+relevant **log files**, that you can find in `/var/local/log/cms/`.
 
 If you encountered a bug, please file an
 [issue](https://github.com/cms-dev/cms/issues) on **GitHub** following the

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -228,43 +228,6 @@ Apart from validity, there are many possible tweaks to reduce the variability in
 We suggest following isolate's `guidelines <https://github.com/ioi/isolate/blob/c679ae936d8e8d64e5dab553bdf1b22261324315/isolate.1.txt#L292>`_ for reproducible results.
 
 
-.. _installation_running-cms-non-installed:
-
-Running CMS non-installed
-=========================
-
-To run CMS without installing it in the system, you need first to build the prerequisites:
-
-.. sourcecode:: bash
-
-    python3 prerequisites.py build
-
-There are still a few steps to complete manually in this case. First, add CMS and isolate to the path and create the configuration files:
-
-.. sourcecode:: bash
-
-    export PATH=$PATH:./isolate/
-    export PYTHONPATH=./
-    cp config/cms.conf.sample config/cms.conf
-    cp config/cms.ranking.conf.sample config/cms.ranking.conf
-
-Second, perform these tasks (that require root permissions):
-
-* create the ``cmsuser`` user and a group with the same name;
-
-* add your user to the ``cmsuser`` group;
-
-* set isolate to be owned by root:cmsuser, and set its suid bit.
-
-For example:
-
-.. sourcecode:: bash
-
-    sudo useradd cmsuser
-    sudo usermod -a -G cmsuser <your user>
-    sudo chown root:cmsuser ./isolate/isolate
-    sudo chmod u+s ./isolate/isolate
-
 Updating CMS
 ============
 


### PR DESCRIPTION
With the virtualenv as recommended install method this isn't really necessary anymore, so we'd rather avoid supporting this.