### PR TITLE
CWS: Impersonation of users by administrators

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -146,6 +146,7 @@ class Config:
         # necessary to change it.
         # [1] http://freedesktop.org/wiki/Software/shared-mime-info
         self.shared_mime_info_prefix = "/usr"
+        self.contest_admin_token = None
 
         # AdminWebServer.
         self.admin_listen_address = ""

--- a/cms/server/contest/authentication.py
+++ b/cms/server/contest/authentication.py
@@ -71,6 +71,7 @@ def validate_login(
     username: str,
     password: str,
     ip_address: AnyIPAddress,
+    admin_token: str = ""
 ) -> tuple[Participation | None, bytes | None]:
     """Authenticate a user logging in, with username and password.
 
@@ -91,6 +92,7 @@ def validate_login(
     username: the username the user provided.
     password: the password the user provided.
     ip_address: the IP address the request came from.
+    admin_token: administrator's token used to impersonate a user
 
     return: if the user couldn't
         be authenticated then return None, otherwise return the
@@ -103,7 +105,7 @@ def validate_login(
                     "%r, on contest %s, at %s: " + msg, ip_address,
                     username, contest.name, timestamp, *args)
 
-    if not contest.allow_password_authentication:
+    if not contest.allow_password_authentication and admin_token == "":
         log_failed_attempt("password authentication not allowed")
         return None, None
 
@@ -119,6 +121,20 @@ def validate_login(
     if participation is None:
         log_failed_attempt("user not registered to contest")
         return None, None
+
+    if admin_token != "":
+        if (config.contest_admin_token is not None
+            and admin_token != config.contest_admin_token):
+            log_failed_attempt("invalid admin token")
+            return None, None
+
+        logger.info("Successful impersonated login from IP address %s, as user %r, on "
+                    "contest %s, at %s", ip_address, username, contest.name,
+                    timestamp)
+
+        return (participation,
+                json.dumps([username, "", make_timestamp(timestamp), True])
+                    .encode("utf-8"))
 
     correct_password = get_password(participation)
 
@@ -151,7 +167,7 @@ def validate_login(
     # If hashing is used, the cookie stores the hashed password so that
     # the expensive bcrypt call doesn't need to be done at every request.
     return (participation,
-            json.dumps([username, correct_password, make_timestamp(timestamp)])
+            json.dumps([username, correct_password, make_timestamp(timestamp), False])
                 .encode("utf-8"))
 
 
@@ -166,7 +182,7 @@ def authenticate_request(
     cookie: bytes | None,
     authorization_header: bytes | None,
     ip_address: AnyIPAddress,
-) -> tuple[Participation | None, bytes | None]:
+) -> tuple[Participation | None, bytes | None, bool]:
     """Authenticate a user returning to the site, with a cookie.
 
     Given the information the user's browser provided (the cookie) and
