### PR TITLE
fix tps loader - OutputOnly submission format

### DIFF
--- a/cmscontrib/loaders/tps.py
+++ b/cmscontrib/loaders/tps.py
@@ -184,7 +184,7 @@ class TpsTaskLoader(TaskLoader):
         if data["task_type"] == 'OutputOnly':
             args["submission_format"] = list()
             for codename in testcase_codenames:
-                args["submission_format"].append("%s.out" % codename)
+                args["submission_format"].append("output_%s.txt" % codename)
         elif data["task_type"] == 'Notice':
             args["submission_format"] = list()
         else:


### PR DESCRIPTION
changed to par with [the grading script](https://github.com/cms-dev/cms/blob/293c52769cb71060ceef951ac9b40dca35a901e5/cms/grading/tasktypes/OutputOnly.py#L55C5-L55C35)

Currently doesn't work properly for output only problems prepared by tps (e.g., ioi2017 nowruz, ioi2019 line).
You have to fix the submission format manually, which takes only too long to figure out.

Trying to save some headaches :)