### PR TITLE
Some changes to authentication.

### DIFF
--- a/cms/server/admin/authentication.py
+++ b/cms/server/admin/authentication.py
@@ -144,7 +144,8 @@ class AWSAuthMiddleware:
             """
             response = Response(status=status, headers=headers)
             self._cookie.save_cookie(
-                response, AWSAuthMiddleware.COOKIE, httponly=True)
+                response, AWSAuthMiddleware.COOKIE, httponly=True,
+                max_age=config.admin_cookie_duration)
             return start_response(
                 status, response.headers.to_wsgi_list(), exc_info)
 

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -183,7 +183,8 @@ class RegistrationHandler(ContestHandler):
 
         # Find user if it exists
         user: User | None = (
-            self.sql_session.query(User).filter(User.username == username).first()
+            self.sql_session.query(User).filter(
+                User.username == username).first()
         )
         if user is None:
             raise tornado_web.HTTPError(404)
@@ -200,7 +201,8 @@ class RegistrationHandler(ContestHandler):
             try:
                 team_code: str = self.get_argument("team")
                 team: Team | None = (
-                    self.sql_session.query(Team).filter(Team.code == team_code).one()
+                    self.sql_session.query(Team).filter(
+                        Team.code == team_code).one()
                 )
             except (tornado_web.MissingArgumentError, NoResultFound):
                 raise tornado_web.HTTPError(400)
@@ -246,7 +248,8 @@ class LoginHandler(ContestHandler):
         if cookie is None:
             self.clear_cookie(cookie_name)
         else:
-            self.set_secure_cookie(cookie_name, cookie, expires_days=None)
+            self.set_secure_cookie(
+                cookie_name, cookie, expires_days=None, max_age=config.cookie_duration)
 
         if participation is None:
             self.redirect(error_page)
@@ -295,7 +298,8 @@ class NotificationsHandler(ContestHandler):
     def get(self):
         participation: Participation = self.current_user
 
-        last_notification: str | None = self.get_argument("last_notification", None)
+        last_notification: str | None = self.get_argument(
+            "last_notification", None)
         if last_notification is not None:
             last_notification = make_datetime(float(last_notification))
 
@@ -380,7 +384,7 @@ class DocumentationHandler(ContestHandler):
         language_docs = []
         if config.docs_path is not None:
             for language in languages:
-                ext = language.source_extensions[0][1:] # remove dot
+                ext = language.source_extensions[0][1:]  # remove dot
                 path = os.path.join(config.docs_path, ext)
                 if os.path.exists(path):
                     language_docs.append((language.name, ext))

--- a/cmstestsuite/unit_tests/server/contest/authentication_test.py
+++ b/cmstestsuite/unit_tests/server/contest/authentication_test.py
@@ -175,6 +175,7 @@ class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
             self.session, self.contest,
             kwargs.get("timestamp", self.timestamp),
             kwargs.get("cookie", self.cookie),
+            kwargs.get("authorization", None),
             ipaddress.ip_address(kwargs.get("ip_address", "10.0.0.1")))
 
     def assertSuccess(self, **kwargs):
@@ -326,6 +327,11 @@ class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
         self.contest.allow_password_authentication = True
         self.assertFailure(cookie=None)
         self.assertFailure(cookie="not a valid cookie")
+
+    def test_authorization_header(self):
+        self.contest.ip_autologin = False
+        self.contest.allow_password_authentication = True
+        self.assertSuccess(cookie=None, authorization=self.cookie)
 
     def test_no_user(self):
         self.session.delete(self.user)


### PR DESCRIPTION
- Do not use session cookies for AWS/CWS, but regular cookies
- Allow authentication in CWS without IP autologin or cookies, but with a `X-CMS-Authorization` header.