@@ -200,16 +216,17 @@ def authenticate_request(
     timestamp: the date and the time of the request.
     cookie: the cookie the user's browser provided in the
         request (if any).
+    authorization_header: the value of X-CMS-Authorization header (if any).
     ip_address: the IP address the request
         came from.
 
-    return: if the user
-        couldn't be authenticated then return None, otherwise return
-        the participation that they wanted to authenticate as; if a
-        cookie has to be set return it as well, otherwise return None.
+    return: a tuple consisting of participation (None if authentication failed),
+        a cookie that has to be set (or None), and a boolean flag indicating
+        whether the admin token was used to impersonate a user.
 
     """
     participation: Participation | None = None
+    impersonated = False
 
     if contest.ip_autologin:
         try:
@@ -219,34 +236,37 @@ def authenticate_request(
             if participation is not None:
                 cookie = None
         except AmbiguousIPAddress:
-            return None, None
-
-    if participation is None \
-            and contest.allow_password_authentication:
-        participation, cookie = _authenticate_request_from_cookie_or_authorization_header(
-            sql_session, contest, timestamp, authorization_header if authorization_header is not None else cookie)
+            return None, None, False
 
     if participation is None:
-        return None, None
+        participation, cookie, impersonated = (
+            _authenticate_request_from_cookie_or_authorization_header(
+                sql_session, contest, timestamp,
+                authorization_header if authorization_header is not None else cookie))
+
+    if participation is None:
+        return None, None, False
 
     # Check if user is using the right IP (or is on the right subnet).
-    if contest.ip_restriction and participation.ip is not None \
-            and not any(ip_address in network for network in participation.ip):
+    if (contest.ip_restriction and participation.ip is not None
+            and not impersonated
+            and not any(ip_address in network for network in participation.ip)):
         logger.info(
             "Unsuccessful authentication from IP address %s, on contest %s, "
             "as %s, at %s: unauthorized IP address",
             ip_address, contest.name, participation.user.username, timestamp)
-        return None, None
+        return None, None, False
 
     # Check that the user is not hidden if hidden users are blocked.
-    if contest.block_hidden_participations and participation.hidden:
+    if (contest.block_hidden_participations and participation.hidden
+            and not impersonated):
         logger.info(
             "Unsuccessful authentication from IP address %s, on contest %s, "
             "as %s, at %s: participation is hidden and unauthorized",
             ip_address, contest.name, participation.user.username, timestamp)
-        return None, None
+        return None, None, False
 
-    return participation, cookie
+    return participation, cookie, impersonated
 
 
 def _authenticate_request_by_ip_address(
@@ -311,7 +331,7 @@ def _authenticate_request_by_ip_address(
 
 def _authenticate_request_from_cookie_or_authorization_header(
     sql_session: Session, contest: Contest, timestamp: datetime, cookie: bytes | None
-) -> tuple[Participation | None, bytes | None]:
+) -> tuple[Participation | None, bytes | None, bool]:
     """Return the current participation based on the cookie.
 
     If a participation can be extracted, the cookie is refreshed.
@@ -323,26 +343,31 @@ def _authenticate_request_from_cookie_or_authorization_header(
     cookie: the contents of the cookie (or authorization header)
         provided in the request (if any).
 
-    return: the participation
-        extracted from the cookie and the cookie to set/refresh, or
-        None in case of errors.
+    return: a triple of the participation extracted from the cookie (or None),
+        the cookie to set/refresh (or None), and a boolean flag indicating
+        impersonation of the user by the administrator.
 
     """
     if cookie is None:
         logger.info("Unsuccessful cookie authentication: no cookie provided")
-        return None, None
+        return None, None, False
 
     # Parse cookie.
     try:
-        cookie = json.loads(cookie.decode("utf-8"))
+        cookie: typing.Any = json.loads(cookie.decode("utf-8"))
         username: str = cookie[0]
         password: str = cookie[1]
         last_update = make_datetime(cookie[2])
+        impersonated: bool = cookie[3]
     except Exception as e:
         # Cookies are stored securely and thus cannot be tampered with:
         # this is either a programming or a configuration error.
         logger.warning("Invalid cookie (%s): %s", e, cookie)
-        return None, None
+        return None, None, False
+
+    # Reject if password authentication is disabled and it's not an impersonation cookie/header.
+    if not contest.allow_password_authentication and not impersonated:
+        return None, None, False
 
     def log_failed_attempt(msg, *args):
         logger.info("Unsuccessful cookie authentication as %r, returning from "
@@ -353,7 +378,7 @@ def _authenticate_request_from_cookie_or_authorization_header(
     if timestamp - last_update > timedelta(seconds=config.cookie_duration):
         log_failed_attempt("cookie expired (lasts %d seconds)",
                            config.cookie_duration)
-        return None, None
+        return None, None, False
 
     # Load participation from DB and make sure it exists.
     participation: Participation | None = (
@@ -366,22 +391,28 @@ def _authenticate_request_from_cookie_or_authorization_header(
     )
     if participation is None:
         log_failed_attempt("user not registered to contest")
-        return None, None
+        return None, None, False
 
-    correct_password = get_password(participation)
+    if impersonated:
+        correct_password = ""
+        logger.info("Successful impersonation of user %r, on contest %s, "
+                    "returning from %s, at %s", username, contest.name, last_update,
+                    timestamp)
+    else:
+        # We compare hashed password because it would be too expensive to
+        # re-hash the user-provided plaintext password at every request.
+        correct_password = get_password(participation)
+        if password != correct_password:
+            log_failed_attempt("wrong password")
+            return None, None, False
 
-    # We compare hashed password because it would be too expensive to
-    # re-hash the user-provided plaintext password at every request.
-    if password != correct_password:
-        log_failed_attempt("wrong password")
-        return None, None
-
-    logger.info("Successful cookie authentication as user %r, on contest %s, "
-                "returning from %s, at %s", username, contest.name, last_update,
-                timestamp)
+        logger.info("Successful cookie authentication as user %r, on contest %s, "
+                    "returning from %s, at %s", username, contest.name, last_update,
+                    timestamp)
 
     # We store the hashed password (if hashing is used) so that the
     # expensive bcrypt hashing doesn't need to be done at every request.
     return (participation,
-            json.dumps([username, correct_password, make_timestamp(timestamp)])
-                .encode("utf-8"))
+            json.dumps([username, correct_password, make_timestamp(timestamp), impersonated])
+                .encode("utf-8"),
+            impersonated)

--- a/cms/server/contest/handlers/api.py
+++ b/cms/server/contest/handlers/api.py
@@ -158,15 +158,23 @@ class ApiSubmitHandler(ApiContestHandler):
         if self.impersonated_by_admin:
             try:
                 official = self.get_boolean_argument('override_official', official)
+                override_max_number = self.get_boolean_argument('override_max_number', False)
+                override_min_interval = self.get_boolean_argument('override_min_interval', False)
             except ValueError as err:
                 self.json({"error": str(err)}, 400)
                 return
+        else:
+            override_max_number = False
+            override_min_interval = False
 
         try:
             submission = accept_submission(
                 self.sql_session, self.service.file_cacher, self.current_user,
                 task, self.timestamp, self.request.files,
-                self.get_argument("language", None), official)
+                self.get_argument("language", None), official,
+                override_max_number=override_max_number,
+                override_min_interval=override_min_interval,
+            )
             self.sql_session.commit()
         except UnacceptableSubmission as e:
             logger.info("API submission rejected: `%s' - `%s'",

--- a/cms/server/contest/handlers/api.py
+++ b/cms/server/contest/handlers/api.py
@@ -77,6 +77,8 @@ class ApiLoginHandler(ApiContestHandler):
         current_user = self.get_current_user()
 
         username = self.get_argument("username", "")
+        password = self.get_argument("password", "")
+        admin_token = self.get_argument("admin_token", "")
 
         if current_user is not None:
             if username != "" and current_user.user.username != username:
@@ -90,8 +92,6 @@ class ApiLoginHandler(ApiContestHandler):
 
             return
 
-        password = self.get_argument("password", "")
-
         try:
             ip_address = ipaddress.ip_address(self.request.remote_ip)
         except ValueError:
@@ -101,7 +101,7 @@ class ApiLoginHandler(ApiContestHandler):
 
         participation, login_data = validate_login(
             self.sql_session, self.contest, self.timestamp, username, password,
-            ip_address)
+            ip_address, admin_token=admin_token)
 
         if participation is None:
             self.json({"error": "Login failed"}, 403)

--- a/cms/server/contest/handlers/api.py
+++ b/cms/server/contest/handlers/api.py
@@ -153,6 +153,15 @@ class ApiSubmitHandler(ApiContestHandler):
         # analysis mode.
         official = self.r_params["actual_phase"] == 0
 
+        # If the submission is performed by the administrator acting on behalf
+        # of a contestant, allow overriding.
+        if self.impersonated_by_admin:
+            try:
+                official = self.get_boolean_argument('override_official', official)
+            except ValueError as err:
+                self.json({"error": str(err)}, 400)
+                return
+
         try:
             submission = accept_submission(
                 self.sql_session, self.service.file_cacher, self.current_user,

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -183,6 +183,20 @@ class BaseHandler(CommonRequestHandler):
         """Return whether it's an API request."""
         return self.api_request
 
+    def get_boolean_argument(self, name: str, default: bool) -> bool:
+        """Parse a Boolean request argument."""
+
+        arg = self.get_argument(name, "")
+        if arg == "":
+            return default
+
+        if arg == '0':
+            return False
+        elif arg == '1':
+            return True
+        else:
+            raise ValueError(f"Cannot parse boolean argument {name}")
+
 
 class ContestListHandler(BaseHandler):
     def get(self):

--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -79,6 +79,7 @@ class ContestHandler(BaseHandler):
         super().__init__(*args, **kwargs)
         self.contest_url: Url = None
         self.contest: Contest
+        self.impersonated_by_admin = False
 
     def prepare(self):
         self.choose_contest()
@@ -173,7 +174,7 @@ class ContestHandler(BaseHandler):
                            self.request.remote_ip)
             return None
 
-        participation, cookie = authenticate_request(
+        participation, cookie, impersonated = authenticate_request(
             self.sql_session, self.contest,
             self.timestamp, cookie,
             authorization_header,
@@ -185,6 +186,7 @@ class ContestHandler(BaseHandler):
             self.set_secure_cookie(
                 cookie_name, cookie, expires_days=None, max_age=config.cookie_duration)
 
+        self.impersonated_by_admin = impersonated
         return participation
 
     def render_params(self):

--- a/cmstestsuite/unit_tests/server/contest/authentication_test.py
+++ b/cmstestsuite/unit_tests/server/contest/authentication_test.py
@@ -192,13 +192,14 @@ class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
         self.session.expire(self.user)
         self.session.expire(self.contest)
 
-        authenticated_participation, cookie = \
+        authenticated_participation, cookie, impersonated = \
             self.attempt_authentication(**kwargs)
 
         self.assertIsNotNone(authenticated_participation)
         self.assertIs(authenticated_participation, self.participation)
         self.assertIs(authenticated_participation.user, self.user)
         self.assertIs(authenticated_participation.contest, self.contest)
+        self.assertIs(impersonated, False)
 
         return cookie
 
@@ -223,10 +224,11 @@ class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
     def assertFailure(self, **kwargs):
         # Assert that the authentication fails.
         # The arguments are the same as those of attempt_authentication.
-        authenticated_participation, cookie = \
+        authenticated_participation, cookie, impersonated = \
             self.attempt_authentication(**kwargs)
         self.assertIsNone(authenticated_participation)
         self.assertIsNone(cookie)
+        self.assertIs(impersonated, False)
 
     @patch.object(config, "cookie_duration", 10)
     def test_cookie_contains_timestamp(self):

--- a/cmstestsuite/unit_tests/server/contest/authentication_test.py
+++ b/cmstestsuite/unit_tests/server/contest/authentication_test.py
@@ -50,7 +50,13 @@ class TestValidateLogin(DatabaseMixin, unittest.TestCase):
         self.participation = self.add_participation(
             contest=self.contest, user=self.user)
 
-    def assertSuccess(self, username, password, ip_address):
+        # Set up a temporary admin token
+        patcher = patch.object(config, "contest_admin_token", "admin-token")
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+
+    def assertSuccess(self, username, password, ip_address, admin_token=""):
         # We had an issue where due to a misuse of contains_eager we ended up
         # with the wrong user attached to the participation. This only happens
         # if the correct user isn't already in the identity map, which is what
@@ -61,7 +67,8 @@ class TestValidateLogin(DatabaseMixin, unittest.TestCase):
 
         authenticated_participation, cookie = validate_login(
             self.session, self.contest, self.timestamp,
-            username, password, ipaddress.ip_address(ip_address))
+            username, password, ipaddress.ip_address(ip_address),
+            admin_token)
 
         self.assertIsNotNone(authenticated_participation)
         self.assertIsNotNone(cookie)
@@ -69,10 +76,11 @@ class TestValidateLogin(DatabaseMixin, unittest.TestCase):
         self.assertIs(authenticated_participation.user, self.user)
         self.assertIs(authenticated_participation.contest, self.contest)
 
-    def assertFailure(self, username, password, ip_address):
+    def assertFailure(self, username, password, ip_address, admin_token=""):
         authenticated_participation, cookie = validate_login(
             self.session, self.contest, self.timestamp,
-            username, password, ipaddress.ip_address(ip_address))
+            username, password, ipaddress.ip_address(ip_address),
+            admin_token)
 
         self.assertIsNone(authenticated_participation)
         self.assertIsNone(cookie)
@@ -150,6 +158,30 @@ class TestValidateLogin(DatabaseMixin, unittest.TestCase):
 
         self.assertSuccess("myuser", "mypass", "10.0.1.1")
 
+    def test_successful_impersonation(self):
+        self.assertSuccess("myuser", "", "127.0.0.1", "admin-token")
+
+    def test_unsuccessful_impersonation(self):
+        self.assertFailure("myuser", "", "127.0.0.1", "bad-admin-token")
+
+    def test_impersonation_overrides_unallowed_password_authentication(self):
+        self.contest.allow_password_authentication = False
+
+        self.assertSuccess("myuser", "", "127.0.0.1", "admin-token")
+
+    def test_impersonation_overrides_unallowed_hidden_participation(self):
+        self.contest.block_hidden_participations = True
+        self.participation.hidden = True
+
+        self.assertSuccess("myuser", "", "127.0.0.1", "admin-token")
+
+    def test_impersonation_overrides_ip_lock(self):
+        self.contest.ip_restriction = True
+        self.participation.ip = [ipaddress.ip_network("10.0.0.0/24")]
+
+        self.assertSuccess("myuser", "mypass", "10.0.0.1", "admin-token")
+        self.assertSuccess("myuser", "mypass", "10.0.1.1", "admin-token")
+
 
 class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
 
@@ -158,7 +190,6 @@ class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
         self.timestamp = make_datetime()
         self.add_contest()
         self.contest = self.add_contest()
-        self.add_user(username="otheruser")
         self.user = self.add_user(
             username="myuser", password=build_password("mypass"))
         self.participation = self.add_participation(
@@ -167,7 +198,26 @@ class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
             self.session, self.contest, self.timestamp, self.user.username,
             "mypass", ipaddress.ip_address("10.0.0.1"))
 
-    def attempt_authentication(self, **kwargs):
+        # For testing impersonation by admin token
+        self.impersonated_user = self.add_user(username="otheruser")
+        self.impersonated_participation = self.add_participation(
+            contest=self.contest, user=self.impersonated_user)
+        with patch.object(config, "contest_admin_token", "admin-token"):
+            _, self.impersonated_cookie = validate_login(
+                self.session, self.contest, self.timestamp, "otheruser",
+                "", ipaddress.ip_address("10.0.0.2"), "admin-token")
+
+    def attempt_authentication(self, db_flush=True, **kwargs):
+        # We had an issue where due to a misuse of contains_eager we ended up
+        # with the wrong user attached to the participation. This only happens
+        # if the correct user isn't already in the identity map, which is what
+        # these lines trigger.
+        if db_flush:
+            self.session.flush()
+            self.session.expire(self.user)
+            self.session.expire(self.impersonated_user)
+            self.session.expire(self.contest)
+
         # The arguments need to be passed as keywords and are timestamp, cookie
         # and ip_address. A missing argument means the default value is used
         # instead. An argument passed as None means that None will be used.
@@ -179,19 +229,6 @@ class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
             ipaddress.ip_address(kwargs.get("ip_address", "10.0.0.1")))
 
     def assertSuccess(self, **kwargs):
