### PR TITLE
Round (sub)task scores to correct precision when displaying

### DIFF
--- a/cms/grading/scoring.py
+++ b/cms/grading/scoring.py
@@ -251,7 +251,7 @@ def _task_score_max_subtask(
         try:
             subtask_scores = dict(
                 (subtask["idx"],
-                 subtask["score_fraction"] * subtask["max_score"])
+                 subtask["score"])
                 for subtask in details)
         except Exception:
             subtask_scores = None

--- a/cmsranking/RankingWebServer.py
+++ b/cmsranking/RankingWebServer.py
@@ -280,8 +280,7 @@ class DataWatcher(EventSource):
         self.send(entity, "%s %s" % (event, key))
 
     def score_callback(self, user: str, task: str, score: float):
-        # FIXME Use score_precision.
-        self.send("score", "%s %s %0.2f" % (user, task, score))
+        self.send("score", "%s %s %s" % (user, task, str(score)))
 
 
 class SubListHandler:

--- a/cmstestsuite/unit_tests/grading/scoretypes/scoretypetestutils.py
+++ b/cmstestsuite/unit_tests/grading/scoretypes/scoretypetestutils.py
@@ -39,6 +39,7 @@ class ScoreTypeTestMixin:
         sr.evaluations = [
             ScoreTypeTestMixin.get_evaluation(codename, 1.0)
             for codename in reversed(sorted(testcases.keys()))]
+        sr.submission.task.score_precision = 4
         return sr
 
     @staticmethod

--- a/cmstestsuite/unit_tests/grading/scoring_test.py
+++ b/cmstestsuite/unit_tests/grading/scoring_test.py
@@ -176,7 +176,8 @@ class TestTaskScoreMaxSubtask(TaskScoreMixin, unittest.TestCase):
         return {
             "idx": idx,
             "max_score": max_score,
-            "score_fraction": score_fraction
+            "score_fraction": score_fraction,
+            "score": round(max_score * score_fraction, 4) # assume a score_precision of 4 for these tests.
         }
 
     def test_no_submissions(self):


### PR DESCRIPTION
* The headings of subtasks in the submission details view were hardcoded to a precision of 2 decimal places. Round them to the correct precision.
* Send correctly rounded scores to RWS (instead of hardcoding 2 decimal places). RWS itself already handles score_precision correctly.
* Compute task score from rounded subtask scores.

First two points are clearly bugs. The last point is a little more debatable; it would theoretically be possible to have higher precision for subtasks than for the whole task. But I feel like that could be confusing to contestants, and rarely useful.