### PR TITLE
Fix type error in StressTest

### DIFF
--- a/cmstestsuite/StressTest.py
+++ b/cmstestsuite/StressTest.py
@@ -179,7 +179,7 @@ class Actor(threading.Thread):
         SLEEP_PERIOD = 0.1
         time_to_wait = self.metrics['time_coeff'] * \
             random.expovariate(self.metrics['time_lambda'])
-        sleep_num = time_to_wait // SLEEP_PERIOD
+        sleep_num = int(time_to_wait // SLEEP_PERIOD)
         remaining_sleep = time_to_wait - (sleep_num * SLEEP_PERIOD)
         for _ in range(sleep_num):
             time.sleep(SLEEP_PERIOD)


### PR DESCRIPTION
StressTest.py reported TypeError because float number can't be used in `range()`, due to `//` in Python doesn't always return a integer. Now it's fixed.