### PR TITLE
Remove use of patoolib, along with other archive-related improvements

### DIFF
--- a/cms/server/contest/submission/file_retrieval.py
+++ b/cms/server/contest/submission/file_retrieval.py
@@ -33,6 +33,7 @@ format.
 
 """
 
+import io
 import os.path
 import typing
 
@@ -40,7 +41,7 @@ from patoolib.util import PatoolError
 if typing.TYPE_CHECKING:
     from tornado.httputil import HTTPFile
 
-from cmscommon.archive import Archive
+from cmscommon.archive import open_archive
 
 
 # Represents a file received through HTTP from an HTML form.
@@ -57,10 +58,21 @@ class ReceivedFile(typing.NamedTuple):
 class InvalidArchive(Exception):
     """Raised when the archive submitted by the user cannot be opened."""
 
-    pass
+    def __init__(self, too_big: bool = False, too_many_files: bool = False):
+        """
+        too_big: Whether the InvalidArchive was raised because the files in it
+            exceeded the size limit after decompression.
+        too_many_files: Whether the InvalidArchive was raised because the
+            archive contained more than the maximum number of files.
+        """
+        self.too_big = too_big
+        self.too_many_files = too_many_files
+        super().__init__()
 
 
-def extract_files_from_archive(data: bytes) -> list[ReceivedFile]:
+def extract_files_from_archive(data: bytes,
+                               max_size: int | None = None,
+                               max_files: int | None = None) -> list[ReceivedFile]:
     """Return the files contained in the given archive.
 
     Given the binary data of an archive in any of the formats supported
@@ -70,6 +82,8 @@ def extract_files_from_archive(data: bytes) -> list[ReceivedFile]:
     will be ignored and the files will be returned with their basename.
 
     data: the raw contents of the archive.
+    max_size: maximum decompressed size of the archive.
+    max_files: maximum number of files to allow in the archive.
 
     return: the files contained in the archive, with
         their filename filled in but their codename set to None.
@@ -78,32 +92,33 @@ def extract_files_from_archive(data: bytes) -> list[ReceivedFile]:
         archive, its contents are invalid, or other issues.
 
     """
-    archive = Archive.from_raw_data(data)
 
-    if archive is None:
-        raise InvalidArchive()
-
-    result = list()
-
+    result: list[ReceivedFile] = []
+    total_size = 0
     try:
-        archive.unpack()
-        for name in archive.namelist():
-            with archive.read(name) as f:
-                result.append(
-                    ReceivedFile(None, os.path.basename(name), f.read()))
-
-    except (PatoolError, OSError):
+        archive = open_archive(io.BytesIO(data))
+        for (filepath, size, handle) in archive.iter_regular_files():
+            total_size += size
+            if max_size is not None and total_size > max_size:
+                raise InvalidArchive(too_big=True)
+            if max_files is not None and len(result) + 1 > max_files:
+                raise InvalidArchive(too_many_files=True)
+            filedata = archive.get_file_bytes(handle)
+            # TODO: is os.path.basename correct here? we should be using whatever sep the archive uses
+            # (seems to be '/' always?)
+            result.append(ReceivedFile(None, os.path.basename(filepath), filedata))
+    except InvalidArchive:
+        raise
+    # the Archive class might raise all kinds of exceptions when fed invalid data. Catch them all here.
+    except Exception:
         raise InvalidArchive()
-
-    finally:
-        archive.cleanup()
 
     return result
 
 
-def extract_files_from_tornado(
-    tornado_files: dict[str, list["HTTPFile"]],
-) -> list[ReceivedFile]:
+def extract_files_from_tornado(tornado_files: dict[str, list["HTTPFile"]],
+                               max_size: int | None = None,
+                               max_files: int | None = None) -> list[ReceivedFile]:
     """Transform some files as received by Tornado into our format.
 
     Given the files as provided by Tornado on the HTTPServerRequest's