-        # Assert that the authentication succeeds in any way (be it through IP
-        # autologin or thanks to the cookie) and return the cookie that should
-        # be set (or None, if it should be cleared/left unset).
-        # The arguments are the same as those of attempt_authentication.
-
-        # We had an issue where due to a misuse of contains_eager we ended up
-        # with the wrong user attached to the participation. This only happens
-        # if the correct user isn't already in the identity map, which is what
-        # these lines trigger.
-        self.session.flush()
-        self.session.expire(self.user)
-        self.session.expire(self.contest)
-
         authenticated_participation, cookie, impersonated = \
             self.attempt_authentication(**kwargs)
 
@@ -220,6 +257,21 @@ class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
         # The arguments are the same as those of attempt_authentication.
         cookie = self.assertSuccess(**kwargs)
         self.assertIsNone(cookie)
+
+    def assertImpersonationSuccess(self, **kwargs):
+        # Assert that the impersonation succeeds.
+        # The arguments are the same as those of attempt_authentication.
+
+        authenticated_participation, cookie, impersonated = \
+            self.attempt_authentication(cookie=self.impersonated_cookie, **kwargs)
+
+        self.assertIsNotNone(authenticated_participation)
+        self.assertIs(authenticated_participation, self.impersonated_participation)
+        self.assertIs(authenticated_participation.user, self.impersonated_user)
+        self.assertIs(authenticated_participation.contest, self.contest)
+        self.assertIs(impersonated, True)
+
+        return cookie
 
     def assertFailure(self, **kwargs):
         # Assert that the authentication fails.
