### PR TITLE
Support BatchAndOutput task type in the importers

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -49,6 +49,7 @@ Benjamin Swart <Benjaminswart@email.cz>
 Andrey Vihrov <andrey.vihrov@gmail.com>
 Grace Hawkins <amoomajid99@gmail.com>
 Pasit Sangprachathanarak <ouipingpasit@gmail.com>
+Zsolt Németh <birka0@gmail.com>
 
 And many other people that didn't write code, but provided useful
 comments, suggestions and feedback. :-)

--- a/cmscontrib/loaders/italy_yaml.py
+++ b/cmscontrib/loaders/italy_yaml.py
@@ -767,12 +767,23 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
 
                 output_only_testcases = load(conf, None, "output_only_testcases",
                                              conv=lambda x: "" if x is None else x)
-                if len(output_only_testcases) > 0:
+                output_optional_testcases = load(conf, None, "output_optional_testcases",
+                                             conv=lambda x: "" if x is None else x)
+                if len(output_only_testcases) > 0 or len(output_optional_testcases) > 0:
                     args["task_type"] = "BatchAndOutput"
-                    output_codenames = \
-                        ["%03d" % int(x.strip()) for x in output_only_testcases.split(',')]
-                    task.submission_format.extend(["output_%s.txt" % s in output_codenames])
-                    args["task_type_parameters"].append(','.join(output_codenames))
+                    output_only_codenames = set()
+                    if len(output_only_testcases) > 0:
+                        output_only_codenames = \
+                            {"%03d" % int(x.strip()) for x in output_only_testcases.split(',')}
+                        args["task_type_parameters"].append(','.join(output_only_codenames))
+                    else:
+                        args["task_type_parameters"].append("")
+                    output_codenames = set()
+                    if len(output_optional_testcases) > 0:
+                        output_codenames = \
+                            {"%03d" % int(x.strip()) for x in output_optional_testcases.split(',')}
+                    output_codenames.update(output_only_codenames)
+                    task.submission_format.extend(["output_%s.txt" % s for s in sorted(output_codenames)])
 
         args["testcases"] = []
         for i in range(n_input):

--- a/cmscontrib/loaders/tps.py
+++ b/cmscontrib/loaders/tps.py
@@ -197,13 +197,21 @@ class TpsTaskLoader(TaskLoader):
                 for filename in os.listdir(testcases_dir)
                 if filename[-3:] == '.in'])
         if data["task_type"] == 'BatchAndOutput':
-            output_only_testcases = {}
+            output_only_testcases = set()
+            output_optional_testcases = set()
             for cur_subtask_data in subtask_data.values():
                 is_output_only = cur_subtask_data.get('output_only', False)
+                is_output_optional = cur_subtask_data.get('output_optional', False)
                 if is_output_only:
                     codenames = cur_subtask_data.get('testcases', list())
                     output_only_testcases.update(codenames)
+                elif is_output_optional:
+                    codenames = cur_subtask_data.get('testcases', list())
+                    output_optional_testcases.update(codenames)
             data["output_only_testcases"] = output_only_testcases
+            output_testcases = \
+                output_optional_testcases | output_only_testcases
+            data["output_testcases"] = output_testcases
         
         # Setting the submission format
         if data["task_type"] == 'OutputOnly':
@@ -214,7 +222,7 @@ class TpsTaskLoader(TaskLoader):
             args["submission_format"] = list()
         elif data["task_type"] == "BatchAndOutput":
             args["submission_format"] = ["%s.%%l" % name]
-            for codename in data["output_only_testcases"]:
+            for codename in sorted(data["output_testcases"]):
                 args["submission_format"].append("output_%s.txt" % codename)
         else:
             args["submission_format"] = ["%s.%%l" % name]

--- a/cmscontrib/loaders/tps.py
+++ b/cmscontrib/loaders/tps.py
@@ -66,7 +66,7 @@ class TpsTaskLoader(TaskLoader):
         task_type_parameters = json.loads(parameters_str)
         par_prefix = 'task_type_parameters_%s' % task_type
 
-        if task_type == 'Batch':
+        if task_type == 'Batch' or task_type == 'BatchAndOutput':
             par_compilation = '%s_compilation' % par_prefix
             par_input = '%s_io_0_inputfile' % par_prefix
             par_output = '%s_io_1_outputfile' % par_prefix
@@ -88,12 +88,15 @@ class TpsTaskLoader(TaskLoader):
                 if not os.path.exists(pas_grader):
                     user_managers = '[\\"grader.%l\\"]'
                 task_type_parameters[par_user_managers] = user_managers
