### PR TITLE
Add a simple API for automated interaction with CMS.

### DIFF
--- a/cms/server/contest/handlers/__init__.py
+++ b/cms/server/contest/handlers/__init__.py
@@ -23,9 +23,24 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .communication import \
-    CommunicationHandler, \
-    QuestionHandler
+from .taskusertest import \
+    UserTestInterfaceHandler, \
+    UserTestHandler, \
+    UserTestStatusHandler, \
+    UserTestDetailsHandler, \
+    UserTestIOHandler, \
+    UserTestFileHandler
+from .tasksubmission import \
+    SubmitHandler, \
+    TaskSubmissionsHandler, \
+    SubmissionStatusHandler, \
+    SubmissionDetailsHandler, \
+    SubmissionFileHandler, \
+    UseTokenHandler
+from .task import \
+    TaskDescriptionHandler, \
+    TaskStatementViewHandler, \
+    TaskAttachmentViewHandler
 from .main import \
     LoginHandler, \
     LogoutHandler, \
@@ -34,24 +49,14 @@ from .main import \
     NotificationsHandler, \
     PrintingHandler, \
     DocumentationHandler
-from .task import \
-    TaskDescriptionHandler, \
-    TaskStatementViewHandler, \
-    TaskAttachmentViewHandler
-from .tasksubmission import \
-    SubmitHandler, \
-    TaskSubmissionsHandler, \
-    SubmissionStatusHandler, \
-    SubmissionDetailsHandler, \
-    SubmissionFileHandler, \
-    UseTokenHandler
-from .taskusertest import \
-    UserTestInterfaceHandler, \
-    UserTestHandler, \
-    UserTestStatusHandler, \
-    UserTestDetailsHandler, \
-    UserTestIOHandler, \
-    UserTestFileHandler
+from .communication import \
+    CommunicationHandler, \
+    QuestionHandler
+from .api import \
+    ApiLoginHandler, \
+    ApiSubmissionListHandler, \
+    ApiSubmitHandler, \
+    ApiTaskListHandler
 
 
 HANDLERS = [
@@ -96,6 +101,12 @@ HANDLERS = [
 
     (r"/communication", CommunicationHandler),
     (r"/question", QuestionHandler),
+
+    # API
+    (r"/api/login", ApiLoginHandler),
+    (r"/api/task_list", ApiTaskListHandler),
+    (r"/api/(.*)/submit", ApiSubmitHandler),
+    (r"/api/(.*)/submission_list", ApiSubmissionListHandler),
 
     # The following prefixes are handled by WSGI middlewares:
     # * /static, defined in cms/io/web_service.py

--- a/cms/server/contest/handlers/api.py
+++ b/cms/server/contest/handlers/api.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2025 Luca Versari <veluca93@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""API handlers for CMS.
+
+"""
+
+import ipaddress
+import logging
+
+try:
+    import tornado4.web as tornado_web
+except ImportError:
+    import tornado.web as tornado_web
+
+from cms.db.submission import Submission
+from cms.server import multi_contest
+from cms.server.contest.authentication import validate_login
+from cms.server.contest.submission import \
+    UnacceptableSubmission, accept_submission
+from .contest import ContestHandler
+from ..phase_management import actual_phase_required
+
+logger = logging.getLogger(__name__)
+
+
+class ApiLoginHandler(ContestHandler):
+    """Login handler.
+
+    """
+    @multi_contest
+    def post(self):
+        username = self.get_argument("username", "")
+        password = self.get_argument("password", "")
+
+        try:
+            ip_address = ipaddress.ip_address(self.request.remote_ip)
+        except ValueError:
+            logger.warning("Invalid IP address provided by Tornado: %s",
+                           self.request.remote_ip)
+            return None
+
+        participation, login_data = validate_login(
+            self.sql_session, self.contest, self.timestamp, username, password,
+            ip_address)
+
+        if participation is None:
+            self.json({"error": "Login failed"}, 403)
+        elif login_data is not None:
+            cookie_name = self.contest.name + "_login"
+            self.json({"login_data": self.create_signed_value(
+                cookie_name, login_data).decode()})
+        else:
+            self.json({})
+
+    def check_xsrf_cookie(self):
+        pass
+
+
+class ApiTaskListHandler(ContestHandler):
+    """Handler to list all tasks and their statements.
+
+    """
+    @tornado_web.authenticated
+    @actual_phase_required(0, 3)
+    @multi_contest
+    def get(self):
+        contest = self.contest
+        tasks = []
+        for task in contest.tasks:
+            name = task.name
+            statements = [s for s in task.statements]
+            sub_format = task.submission_format
+            tasks.append({"name": name,
+                          "statements": statements,
+                          "submission_format": sub_format})
+        self.json({"tasks": tasks})
+
+
+class ApiSubmitHandler(ContestHandler):
+    """Handles the received submissions.
+
+    """
+    @tornado_web.authenticated
+    @actual_phase_required(0, 3)
+    @multi_contest
+    def post(self, task_name: str):
+        task = self.get_task(task_name)
+        if task is None:
+            self.json({"error": "Not found"}, 404)
+            return
+
+        # Only set the official bit when the user can compete and we are not in
+        # analysis mode.
+        official = self.r_params["actual_phase"] == 0
+
+        try:
+            submission = accept_submission(
+                self.sql_session, self.service.file_cacher, self.current_user,
+                task, self.timestamp, self.request.files,
+                self.get_argument("language", None), official)
+            self.sql_session.commit()
+        except UnacceptableSubmission as e:
+            logger.info("API submission rejected: `%s' - `%s'",
+                        e.subject, e.formatted_text)
+            self.json({"error": e.subject, "details": e.formatted_text}, 400)
+        else:
+            logger.info(
+                f'API submission accepted: Submission ID {submission.id}')
+            self.service.evaluation_service.new_submission(
+                submission_id=submission.id)
+            self.json({'id': submission.opaque_id})
+
+
+class ApiSubmissionListHandler(ContestHandler):
+    """Retrieves the list of submissions on a task.
+
+    """
+    @tornado_web.authenticated
+    @actual_phase_required(0, 3)
+    @multi_contest
+    def get(self, task_name: str):
+        task = self.get_task(task_name)
+        if task is None:
+            self.json({"error": "Not found"}, 404)
+            return
+        submissions: list[Submission] = (
+            self.sql_session.query(Submission)
+            .filter(Submission.participation == self.current_user)
+            .filter(Submission.task == task)
+            .all()
+        )
+        self.json({'list': [{"id": s.opaque_id} for s in submissions]})

--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -30,6 +30,7 @@
 """
 
 import ipaddress
+import json
 import logging
 
 import collections
@@ -313,6 +314,11 @@ class ContestHandler(BaseHandler):
 
     def notify_error(self, subject: str, text: str, text_params: object | None = None):
         self.add_notification(subject, text, NOTIFICATION_ERROR, text_params)
+
+    def json(self, data, status_code=200):
+        self.set_header("Content-type", "application/json; charset=utf-8")
+        self.set_status(status_code)
+        self.write(json.dumps(data))
 
     def check_xsrf_cookie(self):
         # We don't need to check for xsrf if the request came with a custom


### PR DESCRIPTION
This adds 4 API endpoints (not CSRF protected):
- A login endpoint that does not return HTML
- An endpoint for programmatic access to the list of tasks, their statements, and the submission format
- An endpoint for programmatic submission
- An endpoint to get the total number of submissions on a task.

Together with the existing submission details APIs, this should allow automatic interaction with CMS.