### PR TITLE
Always include max_score in submission data

### DIFF
--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -267,12 +267,12 @@ class SubmissionStatusHandler(ContestHandler):
                         sr.public_score, score_type.max_public_score,
                         sr.public_score_details, task.score_precision,
                         translation=self.translation)
-            if score_type.max_public_score < score_type.max_score \
-                    and (submission.token is not None
-                         or self.r_params["actual_phase"] == 3):
+            if score_type.max_public_score < score_type.max_score:
                 data["max_score"] = \
                     round(score_type.max_score, task.score_precision)
-                if data["status"] == SubmissionResult.SCORED:
+                if data["status"] == SubmissionResult.SCORED \
+                        and (submission.token is not None
+                            or self.r_params["actual_phase"] == 3):
                     data["score"] = \
                         round(sr.score, task.score_precision)
                     data["score_message"] = score_type.format_score(


### PR DESCRIPTION
Even if a token is not played, the participant should be able to see the `max_score`.

This fixes a UI issue where, in certain cases (below), the "Score of tokened submissions" box displays the wrong color after a submission.

Bug Reproduction Steps:

1. Submit a correct solution and play a token.
2. Submit an incorrect solution without refreshing the page.
3. After evaluation and scoring, the "Score of tokened submissions" box should remain green, but it incorrectly turns yellow.

The root cause of this bug is that the frontend JavaScript receives `data["max_score"]` as `undefined`.