### PR TITLE
Remove the SETUPTOOLS_USE_DISTUTILS env variable usage in documentation

### DIFF
--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -166,7 +166,6 @@ version. So, you can install python dependencies by issuing:
 
 .. sourcecode:: bash
 
-    export SETUPTOOLS_USE_DISTUTILS="stdlib"
     pip3 install -r requirements.txt
     python3 setup.py install
 
@@ -199,15 +198,13 @@ Assuming you have ``pip`` installed, you can do this:
 
 .. sourcecode:: bash
 
-    export SETUPTOOLS_USE_DISTUTILS="stdlib"
-    sudo --preserve-env=SETUPTOOLS_USE_DISTUTILS pip3 install -r requirements.txt
-    sudo --preserve-env=SETUPTOOLS_USE_DISTUTILS python3 setup.py install
+    sudo pip3 install -r requirements.txt
+    sudo python3 setup.py install
 
 This command installs python dependencies globally. Note that on some distros, like Arch Linux, this might interfere with the system package manager. If you want to perform the installation in your home folder instead, then you can do this instead:
 
 .. sourcecode:: bash
 
-    export SETUPTOOLS_USE_DISTUTILS="stdlib"
     pip3 install --user -r requirements.txt
     python3 setup.py install --user
 


### PR DESCRIPTION
It seems that some people have issues when using this, see:

![image](https://github.com/user-attachments/assets/30ba9ea8-f976-4156-a8ee-08b7a5538ed7)

Removing this step solves the issue