@@ -337,7 +389,7 @@ class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
 
     def test_no_user(self):
         self.session.delete(self.user)
-        self.assertFailure()
+        self.assertFailure(db_flush=False)
 
     def test_no_participation_for_user_in_contest(self):
         self.session.delete(self.participation)
@@ -371,6 +423,30 @@ class TestAuthenticateRequest(DatabaseMixin, unittest.TestCase):
 
         self.participation.ip = None
         self.assertSuccessAndCookieRefreshed()
+
+    def test_impersonate(self):
+        self.contest.ip_autologin = False
+        self.contest.allow_password_authentication = False
+        self.assertImpersonationSuccess()
+
+    def test_impersonate_overridden_by_ip_autologin(self):
+        self.contest.ip_autologin = True
+        self.contest.allow_password_authentication = False
+
+        self.participation.ip = [ipaddress.ip_network("10.0.0.1/32")]
+        self.assertSuccessAndCookieCleared(cookie=self.impersonated_cookie)
+
+    def test_impersonation_overrides_unallowed_hidden_participation(self):
+        self.contest.block_hidden_participations = True
+        self.participation.hidden = True
+        self.assertImpersonationSuccess()
+
+    def test_impersonation_overrides_ip_lock(self):
+        self.contest.ip_restriction = True
+        self.participation.ip = [ipaddress.ip_network("10.0.0.0/24")]
+
+        self.assertImpersonationSuccess(ip_address="10.0.0.1")
+        self.assertImpersonationSuccess(ip_address="10.0.1.1")
 
 
 if __name__ == "__main__":

