### PR TITLE
Fix correct orders of parameters in ES

### DIFF
--- a/cms/service/EvaluationService.py
+++ b/cms/service/EvaluationService.py
@@ -356,14 +356,14 @@ class EvaluationService(TriggeredService):
         counter = 0
         with SessionGen() as session:
 
-            for operation, timestamp, priority in \
+            for operation, priority, timestamp in \
                     get_submissions_operations(session, self.contest_id):
-                if self.enqueue(operation, timestamp, priority):
+                if self.enqueue(operation, priority, timestamp):
                     counter += 1
 
-            for operation, timestamp, priority in \
+            for operation, priority, timestamp in \
                     get_user_tests_operations(session, self.contest_id):
-                if self.enqueue(operation, timestamp, priority):
+                if self.enqueue(operation, priority, timestamp):
                     counter += 1
 
         return counter

--- a/cms/service/esoperations.py
+++ b/cms/service/esoperations.py
@@ -290,8 +290,8 @@ def get_submissions_operations(session, contest_id=None):
     contest_id (int|None): the contest for which we want the operations.
         If none, get operations for any contest.
 
-    return ([ESOperation, float, int]): a list of operation, timestamp
-        and priority.
+    return ([ESOperation, int, float]): a list of operation, priority
+        and timestamp.
 
     """
     operations = []


### PR DESCRIPTION
I think it is obvious that don't need to explain.
When I use `AddSubmission` to add a submission manually, ES will find it by `_missing_operation`, and it reports error when trying to enqueue the operation.
ps: Anyone know why it is useless to call `maybe_send_notification` to call a rpc method? Like AddSubmission won't trigger ES's `new_evaluation()` method.