### PR TITLE
AddSubmissions failed to notify the EvaluationService

### DIFF
--- a/cms/io/rpc.py
+++ b/cms/io/rpc.py
@@ -118,6 +118,16 @@ class RemoteServiceBase:
         """
         return self._connection_event.is_set()
 
+    def wait_for_connection(self, timeout: float | None = None) -> bool:
+        """Wait for a limited time until the connection comes up.
+
+        timeout: maximum waiting time in seconds.
+
+        result: the status of the connection.
+
+        """
+        return self._connection_event.wait(timeout)
+
     # TODO: the types here are not precise
     def add_on_connect_handler(self, handler: Callable[[object], Any]):
         """Register a callback for connection establishment.

--- a/cmscontrib/AddSubmission.py
+++ b/cmscontrib/AddSubmission.py
@@ -41,6 +41,7 @@ def maybe_send_notification(submission_id: int):
     """Non-blocking attempt to notify a running ES of the submission"""
     rs = RemoteServiceClient(ServiceCoord("EvaluationService", 0))
     rs.connect()
+    rs.wait_for_connection(timeout=1)
     rs.new_submission(submission_id=submission_id)
     rs.disconnect()
 


### PR DESCRIPTION
The attempt to connect to the remote service is asynchronous and it frequently happens that the `connect` method returns before the connection is set up. Let us wait a little for the connection to come up. In case the EvaluationService is not running, we time out after 1 second.