### PR TITLE
setup.py: use correct license_expression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,7 @@ setup(
         ],
     },
     keywords="ioi programming contest grader management system",
-    license_expression="AGPL-3.0-only",
+    license_expression="AGPL-3.0-or-later",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Natural Language :: English",


### PR DESCRIPTION
When writing PR #1341, I converted the `license="Affero General Public License v3"` in setup.py into `license_expression="AGPL-3.0-only"`. I just noticed that actually, all the copyright blurbs at the start of files (and in debian/copyright) specify AGPL-3.0-or-later.