### PR TITLE
Set RankingWebServer listen address to "" in sample config

### DIFF
--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -142,7 +142,7 @@
     "_help": "Listening HTTP address and port for the AWS. If you access",
     "_help": "it through a proxy running on the same host you could put",
     "_help": "127.0.0.1 here for additional security.",
-    "admin_listen_address": "0.0.0.0",
+    "admin_listen_address": "",
     "admin_listen_port":    8889,
 
     "_help": "Login cookie duration for admins in seconds.",

--- a/config/cms.ranking.conf.sample
+++ b/config/cms.ranking.conf.sample
@@ -2,8 +2,10 @@
     "_help": "There is no way to put comments in a JSON file; the",
     "_help": "fields starting with '_' are meant to be comments.",
 
-    "_help": "Listening address for RankingWebServer.",
-    "bind_address": "127.0.0.1",
+    "_help": "Listening address for RankingWebServer. If you access",
+    "_help": "it through a proxy running on the same host you could put",
+    "_help": "127.0.0.1 here for additional security.",
+    "bind_address": "",
 
     "_help": "Listening port for RankingWebServer.",
     "http_port": 8890,


### PR DESCRIPTION
This matches the defaults in cms.conf.sample. In particular, this is useful because when using cms-dev.sh, the default config leaves RWS listening at 127.0.0.1, which is not accessible outside docker, even though docker-compose.dev.yml specifically exposes port 8890 for it.

Also, I changed AWS from 0.0.0.0 to `""`. `""` seems to listen on both ipv6 and ipv4, as opposed to 0.0.0.0 which is ipv4 only, so it feels like a slightly better choice here.