### PR TITLE
Optimize some unit tests

### DIFF
--- a/cmscommon/crypto.py
+++ b/cmscommon/crypto.py
@@ -48,6 +48,9 @@ __all__ = [
 
 _RANDOM = Random.new()
 
+# bcrypt difficulty parameter. This is here so that it can be set to a lower
+# value when running unit tests. It seems that the lowest accepted value is 4.
+BCRYPT_ROUNDS = 12
 
 def get_random_key() -> bytes:
     """Generate 16 random bytes, safe to be used as AES key.
@@ -226,7 +229,8 @@ def hash_password(password: str, method: str = "bcrypt") -> str:
     """
     if method == "bcrypt":
         password_bytes = password.encode("utf-8")
-        payload = bcrypt.hashpw(password_bytes, bcrypt.gensalt()).decode("ascii")
+        salt = bcrypt.gensalt(BCRYPT_ROUNDS)
+        payload = bcrypt.hashpw(password_bytes, salt).decode("ascii")
     elif method == "plaintext":
         payload = password
     else:

--- a/cmstestsuite/unit_tests/conftest.py
+++ b/cmstestsuite/unit_tests/conftest.py
@@ -1,0 +1,7 @@
+# This file is meant to be used for creating pytest fixtures.
+# It's a bit of a hack, but we can put global initialization here.
+
+# Make bcrypt run faster in tests. Default difficulty is 12,
+# which takes around 250ms per hash. This one takes <1ms.
+import cmscommon.crypto
+cmscommon.crypto.BCRYPT_ROUNDS = 4

--- a/cmstestsuite/unit_tests/server/file_middleware_test.py
+++ b/cmstestsuite/unit_tests/server/file_middleware_test.py
@@ -38,8 +38,7 @@ TESTFILE_LEN = FileCacher.CHUNK_SIZE + 128
 class TestFileByDigestMiddleware(unittest.TestCase):
 
     def setUp(self):
-        self.content = \
-            bytes(random.getrandbits(8) for _ in range(TESTFILE_LEN))
+        self.content = random.randbytes(TESTFILE_LEN)
         self.digest = bytes_digest(self.content)
 
         self.filename = "foobar.pdf"


### PR DESCRIPTION
* Some tests end up having to hash passwords. Add a tweak that allows setting the hashing difficulty to a lower value for the tests.
* file_middleware_test had a really inefficient setUp() method, which matters more now that the FileCacher block size is 1MB.

This should save around 10 seconds in CI (according to codecov test timings).