### PR TITLE
modernize setuptools configuration slightly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN sudo pip3 install --break-system-packages -r dev-requirements.txt
 
 COPY --chown=cmsuser:cmsuser . /home/cmsuser/cms
 
-RUN sudo python3 setup.py install
+RUN sudo pip3 install --break-system-packages .
 
 RUN sudo python3 prerequisites.py --yes --cmsuser=cmsuser install
 

--- a/docs/Docker image.rst
+++ b/docs/Docker image.rst
@@ -97,7 +97,7 @@ similar to:
 The command will build a fresh CMS image when necessary, and drop you into a
 bash prompt where the repository is mounted on ``~/cms`` for ease of
 development. You can edit the code from the host (i.e. outside the container)
-and then reinstall CMS (``python3 setup.py install``) directly from inside the
+and then reinstall CMS (``pip install .``) directly from inside the
 container, without having to rebuild the image every time.
 
 Upon running ``cms-dev.sh`` for the first time, the database will initially be

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -166,8 +166,8 @@ version. So, you can install python dependencies by issuing:
 
 .. sourcecode:: bash
 
-    pip3 install -r requirements.txt
-    python3 setup.py install
+    pip install -r requirements.txt
+    pip install .
 
 .. note::
 
@@ -199,14 +199,14 @@ Assuming you have ``pip`` installed, you can do this:
 .. sourcecode:: bash
 
     sudo pip3 install -r requirements.txt
-    sudo python3 setup.py install
+    sudo pip3 install .
 
 This command installs python dependencies globally. Note that on some distros, like Arch Linux, this might interfere with the system package manager. If you want to perform the installation in your home folder instead, then you can do this instead:
 
 .. sourcecode:: bash
 
     pip3 install --user -r requirements.txt
-    python3 setup.py install --user
+    pip3 install --user .
 
 Method 4: Using your distribution's system packages
 ---------------------------------------------------

--- a/docs/Task types.rst
+++ b/docs/Task types.rst
@@ -194,7 +194,7 @@ Once that is done, install the distribution by executing
 
 .. sourcecode:: bash
 
-    python3 setup.py install
+    pip3 install .
 
 CMS needs to be restarted for it to pick up the new task type.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "babel == 2.12.1"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,25 +1,25 @@
 # This file provides default options for setup.py commands.
 
 [extract_messages]
-mapping-file: babel_mapping.cfg
+mapping_file: babel_mapping.cfg
 keywords: n_:1,2 Nn_:1,2
-output-file: cms/locale/cms.pot
-no-location: 1
+output_file: cms/locale/cms.pot
+no_location: 1
 width: 79
 project: Contest Management System
-copyright-holder: CMS development group
-msgid-bugs-address: contestms@googlegroups.com
+copyright_holder: CMS development group
+msgid_bugs_address: contestms@googlegroups.com
 
 [init_catalog]
 domain: cms
-input-file: cms/locale/cms.pot
-output-dir: cms/locale
+input_file: cms/locale/cms.pot
+output_dir: cms/locale
 width: 79
 
 [update_catalog]
 domain: cms
-input-file: cms/locale/cms.pot
-output-dir: cms/locale
+input_file: cms/locale/cms.pot
+output_dir: cms/locale
 width: 79
 
 [compile_catalog]

--- a/setup.py
+++ b/setup.py
@@ -106,13 +106,7 @@ def find_version():
 # the po and mofiles will be part of the package data for cms.locale,
 # which is collected at this stage.
 class build_py_and_l10n(build_py):
-    def run(self):
-        self.run_command("compile_catalog")
-        # The build command of distutils/setuptools searches the tree
-        # and compiles a list of data files before run() is called and
-        # then stores that value. Hence we need to refresh it.
-        self.data_files = self._get_data_files()
-        super().run()
+    sub_commands = [('compile_catalog', None)] + build_py.sub_commands
 
 
 setup(
@@ -121,7 +115,6 @@ setup(
     author="The CMS development team",
     author_email="contestms@googlegroups.com",
     url="https://github.com/cms-dev/cms",
-    download_url="https://github.com/cms-dev/cms/archive/master.tar.gz",
     description="A contest management system and grader for IOI-like programming competitions",
     packages=find_packages(),
     package_data=PACKAGE_DATA,
@@ -201,12 +194,11 @@ setup(
         ],
     },
     keywords="ioi programming contest grader management system",
-    license="Affero General Public License v3",
+    license_expression="AGPL-3.0-only",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Natural Language :: English",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.9",
-        "License :: OSI Approved :: GNU Affero General Public License v3",
+        "Programming Language :: Python :: 3.12",
     ],
 )


### PR DESCRIPTION
* Add a pyproject.toml, which specifies the build-time dependency on babel. This is required for `pip install` to work in some cases (specifically when using `pip install -e` with setuptools>=80.0.0, but it's nice to specify this in any case)
* Don't use deprecated direct setup.py invocations in Dockerfile (cf. [here](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html)). we might want to update documentation too, to use `pip install` instead of `setup.py install`.
* Fix option names in setup.cfg (I'm not even sure why the old ones used to work... the [docs](https://babel.pocoo.org/en/latest/setup.html#extract-messages) have been saying to use underscores instead of dashes since literally forever)
* Replace the build_py override hack in setup.py with a slightly nicer hack (arguably still a hack, but at least it doesn't require calling private methods of another class)
* Update some setup() metadata fields in setup.py
  * classifiers had outdated python version; also, specifying license in classifiers is deprecated
  * download_url doesn't seem to be used for anything at all and the link is outdated anyways
  * switched to license expression instead of plain license name (this is what pyproject.toml's "license" field uses)

it's now also possible to move most of the text in setup.py into pyproject.toml. I don't think anything that's currently in setup.py is really deprecated (at least, not yet), but maybe it'd be cleaner to have it there. (also, requirements.txt and dev-requirements.txt could live there too.)