### PR TITLE
Render announcements, question replies, and messages as markdown

### DIFF
--- a/cms/db/user.py
+++ b/cms/db/user.py
@@ -336,6 +336,12 @@ class Question(Base):
 
     MAX_SUBJECT_LENGTH = 50
     MAX_TEXT_LENGTH = 2000
+    QUICK_ANSWERS = {
+        "yes": "Yes",
+        "no": "No",
+        "invalid": "Invalid Question (not a Yes/No Question)",
+        "nocomment": "No Comment/Please refer to task statement",
+    }
 
     # Auto increment primary key.
     id: int = Column(

--- a/cms/server/admin/handlers/__init__.py
+++ b/cms/server/admin/handlers/__init__.py
@@ -73,7 +73,8 @@ from .main import \
     LoginHandler, \
     LogoutHandler, \
     ResourcesHandler, \
-    NotificationsHandler
+    NotificationsHandler, \
+    MarkdownRenderHandler
 from .submission import \
     SubmissionHandler, \
     SubmissionCommentHandler, \
@@ -113,6 +114,7 @@ HANDLERS = [
     (r"/resources/([0-9]+|all)/([0-9]+)", ResourcesHandler),
     (r"/notifications", NotificationsHandler),
     (r"/file/([a-f0-9]+)/([a-zA-Z0-9_.-]+)", FileFromDigestHandler),
+    (r"/render_markdown", MarkdownRenderHandler),
 
     # Contest
 

--- a/cms/server/admin/handlers/contestquestion.py
+++ b/cms/server/admin/handlers/contestquestion.py
@@ -68,16 +68,14 @@ class QuestionReplyHandler(BaseHandler):
     """Called when the manager replies to a question made by a user.
 
     """
-    QUICK_ANSWERS = {
-        "yes": "Yes",
-        "no": "No",
-        "invalid": "Invalid Question (not a Yes/No Question)",
-        "nocomment": "No Comment/Please refer to task statement",
-    }
 
     @require_permission(BaseHandler.PERMISSION_MESSAGING)
     def post(self, contest_id, question_id):
-        ref = self.url("contest", contest_id, "questions")
+        userid = self.get_argument("user_id", None)
+        if userid is not None:
+            ref = self.url("contest", contest_id, "user", userid, "edit")
+        else:
+            ref = self.url("contest", contest_id, "questions")
         question = self.safe_get_item(Question, question_id)
         self.contest = self.safe_get_item(Contest, contest_id)
 
@@ -90,12 +88,12 @@ class QuestionReplyHandler(BaseHandler):
         question.reply_text = self.get_argument("reply_question_text", "")
 
         # Ignore invalid answers
-        if reply_subject_code not in QuestionReplyHandler.QUICK_ANSWERS:
+        if reply_subject_code not in Question.QUICK_ANSWERS:
             question.reply_subject = ""
         else:
             # Quick answer given, ignore long answer.
             question.reply_subject = \
-                QuestionReplyHandler.QUICK_ANSWERS[reply_subject_code]
+                Question.QUICK_ANSWERS[reply_subject_code]
             question.reply_text = ""
 
         question.reply_timestamp = make_datetime()
@@ -118,7 +116,11 @@ class QuestionIgnoreHandler(BaseHandler):
     """
     @require_permission(BaseHandler.PERMISSION_MESSAGING)
     def post(self, contest_id, question_id):
-        ref = self.url("contest", contest_id, "questions")
+        userid = self.get_argument("user_id", None)
+        if userid is not None:
+            ref = self.url("contest", contest_id, "user", userid, "edit")
+        else:
+            ref = self.url("contest", contest_id, "questions")
         question = self.safe_get_item(Question, question_id)
         self.contest = self.safe_get_item(Contest, contest_id)
 
@@ -147,7 +149,11 @@ class QuestionClaimHandler(BaseHandler):
 
     @require_permission(BaseHandler.PERMISSION_MESSAGING)
     def post(self, contest_id, question_id):
-        ref = self.url("contest", contest_id, "questions")
+        userid = self.get_argument("user_id", None)
+        if userid is not None:
+            ref = self.url("contest", contest_id, "user", userid, "edit")
+        else:
+            ref = self.url("contest", contest_id, "questions")
         question = self.safe_get_item(Question, question_id)
         self.contest = self.safe_get_item(Contest, contest_id)
 

--- a/cms/server/admin/handlers/main.py
+++ b/cms/server/admin/handlers/main.py
@@ -30,6 +30,7 @@ import logging
 
 from cms import ServiceCoord, get_service_shards, get_service_address
 from cms.db import Admin, Contest, Question
+from cms.server.jinja2_toolbox import markdown_filter
 from cmscommon.crypto import validate_password
 from cmscommon.datetime import make_datetime, make_timestamp
 from .base import BaseHandler, SimpleHandler, require_permission
@@ -167,3 +168,13 @@ class NotificationsHandler(BaseHandler):
         self.service.notifications = []
 
         self.write(json.dumps(res))
+
+class MarkdownRenderHandler(BaseHandler):
+    """Renders Markdown for AWS message previews."""
+
+    @require_permission(BaseHandler.AUTHENTICATED)
+    def post(self):
+        data = self.get_argument("input")
+        rendered = markdown_filter(data)
+        self.write(rendered)
+

--- a/cms/server/admin/jinja2_toolbox.py
+++ b/cms/server/admin/jinja2_toolbox.py
@@ -25,6 +25,7 @@ useful specifically to the use that AWS makes of it.
 
 from jinja2 import Environment, PackageLoader
 
+from cms.db.user import Question
 from cms.grading.languagemanager import LANGUAGES
 from cms.grading.scoretypes import SCORE_TYPES
 from cms.grading.tasktypes import TASK_TYPES
@@ -47,6 +48,7 @@ def instrument_cms_toolbox(env: Environment):
     env.globals["LANGUAGES"] = LANGUAGES
     env.globals["get_hex_random_key"] = get_hex_random_key
     env.globals["parse_authentication"] = safe_parse_authentication
+    env.globals["question_quick_answers"] = Question.QUICK_ANSWERS
 
 
 def instrument_formatting_toolbox(env: Environment):

--- a/cms/server/admin/static/aws_style.css
+++ b/cms/server/admin/static/aws_style.css
@@ -52,6 +52,10 @@ strong, .bold {
     font-weight: bold;
 }
 
+em {
+    font-style: italic;
+}
+
 .login_error {
     color: #F31313;
 }
@@ -420,7 +424,7 @@ th .column-sort {
   text-decoration: underline;
 }
 
-.reply_question textarea {
+.markdown_input {
     width: 100%;
 }
 

--- a/cms/server/admin/static/aws_utils.js
+++ b/cms/server/admin/static/aws_utils.js
@@ -849,10 +849,29 @@ CMS.AWSUtils.prototype.question_reply_toggle = function(event, invoker) {
  * Updates visibility of answer box when choosing quick answers.
  */
 CMS.AWSUtils.prototype.update_additional_answer = function(event, invoker) {
-    var obj = invoker.parentElement.querySelector(".alternative_answer");
+    var obj = $(invoker).parent().find(".alternative_answer");
     if (invoker.value == "other") {
-        obj.style.display = "block";
+        obj.css("display", "");
     } else {
-        obj.style.display = "none";
+        obj.css("display", "none");
     }
+}
+
+/**
+ * Used by templates/macro/markdown_input.html.
+ * Asks the server to render the markdown input and displays it.
+ */
+CMS.AWSUtils.prototype.render_markdown_preview = function(target) {
+    var form_element = $(target).closest("form");
+    var md_text = form_element.find(".markdown_input").val();
+    $.ajax({
+        type: "POST",
+        url: this.url("render_markdown"),
+        data: {input: md_text},
+        dataType: "text",
+        headers: {"X-XSRFToken": get_cookie("_xsrf")},
+        success: function(response) {
+            form_element.find(".markdown_preview").html(response);
+        },
+    });
 }

--- a/cms/server/admin/static/aws_utils.js
+++ b/cms/server/admin/static/aws_utils.js
@@ -826,3 +826,33 @@ CMS.AWSUtils.ajax_delete = function(url) {
 CMS.AWSUtils.ajax_post = function(url) {
     CMS.AWSUtils.ajax_edit_request("POST", url);
 };
+
+
+/**
+ * Used by templates/macro/question.html.
+ * Toggles visibility of the question reply box.
+ */
+CMS.AWSUtils.prototype.question_reply_toggle = function(event, invoker) {
+    var obj = invoker.parentElement.parentElement.querySelector(".reply_question");
+    if (obj.style.display != "block") {
+        obj.style.display = "block";
+        invoker.innerHTML = "Hide reply";
+    } else {
+        obj.style.display = "none";
+        invoker.innerHTML = "Reply";
+    }
+    event.preventDefault();
+}
+
+/**
+ * Used by templates/macro/question.html.
+ * Updates visibility of answer box when choosing quick answers.
+ */
+CMS.AWSUtils.prototype.update_additional_answer = function(event, invoker) {
+    var obj = invoker.parentElement.querySelector(".alternative_answer");
+    if (invoker.value == "other") {
+        obj.style.display = "block";
+    } else {
+        obj.style.display = "none";
+    }
+}

--- a/cms/server/admin/templates/announcements.html
+++ b/cms/server/admin/templates/announcements.html
@@ -24,7 +24,8 @@
           </div>
           <div class="notification_text">
             <label for="new_text">Text</label>
-            <textarea name="text" id="new_text" style="width: 100%" ></textarea>
+            <textarea name="text" id="new_text" style="width: 100%" ></textarea><br/>
+            You can use Markdown here. URLs are not automatically linked, surround them with &lt;&gt; like &lt;http://example.org&gt;.
           </div>
           <input type="submit"
                  value="Add announcement" />

--- a/cms/server/admin/templates/announcements.html
+++ b/cms/server/admin/templates/announcements.html
@@ -44,7 +44,7 @@
           </div>
           <div class="notification_timestamp">{{ msg.timestamp }}</div>
           <div class="notification_subject">{{ msg.subject }}</div>
-          <div class="notification_text preserve_line_breaks">{{ msg.text }}</div>
+          <div class="notification_text">{{ msg.text | markdown }}</div>
           <hr>
           <div class="notification_admin_owner">
             By: {{ msg.admin.name if msg.admin is not none else "<unknown>" }}

--- a/cms/server/admin/templates/announcements.html
+++ b/cms/server/admin/templates/announcements.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import 'macro/markdown_input.html' as macro_markdown %}
 
 {% block core %}
 <div class="core_title">
@@ -23,12 +24,12 @@
             </datalist>
           </div>
           <div class="notification_text">
-            <label for="new_text">Text</label>
-            <textarea name="text" id="new_text" style="width: 100%" ></textarea><br/>
-            You can use Markdown here. URLs are not automatically linked, surround them with &lt;&gt; like &lt;http://example.org&gt;.
+            <label for="text">Text</label>
+            {{ macro_markdown.markdown_input("text") }}
           </div>
           <input type="submit"
                  value="Add announcement" />
+          {{ macro_markdown.markdown_preview() }}
         </form>
       </div>
     </div>

--- a/cms/server/admin/templates/macro/markdown_input.html
+++ b/cms/server/admin/templates/macro/markdown_input.html
@@ -1,0 +1,9 @@
+{% macro markdown_input(name) %}
+<textarea name="{{ name }}" class="markdown_input"></textarea><br/>
+You can use Markdown here. URLs are not automatically linked, surround them with &lt;&gt; like &lt;http://example.org&gt;.
+<div class="markdown_preview"></div>
+{% endmacro %}
+
+{% macro markdown_preview() %}
+<input type="button" value="Preview Markdown" onclick="utils.render_markdown_preview(this)" />
+{% endmacro %}

--- a/cms/server/admin/templates/macro/question.html
+++ b/cms/server/admin/templates/macro/question.html
@@ -23,7 +23,7 @@ user_id (int|None): if we are rendering a single user's questions, this is the
     {% if msg.reply_timestamp is not none %}
       <hr>
       <div class="notification_subject">Reply: {{ msg.reply_subject }}</div>
-      <div class="notification_text preserve_line_breaks">{{ msg.reply_text }}</div>
+      <div class="notification_text">{{ msg.reply_text | markdown }}</div>
       <hr>
       <div class="notification_admin_owner">
         Reply from: {{ msg.admin.name if msg.admin is not none else "<unknown>" }}</div>

--- a/cms/server/admin/templates/macro/question.html
+++ b/cms/server/admin/templates/macro/question.html
@@ -1,5 +1,7 @@
 {# This macro should be imported "with context". #}
 
+{% import 'macro/markdown_input.html' as macro_markdown %}
+
 {% macro question(msg, user_id) %}
 {#
 Render one question by a participant.
@@ -96,10 +98,12 @@ user_id (int|None): if we are rendering a single user's questions, this is the
         <br/>
         <div class="alternative_answer">
           Alternative answer:<br/>
-          <textarea name="reply_question_text"></textarea><br/>
-          You can use Markdown here. URLs are not automatically linked, surround them with &lt;&gt; like &lt;http://example.org&gt;.
+          {{ macro_markdown.markdown_input("reply_question_text") }}
         </div>
         <input type="submit" value="Send"/>
+        <span class="alternative_answer">
+          {{ macro_markdown.markdown_preview() }}
+        </span>
       </form>
     </div>
 {% endif %}

--- a/cms/server/admin/templates/macro/question.html
+++ b/cms/server/admin/templates/macro/question.html
@@ -7,8 +7,9 @@
 Render one question by a participant.
 
 msg (Question): the question object.
-user_id (int|None): if we are rendering a single user's questions, this is the
-    user's id. if we are rendering all questions of the contest, then None.
+user_id (int|None): if we are rendering one of the questions on a single user's
+    page, this is the user's id. if we are rendering one of the questions on
+    the contest questions page, then None.
 #}
 <div class="notification communication {{ ("answered" if msg.reply_timestamp is not none else ("ignored" if msg.ignored else "")) }}">
   <div class="notification_msg">

--- a/cms/server/admin/templates/macro/question.html
+++ b/cms/server/admin/templates/macro/question.html
@@ -1,0 +1,108 @@
+{# This macro should be imported "with context". #}
+
+{% macro question(msg, user_id) %}
+{#
+Render one question by a participant.
+
+msg (Question): the question object.
+user_id (int|None): if we are rendering a single user's questions, this is the
+    user's id. if we are rendering all questions of the contest, then None.
+#}
+<div class="notification communication {{ ("answered" if msg.reply_timestamp is not none else ("ignored" if msg.ignored else "")) }}">
+  <div class="notification_msg">
+    <div class="notification_timestamp">
+      {% if user_id is none %}
+        <a href="{{ url("contest", contest.id, "user", msg.participation.user.id, "edit") }}" title="{{ msg.participation.user.first_name }} {{ msg.participation.user.last_name }}">{{ msg.participation.user.username }}</a> &mdash;
+      {% endif %}
+      {{ msg.question_timestamp }}
+    </div>
+    <div class="notification_subject">{{ msg.subject }}</div>
+    <div class="notification_text preserve_line_breaks">{{ msg.text }}</div>
+    {% if msg.reply_timestamp is not none %}
+      <hr>
+      <div class="notification_subject">Reply: {{ msg.reply_subject }}</div>
+      <div class="notification_text preserve_line_breaks">{{ msg.reply_text }}</div>
+      <hr>
+      <div class="notification_admin_owner">
+        Reply from: {{ msg.admin.name if msg.admin is not none else "<unknown>" }}</div>
+    {% else %}
+      <hr>
+      <div class="notification_subject">Not yet replied.</div>
+      <hr>
+      {% if msg.admin is not none %}
+        <div class="notification_admin_owner">
+          {{ "Ignored" if msg.ignored else "Claimed" }} by: {{ msg.admin.name }}
+        </div>
+      {% endif %}
+    {% endif %}
+    {% if admin.permission_all or admin.permission_messaging %}
+      {% if msg.reply_timestamp is none %}
+        {% if not msg.ignored %}
+          <div class="claim_reply">
+            <form class="claim_question_form" action="{{ url("contest", contest.id, "question", msg.id, "claim") }}" name="claim{{ msg.id }}" method="POST">
+              {{ xsrf_form_html|safe }}
+              {% if user_id is not none %}
+                <input type="hidden" name="user_id" value="{{ user_id }}" />
+              {% endif %}
+              {% if msg.admin is none %}
+                <input type="hidden" name="claim" value="yes"/>
+                <a href="javascript:void(0);" onclick="document.claim{{ msg.id }}.submit();">Claim</a>
+              {% else %}
+                <input type="hidden" name="claim" value="no"/>
+                <a href="javascript:void(0);" onclick="document.claim{{ msg.id }}.submit();">Unclaim</a>
+              {% endif %}
+            </form>
+          </div>
+      {% endif %}
+    <div class="ignore_reply">
+      <form class="ignore_question_form" action="{{ url("contest", contest.id, "question", msg.id, "ignore") }}" name="ignore{{ msg.id }}" method="POST">
+        {{ xsrf_form_html|safe }}
+        {% if user_id is not none %}
+          <input type="hidden" name="user_id" value="{{ user_id }}" />
+        {% endif %}
+        {% if not msg.ignored %}
+          <input type="hidden" name="ignore" value="yes"/>
+          <a href="javascript:void(0);" onclick="document.ignore{{ msg.id }}.submit();">Ignore</a>
+        {% else %}
+          <input type="hidden" name="ignore" value="no"/>
+          <a href="javascript:void(0);" onclick="document.ignore{{ msg.id }}.submit();">Unignore</a>
+        {% endif %}
+      </form>
+    </div>
+    {% endif %}
+    <div class="reply_question_toggle">
+      <a href="javascript:void(0);" onclick="utils.question_reply_toggle(event, this);">
+    {% if msg.reply_timestamp is none %}
+        Reply
+    {% else %}
+        Edit reply
+    {% endif %}
+      </a>
+    </div>
+    <div class="reply_question">
+      <hr/>
+      <form class="reply_question_form" action="{{ url("contest", contest.id, "question", msg.id, "reply") }}" method="POST">
+        {{ xsrf_form_html|safe }}
+        {% if user_id is not none %}
+          <input type="hidden" name="user_id" value="{{ user_id }}" />
+        {% endif %}
+        Precompiled answer:
+        <select name="reply_question_quick_answer" onchange="utils.update_additional_answer(event, this);">
+          {% for key, value in question_quick_answers.items() %}
+            <option value="{{ key }}">{{ value }}</option>
+          {% endfor %}
+          <option value="other" selected>Other</option>
+        </select>
+        <br/>
+        <div class="alternative_answer">
+          Alternative answer:<br/>
+          <textarea name="reply_question_text"></textarea><br/>
+          You can use Markdown here. URLs are not automatically linked, surround them with &lt;&gt; like &lt;http://example.org&gt;.
+        </div>
+        <input type="submit" value="Send"/>
+      </form>
+    </div>
+{% endif %}
+  </div>
+</div>
+{% endmacro %}

--- a/cms/server/admin/templates/participation.html
+++ b/cms/server/admin/templates/participation.html
@@ -179,6 +179,7 @@ function update_additional_answer(element, invoker)
             <div class="alternative_answer">
               Alternative answer:<br/>
               <textarea name="reply_question_text"></textarea><br/>
+              You can use Markdown here. URLs are not automatically linked, surround them with &lt;&gt; like &lt;http://example.org&gt;.
             </div>
             <input type="submit" value="Send"/>
           </form>
@@ -210,7 +211,8 @@ function update_additional_answer(element, invoker)
             </div>
             <div class="notification_text">
               Text:
-              <textarea name="message_text" style="width: 100%" ></textarea>
+              <textarea name="message_text" style="width: 100%" ></textarea><br/>
+              You can use Markdown here. URLs are not automatically linked, surround them with &lt;&gt; like &lt;http://example.org&gt;.
             </div>
           <input type="submit" value="Send"/>
           </div>

--- a/cms/server/admin/templates/participation.html
+++ b/cms/server/admin/templates/participation.html
@@ -2,33 +2,7 @@
 
 {% extends "base.html" %}
 {% import 'macro/submission.html' as macro_submission %}
-
-{% block js %}
-function question_reply_toggle(element, invoker)
-{
-  var obj = document.getElementsByClassName("reply_question")[element];
-  if (obj.style.display != "block")
-    {
-      obj.style.display = "block";
-      invoker.innerHTML = "Hide reply";
-    }
-  else
-    {
-      obj.style.display = "none";
-      invoker.innerHTML = "Reply";
-    }
-  return false;
-}
-
-function update_additional_answer(element, invoker)
-{
-  var obj = document.getElementsByClassName("alternative_answer")[element];
-  if (invoker.selectedIndex == 5)
-    obj.style.display = "block";
-  else
-    obj.style.display = "none";
-}
-{% endblock js %}
+{% import 'macro/question.html' as macro_question with context %}
 
 {% block core %}
 <h1>
@@ -148,44 +122,7 @@ function update_additional_answer(element, invoker)
   {% if participation.questions != [] %}
   <div class="notifications">
     {% for msg in participation.questions %}
-    <div class="notification communication">
-      <div class="notification_msg">
-        <div class="notification_timestamp">{{ msg.question_timestamp }}</div>
-        <div class="notification_subject">{{ msg.subject }}</div>
-        <div class="notification_text preserve_line_breaks">{{ msg.text }}</div>
-        {% if msg.reply_timestamp is not none %}
-        <div class="notification_subject">Reply. {{ msg.reply_subject }}</div>
-        <div class="notification_text preserve_line_breaks">{{ msg.reply_text }}</div>
-        {% else %}
-        <div class="notification_subject">Not yet replied.</div>
-        {% endif %}
-        <div class="reply_question_toggle">
-          <a href="javascript:void(0);" onclick="return question_reply_toggle({{ loop.index0 }}, this);">Reply</a>
-        </div>
-        <div class="reply_question" >
-          <hr/>
-          <form class="reply_question_form" action="{{ url("contest", contest.id, "question", msg.id, "reply") }}" method="POST">
-            {{ xsrf_form_html|safe }}
-            <input type="hidden" name="ref" value="/contest/{{ contest.id }}/user/{{ selected_user.id }}/edit"/>
-            Precompiled answer:
-            <select name="reply_question_quick_answer" onchange="update_additional_answer({{ loop.index0 }}, this);">
-              <option value="yes">Yes</option>
-              <option value="no">No</option>
-              <option value="invalid">Invalid Question (not a Yes/No Question)</option>
-              <option value="nocomment">No Comment/Please refer to task statement</option>
-              <option selected value="other">Other</option>
-            </select>
-            <br/>
-            <div class="alternative_answer">
-              Alternative answer:<br/>
-              <textarea name="reply_question_text"></textarea><br/>
-              You can use Markdown here. URLs are not automatically linked, surround them with &lt;&gt; like &lt;http://example.org&gt;.
-            </div>
-            <input type="submit" value="Send"/>
-          </form>
-        </div>
-      </div>
-    </div>
+      {{ macro_question.question(msg, selected_user.id) }}
     {% endfor %}
   </div>
 

--- a/cms/server/admin/templates/participation.html
+++ b/cms/server/admin/templates/participation.html
@@ -164,7 +164,7 @@
         <div class="notification_msg">
           <div class="notification_timestamp">{{ msg.timestamp }}</div>
           <div class="notification_subject">{{ msg.subject }}</div>
-          <div class="notification_text preserve_line_breaks">{{ msg.text }}</div>
+          <div class="notification_text">{{ msg.text | markdown }}</div>
           <hr>
           <div class="notification_admin_owner">
             By: {{ msg.admin.name if msg.admin is not none else "<unknown>" }}

--- a/cms/server/admin/templates/participation.html
+++ b/cms/server/admin/templates/participation.html
@@ -3,6 +3,7 @@
 {% extends "base.html" %}
 {% import 'macro/submission.html' as macro_submission %}
 {% import 'macro/question.html' as macro_question with context %}
+{% import 'macro/markdown_input.html' as macro_markdown %}
 
 {% block core %}
 <h1>
@@ -148,10 +149,10 @@
             </div>
             <div class="notification_text">
               Text:
-              <textarea name="message_text" style="width: 100%" ></textarea><br/>
-              You can use Markdown here. URLs are not automatically linked, surround them with &lt;&gt; like &lt;http://example.org&gt;.
+              {{ macro_markdown.markdown_input("message_text") }}
             </div>
           <input type="submit" value="Send"/>
+          {{ macro_markdown.markdown_preview() }}
           </div>
         </form>
       </div>

--- a/cms/server/admin/templates/questions.html
+++ b/cms/server/admin/templates/questions.html
@@ -1,31 +1,5 @@
 {% extends "base.html" %}
-
-{% block js %}
-function question_reply_toggle(element, invoker)
-{
-  var obj = document.getElementsByClassName("reply_question")[element];
-  if (obj.style.display != "block")
-    {
-      obj.style.display = "block";
-      invoker.innerHTML = "Hide reply";
-    }
-  else
-    {
-      obj.style.display = "none";
-      invoker.innerHTML = "Reply";
-    }
-  return false;
-}
-
-function update_additional_answer(element, invoker)
-{
-  var obj = document.getElementsByClassName("alternative_answer")[element];
-  if (invoker.selectedIndex == 5)
-    obj.style.display = "block";
-  else
-    obj.style.display = "none";
-}
-{% endblock js %}
+{% import 'macro/question.html' as macro_question with context %}
 
 {% block js_init %}
 
@@ -43,92 +17,7 @@ utils.show_page("questions", 1);
   <div id="page_selector_questions"></div>
   <div id="paged_content_questions">
   {% for msg in questions %}
-  <div class="notification communication {{ ("answered" if msg.reply_timestamp is not none else ("ignored" if msg.ignored else "")) }}">
-    <div class="notification_msg">
-      <div class="notification_timestamp">
-        <a href="{{ url("contest", contest.id, "user", msg.participation.user.id, "edit") }}" title="{{ msg.participation.user.first_name }} {{ msg.participation.user.last_name }}">{{ msg.participation.user.username }}</a> &mdash; {{ msg.question_timestamp }}
-      </div>
-      <div class="notification_subject">{{ msg.subject }}</div>
-      <div class="notification_text preserve_line_breaks">{{ msg.text }}</div>
-      {% if msg.reply_timestamp is not none %}
-      <hr>
-      <div class="notification_subject">Reply: {{ msg.reply_subject }}</div>
-      <div class="notification_text preserve_line_breaks">{{ msg.reply_text }}</div>
-      <hr>
-      <div class="notification_admin_owner">
-        Reply from: {{ msg.admin.name if msg.admin is not none else "<unknown>" }}</div>
-      {% else %}
-      <hr>
-      <div class="notification_subject">Not yet replied.</div>
-      <hr>
-        {% if msg.admin is not none %}
-      <div class="notification_admin_owner">
-        {{ "Ignored" if msg.ignored else "Claimed" }} by: {{ msg.admin.name }}
-      </div>
-        {% endif %}
-      {% endif %}
-{% if admin.permission_all or admin.permission_messaging %}
-      {% if msg.reply_timestamp is none %}
-        {% if not msg.ignored %}
-      <div class="claim_reply">
-        <form class="claim_question_form" action="{{ url("contest", contest.id, "question", msg.id, "claim") }}" name="claim{{ msg.id }}" method="POST">
-          {{ xsrf_form_html|safe }}
-          {% if msg.admin is none %}
-          <input type="hidden" name="claim" value="yes"/>
-          <a href="javascript:void(0);" onclick="document.claim{{ msg.id }}.submit();">Claim</a>
-          {% else %}
-          <input type="hidden" name="claim" value="no"/>
-          <a href="javascript:void(0);" onclick="document.claim{{ msg.id }}.submit();">Unclaim</a>
-          {% endif %}
-        </form>
-      </div>
-        {% endif %}
-      <div class="ignore_reply">
-        <form class="ignore_question_form" action="{{ url("contest", contest.id, "question", msg.id, "ignore") }}" name="ignore{{ msg.id }}" method="POST">
-          {{ xsrf_form_html|safe }}
-          {% if not msg.ignored %}
-          <input type="hidden" name="ignore" value="yes"/>
-          <a href="javascript:void(0);" onclick="document.ignore{{ msg.id }}.submit();">Ignore</a>
-          {% else %}
-          <input type="hidden" name="ignore" value="no"/>
-          <a href="javascript:void(0);" onclick="document.ignore{{ msg.id }}.submit();">Unignore</a>
-          {% endif %}
-        </form>
-      </div>
-      {% endif %}
-      <div class="reply_question_toggle">
-        <a href="javascript:void(0);" onclick="return question_reply_toggle({{ loop.index0 }}, this);">
-      {% if msg.reply_timestamp is none %}
-          Reply
-      {% else %}
-          Edit reply
-      {% endif %}
-        </a>
-      </div>
-      <div class="reply_question" >
-        <hr/>
-        <form class="reply_question_form" action="{{ url("contest", contest.id, "question", msg.id, "reply") }}" method="POST">
-          {{ xsrf_form_html|safe }}
-          Precompiled answer:
-          <select name="reply_question_quick_answer" onchange="update_additional_answer({{ loop.index0 }}, this);">
-            <option value="yes">Yes</option>
-            <option value="no">No</option>
-            <option value="invalid">Invalid Question (not a Yes/No Question)</option>
-            <option value="nocomment">No Comment/Please refer to task statement</option>
-            <option selected value="other">Other</option>
-          </select>
-          <br/>
-          <div class="alternative_answer">
-            Alternative answer:<br/>
-            <textarea name="reply_question_text"></textarea><br/>
-            You can use Markdown here. URLs are not automatically linked, surround them with &lt;&gt; like &lt;http://example.org&gt;.
-          </div>
-          <input type="submit" value="Send"/>
-        </form>
-      </div>
-{% endif %}
-    </div>
-  </div>
+    {{ macro_question.question(msg, none) }}
   {% endfor %}
   </div>
 </div>

--- a/cms/server/admin/templates/questions.html
+++ b/cms/server/admin/templates/questions.html
@@ -121,6 +121,7 @@ utils.show_page("questions", 1);
           <div class="alternative_answer">
             Alternative answer:<br/>
             <textarea name="reply_question_text"></textarea><br/>
+            You can use Markdown here. URLs are not automatically linked, surround them with &lt;&gt; like &lt;http://example.org&gt;.
           </div>
           <input type="submit" value="Send"/>
         </form>

--- a/cms/server/contest/static/cws_style.css
+++ b/cms/server/contest/static/cws_style.css
@@ -92,6 +92,11 @@ div.question_list div.answer div.body,
 div.message_list div.message div.body {
     padding-top: 5px;
     clear: both;
+}
+
+/* admin-sent messages have markdown formatting and thus don't need
+ * mucking with whitespace, but user questions are plaintext */
+div.question_list div.question div.body {
     white-space: pre-line;
 }
 

--- a/cms/server/contest/templates/communication.html
+++ b/cms/server/contest/templates/communication.html
@@ -22,7 +22,7 @@
         {% endif %}
         <span class="timestamp">{{ msg.timestamp|format_datetime_smart }}</span>
         {% if msg.text|length > 0 %}
-        <div class="body">{{ msg.text }}</div>
+        <div class="body">{{ msg.text | markdown }}</div>
         {% endif %}
     </div>
     {% endfor %}
@@ -91,7 +91,7 @@
             {% endif %}
         <span class="timestamp">{{ msg.reply_timestamp|format_datetime_smart }}</span>
             {% if msg.reply_text|length > 0 %}
-        <div class="body">{{ msg.reply_text }}</div>
+        <div class="body">{{ msg.reply_text | markdown }}</div>
             {% endif %}
     </div>
         {% else %}
@@ -118,7 +118,7 @@
         {% endif %}
         <span class="timestamp">{{ msg.timestamp|format_datetime_smart }}</span>
         {% if msg.text|length > 0 %}
-        <div class="body">{{ msg.text }}</div>
+        <div class="body">{{ msg.text | markdown }}</div>
         {% endif %}
     </div>
     {% endfor %}

--- a/cms/server/jinja2_toolbox.py
+++ b/cms/server/jinja2_toolbox.py
@@ -28,6 +28,8 @@ from datetime import datetime, timedelta, tzinfo
 from jinja2 import Environment, StrictUndefined, contextfilter, \
     contextfunction, environmentfunction
 from jinja2.runtime import Context
+import markdown_it
+import markupsafe
 
 from cms import TOKEN_MODE_DISABLED, TOKEN_MODE_FINITE, TOKEN_MODE_INFINITE, \
     TOKEN_MODE_MIXED, FEEDBACK_LEVEL_FULL, FEEDBACK_LEVEL_RESTRICTED, \
@@ -138,6 +140,19 @@ def today(ctx: Context, dt: datetime) -> bool:
         == now.replace(tzinfo=utc).astimezone(timezone).date()
 
 
+def markdown_filter(text: str) -> markupsafe.Markup:
+    """Renders text as markdown and returns a Markup object
+    corresponding to it.
+
+    text: The markdown text to render.
+
+    return: rendered HTML wrapped in the Markup class.
+    """
+    md = markdown_it.MarkdownIt('js-default')
+    html = md.render(text)
+    return markupsafe.Markup(html)
+
+
 def instrument_generic_toolbox(env: Environment):
     env.globals["iter"] = iter
     env.globals["next"] = next
@@ -163,6 +178,7 @@ def instrument_generic_toolbox(env: Environment):
     env.filters["any"] = any_
     env.filters["dictselect"] = dictselect
     env.filters["make_timestamp"] = make_timestamp
+    env.filters["markdown"] = markdown_filter
 
     env.tests["contains"] = lambda s, p: p in s
     env.tests["endswith"] = lambda s, p: s.endswith(p)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ chardet>=3.0,<5.3  # https://pypi.python.org/pypi/chardet
 babel==2.12.1  # http://babel.pocoo.org/en/latest/changelog.html
 pyxdg>=0.26,<0.29  # https://freedesktop.org/wiki/Software/pyxdg/
 Jinja2>=2.10,<2.11  # http://jinja.pocoo.org/docs/latest/changelog/
+markdown-it-py==3.0.0  # https://github.com/executablebooks/markdown-it-py/blob/master/CHANGELOG.md
 
 # See https://github.com/pallets/markupsafe/issues/286 but breaking change in
 # MarkupSafe causes jinja to break


### PR DESCRIPTION
Closes #1352, closes #1362.

I actually realized that i had forgotten messages to users in my original implementation; this one handles those too.

I switched out the markdown parser to one that allows disabling html tags.