### PR TITLE
Use the filenames of the contestant as a default submission comment

### DIFF
--- a/cms/server/contest/submission/workflow.py
+++ b/cms/server/contest/submission/workflow.py
@@ -220,11 +220,15 @@ def accept_submission(
     logger.info("All files stored for submission sent by %s",
                 participation.user.username)
 
+    # Use the filenames of the contestant as a default submission comment
+    received_filenames_joined = ",".join([file.filename for file in received_files])
+
     submission = Submission(
         timestamp=timestamp,
         language=language.name if language is not None else None,
         task=task,
         participation=participation,
+        comment=received_filenames_joined,
         official=official)
     sql_session.add(submission)
 

--- a/cmstestsuite/unit_tests/server/contest/submission/workflow_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission/workflow_test.py
@@ -83,7 +83,7 @@ class TestAcceptSubmission(DatabaseMixin, unittest.TestCase):
         self.tornado_files = sentinel.tornado_files
         self.language_name = sentinel.language_name
         self.official = True
-        self.received_files = sentinel.received_files
+        self.received_files = []
         self.files = {"foo.%l": FOO_CONTENT}
         # Multiple extensions, primary one doesn't start with a period.
         self.language = make_language("MockLanguage", ["mock.1", ".mock2"])


### PR DESCRIPTION
It is very useful for the scientific commitee to see it in the Comment column of the submissions page in the admin website. This column was mostly unused and empty in the past.

Closes #1371 