### PR TITLE
Set listen addresses in sample config to 127.0.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,11 @@ RUN sudo pip3 install --break-system-packages .
 
 RUN sudo python3 prerequisites.py --yes --cmsuser=cmsuser install
 
-RUN sudo sed 's|/cmsuser:your_password_here@localhost:5432/cmsdb"|/postgres@testdb:5432/cmsdbfortesting"|' ./config/cms.conf.sample \
+RUN sed 's|/cmsuser:your_password_here@localhost:5432/cmsdb"|/postgres@testdb:5432/cmsdbfortesting"|' ./config/cms.conf.sample \
     | sudo tee /usr/local/etc/cms-testdb.conf
-RUN sudo sed 's|/cmsuser:your_password_here@localhost:5432/cmsdb"|/postgres@devdb:5432/cmsdb"|' ./config/cms.conf.sample \
+RUN sed -e 's|/cmsuser:your_password_here@localhost:5432/cmsdb"|/postgres@devdb:5432/cmsdb"|' -e 's/127.0.0.1/0.0.0.0/' ./config/cms.conf.sample \
     | sudo tee /usr/local/etc/cms-devdb.conf
+RUN sed 's/127.0.0.1/0.0.0.0/' ./config/cms.ranking.conf.sample | sudo tee /usr/local/etc/cms.ranking.conf
 
 ENV LANG C.UTF-8
 

--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -102,10 +102,10 @@
     "_section": "ContestWebServer",
 
     "_help": "Listening HTTP addresses and ports for the CWSs listed above",
-    "_help": "in core_services. If you access them through a proxy (acting",
-    "_help": "as a load balancer) running on the same host you could put",
-    "_help": "127.0.0.1 here for additional security.",
-    "contest_listen_address": [""],
+    "_help": "in core_services. By default only listens on localhost, meaning",
+    "_help": "you need a separate reverse proxy to access it from the web.",
+    "_help": "Set to empty string to allow connecting from anywhere.",
+    "contest_listen_address": ["127.0.0.1"],
     "contest_listen_port":    [8888],
 
     "_help": "Login cookie duration in seconds. The duration is refreshed",
@@ -139,10 +139,11 @@
 
     "_section": "AdminWebServer",
 
-    "_help": "Listening HTTP address and port for the AWS. If you access",
-    "_help": "it through a proxy running on the same host you could put",
-    "_help": "127.0.0.1 here for additional security.",
-    "admin_listen_address": "0.0.0.0",
+    "_help": "Listening HTTP address and port for the AWS. By default only",
+    "_help": "listens on localhost, meaning you need a separate reverse proxy",
+    "_help": "to access it from the web. Set to empty string to allow",
+    "_help": "connecting from anywhere.",
+    "admin_listen_address": "127.0.0.1",
     "admin_listen_port":    8889,
 
     "_help": "Login cookie duration for admins in seconds.",

--- a/config/cms.ranking.conf.sample
+++ b/config/cms.ranking.conf.sample
@@ -2,7 +2,10 @@
     "_help": "There is no way to put comments in a JSON file; the",
     "_help": "fields starting with '_' are meant to be comments.",
 
-    "_help": "Listening address for RankingWebServer.",
+    "_help": "Listening address for RankingWebServer. By default only",
+    "_help": "listens on localhost, meaning you need a separate reverse proxy",
+    "_help": "to access it from the web. Set to empty string to allow",
+    "_help": "connecting from anywhere.",
     "bind_address": "127.0.0.1",
 
     "_help": "Listening port for RankingWebServer.",


### PR DESCRIPTION
See #1397.

the cms-test config file isn't altered, as the test machine doesn't need to be accessible from outside.