--- a/config/cms.sample.toml
+++ b/config/cms.sample.toml
@@ -91,6 +91,10 @@ max_input_length = 5000000
 # example for C++ add 'cpp/index.html', for Java 'java/index.html'.
 docs_path = "/usr/share/cms/docs"
 
+# An authentication token that can be used by the administrator
+# to impersonate an arbitrary user and bypass submit restrictions.
+# contest_admin_token = "CHANGE-ME"
+
 ##################
 # AdminWebServer #
 ##################

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -88,3 +88,35 @@ its field `public_score` will contain the score of this submission, and
 Additional details on the submission's results can be retrieved by making an
 authenticated `GET` request to `/tasks/{taskname}/submissions/{id}/details`.
 The endpoint will return an HTML snippet matching what is seen by contestants.
+
+Impersonation of users
+======================
+
+Administrators may impersonate a user and perform requests on their behalf.
+
+This is accomplished by using the authentication endpoint without `password`
+and with an additional `admin_token` parameter equal to the `contest_admin_token`
+from the CMS configuration. The returned authentication token refers to the
+given user, but it is marked as impersonated.
+
+Requests carrying an impersonated authentication token may bypass certain restrictions:
+
+* IP-based login restrictions do no apply. (But if IP-based autologin is set,
+  it overrides all authentication tokens including impersonated ones.)
+
+* Hidden participation is never blocked.
+
+* Requests can carry special parameters (either in the URL or in `POST` data)
+  that bypasses further restrictions when set to ``1``:
+
+    * `override_phase_check` lets the operation proceed regardless of contest phase
+      (for example, you can submit even though the contest has already ended).
+
+    * `override_official` (in the submit endpoint) makes the submission count as
+      official regardless of contest phase.
+
+    * `override_max_number` (in the submit endpoint) skips all checks for the
+      maximum number of submits.
+
+    * `override_min_interval` (in the submit endpoint) skips all checks for the
+      minimum time interval between submits.

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -21,7 +21,7 @@ return a JSON object with the following structure:
 
 .. sourcecode:: json
 
