### PR TITLE
Start subtask numbering from 0 instead of 1

### DIFF
--- a/cms/grading/scoretypes/abc.py
+++ b/cms/grading/scoretypes/abc.py
@@ -394,7 +394,7 @@ class ScoreTypeGroup(ScoreTypeAlone):
             score += parameter[0]
             if all(self.public_testcases[tc_idx] for tc_idx in target):
                 public_score += parameter[0]
-            headers += ["Subtask %d (%g)" % (st_idx + 1, parameter[0])]
+            headers += ["Subtask %d (%g)" % (st_idx, parameter[0])]
 
         return score, public_score, headers
 
@@ -464,7 +464,7 @@ class ScoreTypeGroup(ScoreTypeAlone):
 
             score += st_score
             subtasks.append({
-                "idx": st_idx + 1,
+                "idx": st_idx,
                 # We store the fraction so that an "example" testcase
                 # with a max score of zero is still properly rendered as
                 # correct or incorrect.
@@ -475,7 +475,7 @@ class ScoreTypeGroup(ScoreTypeAlone):
                 public_score += st_score
                 public_subtasks.append(subtasks[-1])
             else:
-                public_subtasks.append({"idx": st_idx + 1,
+                public_subtasks.append({"idx": st_idx,
                                         "testcases": public_testcases})
             ranking_details.append("%g" % round(st_score, 2))
 

--- a/cmstestsuite/unit_tests/grading/scoretypes/GroupMinTest.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/GroupMinTest.py
@@ -31,6 +31,7 @@ class TestGroupMin(ScoreTypeTestMixin, unittest.TestCase):
     def setUp(self):
         super().setUp()
         self._public_testcases = {
+            "0_0": True,
             "1_0": True,
             "1_1": True,
             "2_0": True,
@@ -86,8 +87,9 @@ class TestGroupMin(ScoreTypeTestMixin, unittest.TestCase):
     def test_max_scores_regexp(self):
         """Test max score is correct when groups are regexp-defined."""
         s1, s2, s3 = 10.5, 30.5, 59
-        parameters = [[s1, "1_*"], [s2, "2_*"], [s3, "3_*"]]
-        header = ["Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
+        parameters = [[0, "0_*"], [s1, "1_*"], [s2, "2_*"], [s3, "3_*"]]
+        header = ["Subtask 0 (0)",
+                  "Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
 
         # Only group 1_* is public.
         public_testcases = dict(self._public_testcases)
@@ -109,8 +111,9 @@ class TestGroupMin(ScoreTypeTestMixin, unittest.TestCase):
     def test_max_scores_number(self):
         """Test max score is correct when groups are number-defined."""
         s1, s2, s3 = 10.5, 30.5, 59
-        parameters = [[s1, 2], [s2, 2], [s3, 2]]
-        header = ["Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
+        parameters = [[0, 1], [s1, 2], [s2, 2], [s3, 2]]
+        header = ["Subtask 0 (0)",
+                  "Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
 
         # Only group 1_* is public.
         public_testcases = dict(self._public_testcases)
@@ -131,31 +134,55 @@ class TestGroupMin(ScoreTypeTestMixin, unittest.TestCase):
 
     def test_compute_score(self):
         s1, s2, s3 = 10.5, 30.5, 59
-        parameters = [[s1, "1_*"], [s2, "2_*"], [s3, "3_*"]]
+        parameters = [[0, "0_*"], [s1, "1_*"], [s2, "2_*"], [s3, "3_*"]]
         gmin = GroupMin(parameters, self._public_testcases)
         sr = self.get_submission_result(self._public_testcases)
 
         # All correct.
-        self.assertComputeScore(gmin.compute_score(sr),
-                                s1 + s2 + s3, s1, [s1, s2, s3])
+        self.assertComputeScore(
+            gmin.compute_score(sr),
+            s1 + s2 + s3, s1, [0, s1, s2, s3], [
+                {"idx": 0},
+                {"idx": 1},
+                {"idx": 2},
+                {"idx": 3}
+            ])
 
         # Some non-public subtask is incorrect.
         self.set_outcome(sr, "3_1", 0.0)
-        self.assertComputeScore(gmin.compute_score(sr),
-                                s1 + s2, s1, [s1, s2, 0])
+        self.assertComputeScore(
+            gmin.compute_score(sr),
+            s1 + s2, s1, [0, s1, s2, 0], [
+                {"idx": 0},
+                {"idx": 1},
+                {"idx": 2},
+                {"idx": 3}
+            ])
 
         # Also the public subtask is incorrect.
         self.set_outcome(sr, "1_0", 0.0)
         self.set_outcome(sr, "1_1", 0.0)
         sr.evaluations[1].outcome = 0.0
-        self.assertComputeScore(gmin.compute_score(sr),
-                                s2, 0.0, [0, s2, 0])
+        self.assertComputeScore(
+            gmin.compute_score(sr),
+            s2, 0.0, [0, 0, s2, 0], [
+                {"idx": 0},
+                {"idx": 1},
+                {"idx": 2},
+                {"idx": 3}
+            ])
 
         # Some partial results.
         self.set_outcome(sr, "3_0", 0.5)
         self.set_outcome(sr, "3_1", 0.1)
-        self.assertComputeScore(gmin.compute_score(sr),
-                                s2 + s3 * 0.1, 0.0, [0, s2, s3 * 0.1])
+        self.assertComputeScore(
+            gmin.compute_score(sr),
+            s2 + s3 * 0.1, 0.0, [0, 0, s2, s3 * 0.1], [
+                {"idx": 0},
+                {"idx": 1},
+                {"idx": 2},
+                {"idx": 3}
+            ])
 
 
 if __name__ == "__main__":

--- a/cmstestsuite/unit_tests/grading/scoretypes/GroupMulTest.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/GroupMulTest.py
@@ -31,6 +31,7 @@ class TestGroupMul(ScoreTypeTestMixin, unittest.TestCase):
     def setUp(self):
         super().setUp()
         self._public_testcases = {
+            "0_0": True,
             "1_0": True,
             "1_1": True,
             "2_0": True,
@@ -86,8 +87,9 @@ class TestGroupMul(ScoreTypeTestMixin, unittest.TestCase):
     def test_max_scores_regexp(self):
         """Test max score is correct when groups are regexp-defined."""
         s1, s2, s3 = 10.5, 30.5, 59
-        parameters = [[s1, "1_*"], [s2, "2_*"], [s3, "3_*"]]
-        header = ["Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
+        parameters = [[0, "0_*"], [s1, "1_*"], [s2, "2_*"], [s3, "3_*"]]
+        header = ["Subtask 0 (0)",
+                  "Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
 
         # Only group 1_* is public.
         public_testcases = dict(self._public_testcases)
@@ -109,8 +111,9 @@ class TestGroupMul(ScoreTypeTestMixin, unittest.TestCase):
     def test_max_scores_number(self):
         """Test max score is correct when groups are number-defined."""
         s1, s2, s3 = 10.5, 30.5, 59
-        parameters = [[s1, 2], [s2, 2], [s3, 2]]
-        header = ["Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
+        parameters = [[0, 1], [s1, 2], [s2, 2], [s3, 2]]
+        header = ["Subtask 0 (0)",
+                  "Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
 
         # Only group 1_* is public.
         public_testcases = dict(self._public_testcases)
@@ -131,31 +134,55 @@ class TestGroupMul(ScoreTypeTestMixin, unittest.TestCase):
 
     def test_compute_score(self):
         s1, s2, s3 = 10.5, 30.5, 59
-        parameters = [[s1, "1_*"], [s2, "2_*"], [s3, "3_*"]]
+        parameters = [[0, "0_*"], [s1, "1_*"], [s2, "2_*"], [s3, "3_*"]]
         gmul = GroupMul(parameters, self._public_testcases)
         sr = self.get_submission_result(self._public_testcases)
 
         # All correct.
-        self.assertComputeScore(gmul.compute_score(sr),
-                                s1 + s2 + s3, s1, [s1, s2, s3])
+        self.assertComputeScore(
+            gmul.compute_score(sr),
+            s1 + s2 + s3, s1, [0, s1, s2, s3], [
+                {"idx": 0},
+                {"idx": 1},
+                {"idx": 2},
+                {"idx": 3}
+            ])
 
         # Some non-public subtask is incorrect.
         self.set_outcome(sr, "3_1", 0.0)
-        self.assertComputeScore(gmul.compute_score(sr),
-                                s1 + s2, s1, [s1, s2, 0])
+        self.assertComputeScore(
+            gmul.compute_score(sr),
+            s1 + s2, s1, [0, s1, s2, 0], [
+                {"idx": 0},
+                {"idx": 1},
+                {"idx": 2},
+                {"idx": 3}
+            ])
 
         # Also the public subtask is incorrect.
         self.set_outcome(sr, "1_0", 0.0)
         self.set_outcome(sr, "1_1", 0.0)
-        self.assertComputeScore(gmul.compute_score(sr),
-                                s2, 0.0, [0, s2, 0])
+        self.assertComputeScore(
+            gmul.compute_score(sr),
+            s2, 0.0, [0, 0, s2, 0], [
+                {"idx": 0},
+                {"idx": 1},
+                {"idx": 2},
+                {"idx": 3}
+            ])
 
         # Some partial results.
         self.set_outcome(sr, "3_0", 0.5)
         self.set_outcome(sr, "3_1", 0.1)
-        self.assertComputeScore(gmul.compute_score(sr),
-                                s2 + s3 * 0.5 * 0.1, 0.0,
-                                [0, s2, s3 * 0.5 * 0.1])
+        self.assertComputeScore(
+            gmul.compute_score(sr),
+            s2 + s3 * 0.5 * 0.1, 0.0,
+            [0, 0, s2, s3 * 0.5 * 0.1], [
+                {"idx": 0},
+                {"idx": 1},
+                {"idx": 2},
+                {"idx": 3}
+            ])
 
 
 if __name__ == "__main__":

--- a/cmstestsuite/unit_tests/grading/scoretypes/GroupThresholdTest.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/GroupThresholdTest.py
@@ -31,6 +31,7 @@ class TestGroupThreshold(ScoreTypeTestMixin, unittest.TestCase):
     def setUp(self):
         super().setUp()
         self._public_testcases = {
+            "0_0": True,
             "1_0": True,
             "1_1": True,
             "2_0": True,
@@ -94,8 +95,9 @@ class TestGroupThreshold(ScoreTypeTestMixin, unittest.TestCase):
     def test_max_scores_regexp(self):
         """Test max score is correct when groups are regexp-defined."""
         s1, s2, s3 = 10.5, 30.5, 59
-        parameters = [[s1, "1_*", 10], [s2, "2_*", 20], [s3, "3_*", 30]]
-        header = ["Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
+        parameters = [[0, "0_*", 0], [s1, "1_*", 10], [s2, "2_*", 20], [s3, "3_*", 30]]
+        header = ["Subtask 0 (0)",
+                  "Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
 
         # Only group 1_* is public.
         public_testcases = dict(self._public_testcases)
@@ -120,8 +122,9 @@ class TestGroupThreshold(ScoreTypeTestMixin, unittest.TestCase):
     def test_max_scores_number(self):
         """Test max score is correct when groups are number-defined."""
         s1, s2, s3 = 10.5, 30.5, 59
-        parameters = [[s1, 2, 10], [s2, 2, 20], [s3, 2, 30]]
-        header = ["Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
+        parameters = [[0, 1, 0], [s1, 2, 10], [s2, 2, 20], [s3, 2, 30]]
+        header = ["Subtask 0 (0)",
+                  "Subtask 1 (10.5)", "Subtask 2 (30.5)", "Subtask 3 (59)"]
 
         # Only group 1_* is public.
         public_testcases = dict(self._public_testcases)
@@ -145,33 +148,58 @@ class TestGroupThreshold(ScoreTypeTestMixin, unittest.TestCase):
 
     def test_compute_score(self):
         s1, s2, s3 = 10.5, 30.5, 59
-        parameters = [[s1, "1_*", 10], [s2, "2_*", 20], [s3, "3_*", 30]]
+        parameters = [[0, "0_*", 0],
+                      [s1, "1_*", 10], [s2, "2_*", 20], [s3, "3_*", 30]]
         st = GroupThreshold(parameters, self._public_testcases)
         sr = self.get_submission_result(self._public_testcases)
 
         # All correct (below threshold).
         for evaluation in sr.evaluations:
             evaluation.outcome = 5.5
-        self.assertComputeScore(st.compute_score(sr),
-                                s1 + s2 + s3, s1, [s1, s2, s3])
+        self.assertComputeScore(
+            st.compute_score(sr),
+            s1 + s2 + s3, s1, [0, s1, s2, s3], [
+                {"idx": 0},
+                {"idx": 1},
+                {"idx": 2},
+                {"idx": 3}
+            ])
 
         # Some non-public subtask is incorrect.
         self.set_outcome(sr, "3_1", 100.5)
-        self.assertComputeScore(st.compute_score(sr),
-                                s1 + s2, s1, [s1, s2, 0])
+        self.assertComputeScore(
+            st.compute_score(sr),
+            s1 + s2, s1, [0, s1, s2, 0], [
+                {"idx": 0},
+                {"idx": 1},
+                {"idx": 2},
+                {"idx": 3}
+            ])
 
         # Also the public subtask is incorrect.
         self.set_outcome(sr, "1_0", 12.5)
         self.set_outcome(sr, "1_1", 12.5)
-        self.assertComputeScore(st.compute_score(sr),
-                                s2, 0.0, [0, s2, 0])
+        self.assertComputeScore(
+            st.compute_score(sr),
+            s2, 0.0, [0, 0, s2, 0], [
+                {"idx": 0},
+                {"idx": 1},
+                {"idx": 2},
+                {"idx": 3}
+            ])
 
         # Outcome equal to 0 is special and treated as error even if it is
         # below the threshold.
         self.set_outcome(sr, "1_0", 0.0)
         self.set_outcome(sr, "1_1", 0.0)
-        self.assertComputeScore(st.compute_score(sr),
-                                s2, 0.0, [0, s2, 0])
+        self.assertComputeScore(
+            st.compute_score(sr),
+            s2, 0.0, [0, 0, s2, 0], [
+                {"idx": 0},
+                {"idx": 1},
+                {"idx": 2},
+                {"idx": 3}
+            ])
 
 
 if __name__ == "__main__":

--- a/cmstestsuite/unit_tests/grading/scoretypes/SumTest.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/SumTest.py
@@ -60,23 +60,47 @@ class TestSum(ScoreTypeTestMixin, unittest.TestCase):
         sr = self.get_submission_result(self._public_testcases)
 
         # All correct.
-        self.assertComputeScore(st.compute_score(sr),
-                                testcase_score * 4, testcase_score, [])
+        self.assertComputeScore(
+            st.compute_score(sr),
+            testcase_score * 4, testcase_score, [], [
+                {"idx": '0'},
+                {"idx": '1'},
+                {"idx": '2'},
+                {"idx": '3'}
+            ])
 
         # Some non-public subtask is incorrect.
         self.set_outcome(sr, "3", 0.0)
-        self.assertComputeScore(st.compute_score(sr),
-                                testcase_score * 3, testcase_score, [])
+        self.assertComputeScore(
+            st.compute_score(sr),
+            testcase_score * 3, testcase_score, [], [
+                {"idx": '0'},
+                {"idx": '1'},
+                {"idx": '2'},
+                {"idx": '3'}
+            ])
 
         # Also the public subtask is incorrect.
         self.set_outcome(sr, "1", 0.0)
-        self.assertComputeScore(st.compute_score(sr),
-                                testcase_score * 2, 0.0, [])
+        self.assertComputeScore(
+            st.compute_score(sr),
+            testcase_score * 2, 0.0, [], [
+                {"idx": '0'},
+                {"idx": '1'},
+                {"idx": '2'},
+                {"idx": '3'}
+            ])
 
         # Now the public subtask has some partial scores.
         self.set_outcome(sr, "1", 0.2)
-        self.assertComputeScore(st.compute_score(sr),
-                                testcase_score * 2.2, testcase_score * 0.2, [])
+        self.assertComputeScore(
+            st.compute_score(sr),
+            testcase_score * 2.2, testcase_score * 0.2, [], [
+                {"idx": '0'},
+                {"idx": '1'},
+                {"idx": '2'},
+                {"idx": '3'}
+            ])
 
 
 if __name__ == "__main__":

--- a/cmstestsuite/unit_tests/grading/scoretypes/scoretypetestutils.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/scoretypetestutils.py
@@ -24,8 +24,10 @@ from unittest.mock import Mock
 class ScoreTypeTestMixin:
     """A test mixin to make it easier to test score types."""
 
-    def assertComputeScore(self, scores, total, public, rws_scores):
+    def assertComputeScore(self, scores, total, public, rws_scores, subtasks):
         self.assertAlmostEqual(scores[0], total)
+        self.assertEqual([{"idx": s["idx"]} for s in scores[1]],
+                         subtasks)
         self.assertAlmostEqual(scores[2], public)
         self.assertEqual(scores[4], [str(score) for score in rws_scores])
 


### PR DESCRIPTION
Does not fix (yet) #1367, because we want to make the behaviour configurable.