-            return [
+            param_list = [
                 task_type_parameters[par_compilation],
                 [task_type_parameters[par_input],
                  task_type_parameters[par_output]],
                 evaluation_param,
             ]
+            if task_type == 'BatchAndOutput':
+                param_list.append(','.join(data["output_only_testcases"]))
+            return param_list
 
         if task_type == 'Communication':
             par_processes = '%s_num_processes' % par_prefix
@@ -170,7 +173,19 @@ class TpsTaskLoader(TaskLoader):
         data["task_type"] = \
             data["task_type"][0].upper() + data["task_type"][1:]
 
-        # Setting the submission format
+        # Parse subtask data
+        subtasks_dir = os.path.join(self.path, 'subtasks')
+        subtask_data = {}
+        if not os.path.exists(subtasks_dir):
+            logger.warning('Subtask folder was not found')
+            subtasks = []
+        else:
+            subtasks = sorted(os.listdir(subtasks_dir))
+            for subtask in subtasks:
+                with open(os.path.join(subtasks_dir, subtask), 'rt',
+                          encoding='utf-8') as subtask_json:
+                    subtask_data[subtask] = json.load(subtask_json)
+
         # Obtaining testcases' codename
         testcases_dir = os.path.join(self.path, 'tests')
         if not os.path.exists(testcases_dir):
@@ -181,12 +196,26 @@ class TpsTaskLoader(TaskLoader):
                 filename[:-3]
                 for filename in os.listdir(testcases_dir)
                 if filename[-3:] == '.in'])
+        if data["task_type"] == 'BatchAndOutput':
+            output_only_testcases = {}
+            for cur_subtask_data in subtask_data.values():
+                is_output_only = cur_subtask_data.get('output_only', False)
+                if is_output_only:
+                    codenames = cur_subtask_data.get('testcases', list())
+                    output_only_testcases.update(codenames)
+            data["output_only_testcases"] = output_only_testcases
+        
+        # Setting the submission format
         if data["task_type"] == 'OutputOnly':
             args["submission_format"] = list()
             for codename in testcase_codenames:
                 args["submission_format"].append("output_%s.txt" % codename)
         elif data["task_type"] == 'Notice':
             args["submission_format"] = list()
+        elif data["task_type"] == "BatchAndOutput":
+            args["submission_format"] = ["%s.%%l" % name]
+            for codename in data["output_only_testcases"]:
+                args["submission_format"].append("output_%s.txt" % codename)
         else:
             args["submission_format"] = ["%s.%%l" % name]
 
@@ -240,7 +269,7 @@ class TpsTaskLoader(TaskLoader):
             logger.info("Checker found, compiling")
             checker_exe = os.path.join(checker_dir, "checker")
             ret = subprocess.call([
-                "g++", "-x", "c++", "-std=gnu++17", "-O2", "-static",
+                "g++", "-x", "c++", "-std=gnu++20", "-O2", "-static",
                 "-o", checker_exe, checker_src
             ])
             if ret != 0:
@@ -298,7 +327,7 @@ class TpsTaskLoader(TaskLoader):
             logger.info("Manager found, compiling")
             manager_exe = os.path.join(graders_dir, "manager")
             ret = subprocess.call([
-                "g++", "-x", "c++", "-std=gnu++17", "-O2", "-static",
+                "g++", "-x", "c++", "-std=gnu++20", "-O2", "-static",
                 "-o", manager_exe, manager_src
             ])
             if ret != 0:
@@ -332,13 +361,6 @@ class TpsTaskLoader(TaskLoader):
             args["testcases"][codename] = testcase
 
         # Score Type
-        subtasks_dir = os.path.join(self.path, 'subtasks')
-        if not os.path.exists(subtasks_dir):
-            logger.warning('Subtask folder was not found')
-            subtasks = []
-        else:
-            subtasks = sorted(os.listdir(subtasks_dir))
-
         if len(subtasks) == 0:
             number_tests = max(len(testcase_codenames), 1)
             args["score_type"] = "Sum"
@@ -350,22 +372,20 @@ class TpsTaskLoader(TaskLoader):
             add_optional_name = False
             for subtask in subtasks:
                 subtask_no += 1
-                with open(os.path.join(subtasks_dir, subtask), 'rt',
-                          encoding='utf-8') as subtask_json:
-                    subtask_data = json.load(subtask_json)
-                    score = int(subtask_data["score"])
-                    testcases = "|".join(
-                        re.escape(testcase)
-                        for testcase in subtask_data["testcases"]
-                    )
-                    optional_name = "Subtask %d" % subtask_no
-                    if subtask_no == 0 and score == 0:
-                        add_optional_name = True
-                        optional_name = "Samples"
-                    if add_optional_name:
-                        parsed_data.append([score, testcases, optional_name])
-                    else:
-                        parsed_data.append([score, testcases])
+                cur_subtask_data = subtask_data[subtask]
+                score = int(cur_subtask_data["score"])
+                testcases = "|".join(
+                    re.escape(testcase)
+                    for testcase in cur_subtask_data["testcases"]
+                )
+                optional_name = "Subtask %d" % subtask_no
+                if subtask_no == 0 and score == 0:
+                    add_optional_name = True
+                    optional_name = "Samples"
+                if add_optional_name:
+                    parsed_data.append([score, testcases, optional_name])
+                else:
+                    parsed_data.append([score, testcases])
             args["score_type_parameters"] = parsed_data
 
         dataset = Dataset(**args)


### PR DESCRIPTION
Based on: #1330 

`tps`: Since TPS does not handle testcase metadata very well (e.g., codenames are generated arbitrarily and developers might unintentionally change them), explicitly listing output-only testcases in a config file is not a good idea.
Instead, we can optionally mark subtasks as collections of output-only testcases.
Note that this approach aligns with IOI rules, where output-only is considered a subtask property rather than a testcase-specific one.

`italy_yaml`: Simply copied the logic used for handling `public_testcases`.