-  {"login_data": string}
+  {"login_data": "string"}
 
 The content of the returned login data string should be passed to API calls
 that require authentication in a `X-CMS-Authorization` header.
@@ -36,7 +36,7 @@ running, will return the following object:
 
 .. sourcecode:: json
 
-  {"tasks": [{"name": string, "statements": [string], "submission_format": [string] }]}
+  {"tasks": [{"name": "string", "statements": ["string"], "submission_format": ["string"] }]}
 
 
 Tasks are ordered in the same order as in the UI. The `name` of the task is
@@ -57,7 +57,7 @@ The request will return an object with the ID of the new submission:
 
 .. sourcecode:: json
 
-  {"id": string}
+  {"id": "string"}
 
 
 List submissions
@@ -69,7 +69,7 @@ chronological order:
 
 .. sourcecode:: json
 
-  {"list": [{"id": string}]}
+  {"list": [{"id": "string"}]}
 
 Task statement
 ==============


### PR DESCRIPTION
This is a proof of concept of an extension of API authentication, which makes it possible to impersonate an arbitrary user if one knows a secret admin token (set in the configuration file). Impersonation will also make it possible to ignore certain restrictions (contest phase, time between submits).

I would like to use this for offline submissions made by the `ioisubmit` tool.

At this moment, I would like to know if you consider this approach reasonable before I finish all the details. (Please look only at the whole diff, individual commits are currently a tangled web of messy fixups.)