### PR TITLE
Remove CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# For things like schema changes, where we need to make sure that an updater is provided
-/cms/db     @wil93


### PR DESCRIPTION
As we discussed, the consensus between active devs is that CODEOWNERS is not the best way for individual devs to be notified about specific PRs.