@@ -112,6 +127,9 @@ def extract_files_from_tornado(
     it and return its contents instead.
 
     tornado_files: a bunch of files, in Tornado's format.
+    max_size: limit on total size of decompressed files
+        (protects against zip bombs).
+    max_files: maximum number of files to allow in the archive
 
     return: the same bunch of files, in our format
         (except if it was an archive: then it's the archive's contents).
@@ -121,7 +139,7 @@ def extract_files_from_tornado(
     """
     if len(tornado_files) == 1 and "submission" in tornado_files \
             and len(tornado_files["submission"]) == 1:
-        return extract_files_from_archive(tornado_files["submission"][0].body)
+        return extract_files_from_archive(tornado_files["submission"][0].body, max_size, max_files)
 
     result = list()
     for codename, files in tornado_files.items():

--- a/cms/server/contest/submission/workflow.py
+++ b/cms/server/contest/submission/workflow.py
@@ -155,12 +155,34 @@ def accept_submission(
 
     required_codenames = set(task.submission_format)
 
+    # To protect against zip bombs, we raise an error if the archive's contents
+    # are too big even before extracting everything. The largest "reasonable"
+    # archive size is with every submission file provided, and every file being
+    # the largest allowed. Since we don't yet know which files from the archive
+    # are used and which are extraneous, this size limit applies to the entire
+    # archive in total.
+    archive_size_limit = config.max_submission_length * len(required_codenames)
+    # Honest users never need to submit more than required_codenames files, but
+    # we are a bit lenient to allow .DS_Store or other hidden files that might
+    # accidentally end up in an archive.
+    archive_max_files = 2 * len(required_codenames)
     try:
-        received_files = extract_files_from_tornado(tornado_files)
-    except InvalidArchive:
-        raise UnacceptableSubmission(
-            N_("Invalid archive format!"),
-            N_("The submitted archive could not be opened."))
+        received_files = extract_files_from_tornado(tornado_files, archive_size_limit, archive_max_files)
+    except InvalidArchive as e:
+        if e.too_big:
+            raise UnacceptableSubmission(
+                N_("Submission too big!"),
+                N_("Each source file must be at most %d bytes long."),
+                config.max_submission_length)
+        if e.too_many_files:
+            raise UnacceptableSubmission(
+                N_("Submission too big!"),
+                N_("The submission should contain at most %d files."),
+                len(required_codenames))
+        else:
+            raise UnacceptableSubmission(
+                N_("Invalid archive format!"),
+                N_("The submitted archive could not be opened."))
 
     try:
         files, language = match_files_and_language(
@@ -340,8 +362,11 @@ def accept_user_test(
     required_codenames.update(task_type.get_user_managers())
     required_codenames.add("input")
 
+    # See accept_submission() for these variables.
+    archive_size_limit = config.max_submission_length * len(required_codenames)
+    archive_max_files = 2 * len(required_codenames)
     try:
-        received_files = extract_files_from_tornado(tornado_files)
+        received_files = extract_files_from_tornado(tornado_files, archive_size_limit, archive_max_files)
     except InvalidArchive:
         raise UnacceptableUserTest(
             N_("Invalid archive format!"),

--- a/cmscommon/digest.py
+++ b/cmscommon/digest.py
@@ -18,6 +18,7 @@
 
 import hashlib
 import io
+import typing
 
 from cmscommon.binary import bin_to_hex
 
@@ -58,6 +59,20 @@ def bytes_digest(b: bytes) -> str:
     return d.digest()
 
 
+def fobj_digest(fobj: typing.IO[bytes]) -> str:
+    """Return the digest of the content of a file-like object.
+
+    fobj: file-like object (readable, in binary mode) to compute the digest of.
+
+    return: the digest.
+    """
+    d = Digester()
+    buf = fobj.read(io.DEFAULT_BUFFER_SIZE)
+    while len(buf) > 0:
+        d.update(buf)
+        buf = fobj.read(io.DEFAULT_BUFFER_SIZE)
+    return d.digest()
+
 def path_digest(path: str) -> str:
     """Return the digest of the content of a file, given by its path.
 
@@ -67,9 +82,4 @@ def path_digest(path: str) -> str:
 
     """
     with open(path, 'rb') as fin:
-        d = Digester()
-        buf = fin.read(io.DEFAULT_BUFFER_SIZE)
-        while len(buf) > 0:
-            d.update(buf)
-            buf = fin.read(io.DEFAULT_BUFFER_SIZE)
-        return d.digest()
+        return fobj_digest(fin)

--- a/cmstestsuite/unit_tests/server/contest/submission/file_retrieval_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission/file_retrieval_test.py
@@ -17,12 +17,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import base64
 import io
 import tarfile
 import unittest
 import zipfile
 from collections import namedtuple
 from unittest.mock import patch
+import zlib
 
 from cms.server.contest.submission import ReceivedFile, InvalidArchive, \
     extract_files_from_archive, extract_files_from_tornado
@@ -92,17 +94,7 @@ class TestExtractFilesFromArchive(unittest.TestCase):
             extract_files_from_archive(archive_data.getvalue()),
             [ReceivedFile(None, "foo", b"some content")])
 
-    # The behavior documented in this test actually only happens when
-    # patool uses 7z (which happens if it is found installed). Otherwise
-    # it falls back on Python's zipfile module which outright fails.
-    # Due to this difference we do not run this test.
-    @unittest.skip("Depends on what is installed in the system.")
     def test_empty_filename(self):
-        # This is a quite unexpected behavior: luckily in practice it
-        # should have no effect as the elements of the submission format
-        # aren't allowed to be empty and thus the submission would be
-        # rejected later on anyways. It also shouldn't leak any private
-        # information.
         archive_data = io.BytesIO()
         with zipfile.ZipFile(archive_data, "w") as f:
             # Need ZipInfo because of "bug" in writestr.
@@ -111,9 +103,7 @@ class TestExtractFilesFromArchive(unittest.TestCase):
         self.assertEqual(len(res), 1)
         f = res[0]
         self.assertIsNone(f.codename)
-        # The extracted file is named like the temporary file where the
-        # archive's contents were copied to, plus a trailing tilde.
-        self.assertRegex(f.filename, "tmp[a-z0-9_]+~")
+        self.assertEqual(f.filename, "")
         self.assertEqual(f.content, b"some content")
 
     def test_multiple_slashes_are_compressed(self):
@@ -137,18 +127,81 @@ class TestExtractFilesFromArchive(unittest.TestCase):
                 extract_files_from_archive(archive_data.getvalue()),
                 [ReceivedFile(None, "bar", b"some content")])
 
-    def test_conflicting_filenames(self):
-        # This is an unnecessary limitation due to the fact that patool
-        # does extract files to the actual filesystem. We could avoid it
-        # by using zipfile, tarfile, etc. directly but it would be too
-        # burdensome to support the same amount of archive types as
-        # patool does.
+    def test_zip_bomb_size_tarbz(self):
+        # this test should finish almost instantly, instead of trying to
+        # decompress the entire archive.
+
+        # This data is a tar.bz2 file that contains one file, with 64GB of null
+        # bytes.
+        data = zlib.decompress(base64.b64decode("""
+eJztyu9rzHEAAODPjHabezHaSSm+Yy1WlHKxpI5km1d34/vi9uaKKeUNI8kL2khRy3UK+XG1ue4uKaF
+TvNBerNTe2isvpDVLFNNaebMS/4Q3z+vnOTR0unf3wXz3sXw1f6625kqyMDpTzDStzGUy2bAQfcqGKJ
+GIQql1R9/4wLcT4XL5SbTlaaIycWe2pTK8Zzpc+vm98PXRQO54fLgex6nc3h/PHkfbTlYbcS5e3/5y8
+OaHdFv/pq2T6za8qBzp6Xo+9+vLvpmR97W29JkD2dr4cmNt5u61d1dfLS1/XNjfe33jjULLxbe333R2
+FUv9fUsdqdKpdPFzeedi6vd8SIYQxkJzYvXscM+qoWK99TznnHPOOeecc84555xzzjnnnHPOOeecc84
+555xzzjnnnHPOOeecc84555xzzjnnnHPOOeecc84555xzzjnnnHPOOeecc84555xzzjnnnHPOOeecc8
+4555xzzjnnnHPOOeecc84555xzzjnnnHPOOeecc845/w/+sD79erF5pfzX2/+N5NSD6v3JpsZgtHnX/
+K2zE53bL9w7+gctbrLz"""))
+
+        with self.assertRaises(InvalidArchive) as exc:
+            extract_files_from_archive(data, 1_000_000, None)
+
+        self.assertTrue(exc.exception.too_big)
+
+
+    def test_zip_bomb_count_tarbz(self):
+        # this test should finish almost instantly, instead of trying to
+        # decompress the entire archive.
+
+        # This data is a tar.bz2 file that contains 120 million empty files,
+        # all named "x". (the decompressed tar file would be 6GB.)
+        block = base64.b64decode("""
+MUFZJlNZFfIt8gXzb9uAyIBAAHcAAADgAB5ACAAwAVgAUyYmQZGFMmJkGRgUqmo2poaD1GgVKm4FSpg
+CRQ7gqVPYKlTwCpUyBUqdgKlTIKlTIJFDYBUqbAqVOAVKmAJFDAKlTYCiSuQVKmAUSVgFSpyCpU8gqV
+OAVKmAVKnIKlTqCpU3BIofQVKnwFSpoFSpoFSpoFSp+BUqZBUqfw==""")
+        data = b"BZh9" + 1000*block + bytes.fromhex("1772453850905d4ab55d")
+
+        with self.assertRaises(InvalidArchive) as exc:
+            extract_files_from_archive(data, None, 1000)
+
+        self.assertTrue(exc.exception.too_many_files)
+
+    def test_zip_bomb_size_zip(self):
+        # Similar to test_zip_bomb_size_tarbz. This test uses zip's
+        # (little-used?) bzip2 mode, because bzip2 is the most efficient at
+        # compressing large amounts of null bytes. It should be fine for the
+        # test though, we care more about zipfile's API here than the
+        # underlying compression algorithm.
+
+        # This data is a zip file with one file containing 16GB of null bytes.
+        data = zlib.decompress(base64.b64decode("""
+eJzt2r9qwlAUx/Fzm1hUpEixm4MKCi6pbi1d/IdLEIJOyeKojxA3FScHkVBwdejSZ3Ap4t7JUQQHVx9
+Bk6LgUDfH7+9wzzmXzyscy9R0Q0Ri8vG8cpLbWvp4jpKEuEriEkT338H4W6XidN+LZTvXsp8iu61qT0
+ryIxJOSaHfqFfm2e9of4bjOI7jOI7jOI7jOI7jOI7jOI7jOI7jOI7jOI7jOI7jOI7j9/Pxb+9FOutrX
+3vT/Gcz9Lbw8svRcLMvupapHgzt9o38JV+DoP97MW+ZocdgKr+q/sy8Br8TACk9vA=="""))
+
+        with self.assertRaises(InvalidArchive) as exc:
+            extract_files_from_archive(data, 1_000_000, None)
+
+        self.assertTrue(exc.exception.too_big)
+
+    def test_zip_bomb_count_zip(self):
+        # This test is not as extreme as the other zip-bomb ones, because zip
+        # does not have metadata compression. Once we have a zip in memory (as
+        # returned by tornado), constructing the file list is quite cheap, so
+        # zipfile doesn't even have an API to not construct the entire file
+        # list.
         archive_data = io.BytesIO()
         with zipfile.ZipFile(archive_data, "w") as f:
-            f.writestr("foo", b"some content")
-            f.writestr("foo/bar", b"more content")
-        with self.assertRaises(InvalidArchive):
-            extract_files_from_archive(archive_data.getvalue())
+            for i in range(1000):
+                f.writestr(f"{i}", b"x")
+
+        with self.assertRaises(InvalidArchive) as exc:
+            extract_files_from_archive(archive_data.getvalue(), 500, 50)
+
+        # size limit 500 vs total file size 1000 (1 byte per file) means we
+        # will hit both limits, but the file count limit should be hit first.
+        self.assertTrue(exc.exception.too_many_files)
 
 
 MockHTTPFile = namedtuple("MockHTTPFile", ["filename", "body"])
@@ -202,7 +255,7 @@ class TestExtractFilesFromTornado(unittest.TestCase):
         self.assertIs(extract_files_from_tornado(tornado_files),
                       self.extract_files_from_archive.return_value)
         self.extract_files_from_archive.assert_called_once_with(
-            b"this is an archive")
+            b"this is an archive", None, None)
 
     def test_bad_archive(self):
         tornado_files = {
@@ -212,7 +265,7 @@ class TestExtractFilesFromTornado(unittest.TestCase):
         with self.assertRaises(InvalidArchive):
             extract_files_from_tornado(tornado_files)
         self.extract_files_from_archive.assert_called_once_with(
-            b"this is not a valid archive")
+            b"this is not a valid archive", None, None)
 
 
 if __name__ == "__main__":

--- a/cmstestsuite/unit_tests/server/contest/submission/workflow_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission/workflow_test.py
@@ -304,7 +304,7 @@ class TestAcceptSubmission(DatabaseMixin, unittest.TestCase):
         with self.assertRaisesRegex(UnacceptableSubmission, "archive"):
             self.call()
 
-        self.extract_files_from_tornado.assert_called_with(self.tornado_files)
+        self.extract_files_from_tornado.assert_called()
 
     def test_failure_due_to_match_files_and_language(self):
         self.match_files_and_language.side_effect = InvalidFilesOrLanguage
@@ -637,7 +637,7 @@ class TestAcceptUserTest(DatabaseMixin, unittest.TestCase):
         with self.assertRaisesRegex(UnacceptableUserTest, "archive"):
             self.call()
 
-        self.extract_files_from_tornado.assert_called_with(self.tornado_files)
+        self.extract_files_from_tornado.assert_called()
 
     def test_failure_due_to_match_files_and_language(self):
         self.match_files_and_language.side_effect = InvalidFilesOrLanguage


### PR DESCRIPTION
This removes use of patoolib in CWS, instead using Python standard libraries, which are much safer due to not extracting anything to disk.

This also allowed implementing zip bomb protection: any archive with too many files or too big files is rejected before fully decompressing it.

I also rewrote the archive handling of DumpExporter aiming to fix #1226. The dump archive is constructed on the fly, without storing too much things in RAM or in temporary directories. (The entire model is still built in RAM and converted to json in RAM though. Hopefully it doesn't get too big...)

This is WIP because I want to also implement corresponding functionality in DumpUpdater and DumpImporter, which would allow fully removing patoolib.

The obvious drawback of this is that the set of supported archive formats is smaller: only .zip, .tar, .tar.gz, .tar.bz2, and .tar.xz. (And .tar.zst starting from Python 3.14.)