### PR TITLE
"Rerun and archive sandbox" button in AWS

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -81,7 +81,7 @@ __all__ = [
 
 # Instantiate or import these objects.
 
-version = 45
+version = 46
 
 engine = create_engine(config.database, echo=config.database_debug,
                        pool_timeout=60, pool_recycle=120)

--- a/cms/db/submission.py
+++ b/cms/db/submission.py
@@ -362,13 +362,12 @@ class SubmissionResult(Base):
     compilation_shard: int | None = Column(
         Integer,
         nullable=True)
-    compilation_sandbox: str | None = Column(
-        Unicode,
+    compilation_sandbox_paths: list[str] | None = Column(
+        ARRAY(Unicode),
         nullable=True)
-    compilation_sandbox_digests = Column(
+    compilation_sandbox_digests: list[str] | None = Column(
         ARRAY(String),
-        nullable=True
-    )
+        nullable=True)
 
     # Evaluation outcome (can be None = yet to evaluate, "ok" =
     # evaluation successful). At any time, this should be equal to
@@ -784,13 +783,12 @@ class Evaluation(Base):
     evaluation_shard: int | None = Column(
         Integer,
         nullable=True)
-    evaluation_sandbox: str | None = Column(
-        Unicode,
+    evaluation_sandbox_paths: list[str] | None = Column(
+        ARRAY(Unicode),
         nullable=True)
-    evaluation_sandbox_digests = Column(
+    evaluation_sandbox_digests: list[str] | None = Column(
         ARRAY(String),
-        nullable=True
-    )
+        nullable=True)
 
     @property
     def codename(self) -> str:

--- a/cms/db/submission.py
+++ b/cms/db/submission.py
@@ -365,6 +365,10 @@ class SubmissionResult(Base):
     compilation_sandbox: str | None = Column(
         Unicode,
         nullable=True)
+    compilation_sandbox_digests = Column(
+        ARRAY(String),
+        nullable=True
+    )
 
     # Evaluation outcome (can be None = yet to evaluate, "ok" =
     # evaluation successful). At any time, this should be equal to
@@ -594,16 +598,22 @@ class SubmissionResult(Base):
         self.compilation_memory = None
         self.compilation_shard = None
         self.compilation_sandbox = None
+        self.compilation_sandbox_digests = []
         self.executables = {}
 
-    def invalidate_evaluation(self):
+    def invalidate_evaluation(self, testcase_id: int | None = None):
         """Blank the evaluation outcomes and the score.
+
+        testcase_id: ID of testcase to invalidate, or None to invalidate all.
 
         """
         self.invalidate_score()
         self.evaluation_outcome = None
         self.evaluation_tries = 0
-        self.evaluations = []
+        if testcase_id:
+            self.evaluations = [e for e in self.evaluations if e.testcase_id != testcase_id]
+        else:
+            self.evaluations = []
 
     def invalidate_score(self):
         """Blank the score.
@@ -777,6 +787,10 @@ class Evaluation(Base):
     evaluation_sandbox: str | None = Column(
         Unicode,
         nullable=True)
+    evaluation_sandbox_digests = Column(
+        ARRAY(String),
+        nullable=True
+    )
 
     @property
     def codename(self) -> str:

--- a/cms/db/usertest.py
+++ b/cms/db/usertest.py
@@ -312,8 +312,11 @@ class UserTestResult(Base):
     compilation_shard: int | None = Column(
         Integer,
         nullable=True)
-    compilation_sandbox: str | None = Column(
-        String,
+    compilation_sandbox_paths: list[str] | None = Column(
+        ARRAY(Unicode),
+        nullable=True)
+    compilation_sandbox_digests: list[str] | None = Column(
+        ARRAY(String),
         nullable=True)
 
     # Evaluation outcome (can be None = yet to evaluate, "ok" =
@@ -352,8 +355,11 @@ class UserTestResult(Base):
     evaluation_shard: int | None = Column(
         Integer,
         nullable=True)
-    evaluation_sandbox: str | None = Column(
-        String,
+    evaluation_sandbox_paths: list[str] | None = Column(
+        ARRAY(Unicode),
+        nullable=True)
+    evaluation_sandbox_digests: list[str] | None = Column(
+        ARRAY(String),
         nullable=True)
 
     # These one-to-many relationships are the reversed directions of

--- a/cms/grading/Job.py
+++ b/cms/grading/Job.py
@@ -85,9 +85,11 @@ class Job:
         task_type_parameters: object = None,
         language: str | None = None,
         multithreaded_sandbox: bool = False,
+        archive_sandbox: bool = False,
         shard: int | None = None,
         keep_sandbox: bool = False,
         sandboxes: list[str] | None = None,
+        sandbox_digests: list[str] | None = None,
         info: str | None = None,
         success: bool | None = None,
         text: list[str] | None = None,
@@ -104,12 +106,15 @@ class Job:
         language: the language of the submission / user test.
         multithreaded_sandbox: whether the sandbox should
             allow multithreading.
+        archive_sandbox: whether the sandbox is to be archived.
         shard: the shard of the Worker completing this job.
         keep_sandbox: whether to forcefully keep the sandbox,
             even if other conditions (the config, the sandbox status)
             don't warrant it.
         sandboxes: the paths of the sandboxes used in
             the Worker during the execution of the job.
+        sandbox_digests: the digests of the sandbox
+            archives used to debug user solutions.
         info: a human readable description of the job.
         success: whether the job succeeded.
         text: description of the outcome of the job,
@@ -125,6 +130,8 @@ class Job:
             task_type = ""
         if sandboxes is None:
             sandboxes = []
+        if sandbox_digests is None:
+            sandbox_digests = []
         if info is None:
             info = ""
         if files is None:
@@ -139,9 +146,11 @@ class Job:
         self.task_type_parameters = task_type_parameters
         self.language = language
         self.multithreaded_sandbox = multithreaded_sandbox
+        self.archive_sandbox = archive_sandbox
         self.shard = shard
         self.keep_sandbox = keep_sandbox
         self.sandboxes = sandboxes
+        self.sandbox_digests = sandbox_digests
         self.info = info
 
         self.success = success
@@ -161,9 +170,11 @@ class Job:
             'task_type_parameters': self.task_type_parameters,
             'language': self.language,
             'multithreaded_sandbox': self.multithreaded_sandbox,
+            'archive_sandbox': self.archive_sandbox,
             'shard': self.shard,
             'keep_sandbox': self.keep_sandbox,
             'sandboxes': self.sandboxes,
+            'sandbox_digests': self.sandbox_digests,
             'info': self.info,
             'success': self.success,
             'text': self.text,
@@ -274,9 +285,11 @@ class CompilationJob(Job):
         shard: int | None = None,
         keep_sandbox: bool = False,
         sandboxes: list[str] | None = None,
+        sandbox_digests: list[str] | None = None,
         info: str | None = None,
         language: str | None = None,
         multithreaded_sandbox: bool = False,
+        archive_sandbox: bool = False,
         files: dict[str, File] | None = None,
         managers: dict[str, Manager] | None = None,
         success: bool | None = None,
@@ -296,9 +309,9 @@ class CompilationJob(Job):
         """
 
         Job.__init__(self, operation, task_type, task_type_parameters,
-                     language, multithreaded_sandbox,
-                     shard, keep_sandbox, sandboxes, info, success, text,
-                     files, managers, executables)
+                     language, multithreaded_sandbox, archive_sandbox,
+                     shard, keep_sandbox, sandboxes, sandbox_digests, info, success,
+                     text, files, managers, executables)
         self.compilation_success = compilation_success
         self.plus = plus
 
@@ -341,6 +354,7 @@ class CompilationJob(Job):
             task_type_parameters=dataset.task_type_parameters,
             language=submission.language,
             multithreaded_sandbox=multithreaded,
+            archive_sandbox=operation.archive_sandbox,
             files=dict(submission.files),
             managers=dict(dataset.managers),
             info="compile submission %d" % (submission.id)
@@ -368,6 +382,7 @@ class CompilationJob(Job):
         sr.compilation_memory = self.plus.get('execution_memory')
         sr.compilation_shard = self.shard
         sr.compilation_sandbox = ":".join(self.sandboxes)
+        sr.compilation_sandbox_digests = self.sandbox_digests
         for executable in self.executables.values():
             sr.executables.set(executable)
 
@@ -431,6 +446,7 @@ class CompilationJob(Job):
             task_type_parameters=dataset.task_type_parameters,
             language=user_test.language,
             multithreaded_sandbox=multithreaded,
+            archive_sandbox=operation.archive_sandbox,
             files=dict(user_test.files),
             managers=managers,
             info="compile user test %d" % (user_test.id)
@@ -485,9 +501,11 @@ class EvaluationJob(Job):
         shard: int | None = None,
         keep_sandbox: bool = False,
         sandboxes: list[str] | None = None,
+        sandbox_digests: list[str] | None = None,
         info: str | None = None,
         language: str | None = None,
         multithreaded_sandbox: bool = False,
+        archive_sandbox: bool = False,
         files: dict[str, File] | None = None,
         managers: dict[str, Manager] | None = None,
         executables: dict[str, Executable] | None = None,
@@ -526,9 +544,9 @@ class EvaluationJob(Job):
 
         """
         Job.__init__(self, operation, task_type, task_type_parameters,
-                     language, multithreaded_sandbox,
-                     shard, keep_sandbox, sandboxes, info, success, text,
-                     files, managers, executables)
+                     language, multithreaded_sandbox, archive_sandbox,
+                     shard, keep_sandbox, sandboxes, sandbox_digests, info, success,
+                     text, files, managers, executables)
         self.input = input
         self.output = output
         self.time_limit = time_limit
@@ -592,6 +610,7 @@ class EvaluationJob(Job):
             task_type_parameters=dataset.task_type_parameters,
             language=submission.language,
             multithreaded_sandbox=multithreaded,
+            archive_sandbox=operation.archive_sandbox,
             files=dict(submission.files),
             managers=dict(dataset.managers),
             executables=dict(submission_result.executables),
@@ -620,6 +639,7 @@ class EvaluationJob(Job):
             execution_memory=self.plus.get('execution_memory'),
             evaluation_shard=self.shard,
             evaluation_sandbox=":".join(self.sandboxes),
+            evaluation_sandbox_digests=self.sandbox_digests,
             testcase=sr.dataset.testcases[self.operation.testcase_codename])]
 
     @staticmethod
@@ -674,6 +694,7 @@ class EvaluationJob(Job):
             task_type_parameters=dataset.task_type_parameters,
             language=user_test.language,
             multithreaded_sandbox=multithreaded,
+            archive_sandbox=operation.archive_sandbox,
             files=dict(user_test.files),
             managers=managers,
             executables=dict(user_test_result.executables),

--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -27,6 +27,7 @@ import select
 import stat
 import tempfile
 import time
+import zipfile
 from abc import ABCMeta, abstractmethod
 from functools import wraps, partial
 import typing
@@ -532,9 +533,30 @@ class SandboxBase(metaclass=ABCMeta):
 
         delete: if True, also delete get_root_path() and everything it
             contains.
-
         """
         pass
+
+    def archive(self):
+        """Archive the directory where the sandbox operated.
+
+        """
+        logger.info("Archiving sandbox in %s.", self.get_root_path())
+
+        # Archive the working directory
+        sandbox_archive_filename = "sandbox.zip"
+        sandbox_archive = self.relative_path(sandbox_archive_filename)
+        content_path = self.get_root_path()
+        with zipfile.ZipFile(sandbox_archive, "w") as zip_file:
+            for root, dirs, files in os.walk(content_path):
+                if sandbox_archive_filename in files:
+                    files.remove(sandbox_archive_filename)
+                zip_file.write(root, os.path.relpath(root, content_path))
+                for f in files:
+                    f_path = os.path.join(root, f)
+                    zip_file.write(f_path, os.path.relpath(f_path, content_path))
+
+        # Put archive to FS
+        return self.get_file_to_storage(sandbox_archive, "Sandbox %s" % self.get_root_path())
 
 
 class StupidSandbox(SandboxBase):

--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -536,8 +536,11 @@ class SandboxBase(metaclass=ABCMeta):
         """
         pass
 
-    def archive(self):
+    def archive(self) -> str | None:
         """Archive the directory where the sandbox operated.
+
+        Stores the archived sandbox in the file cacher and returns its digest.
+        Returns None if archiving failed.
 
         """
         logger.info("Archiving sandbox in %s.", self.get_root_path())
@@ -545,8 +548,12 @@ class SandboxBase(metaclass=ABCMeta):
         with tempfile.TemporaryFile(dir=self.temp_dir) as sandbox_archive:
             # Archive the working directory
             content_path = self.get_root_path()
-            with tarfile.open(fileobj=sandbox_archive, mode='w:gz') as tar_file:
-                tar_file.add(content_path, os.path.basename(content_path))
+            try:
+                with tarfile.open(fileobj=sandbox_archive, mode='w:gz') as tar_file:
+                    tar_file.add(content_path, os.path.basename(content_path))
+            except Exception:
+                logger.warning("Failed to archive sandbox", exc_info=True)
+                return None
 
             # Put archive to FS
             sandbox_archive.seek(0)

--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -27,7 +27,7 @@ import select
 import stat
 import tempfile
 import time
-import zipfile
+import tarfile
 from abc import ABCMeta, abstractmethod
 from functools import wraps, partial
 import typing
@@ -545,14 +545,8 @@ class SandboxBase(metaclass=ABCMeta):
         with tempfile.TemporaryFile(dir=self.temp_dir) as sandbox_archive:
             # Archive the working directory
             content_path = self.get_root_path()
-            with zipfile.ZipFile(sandbox_archive, "w",
-                                 compression=zipfile.ZIP_DEFLATED,
-                                 compresslevel=9) as zip_file:
-                for root, dirs, files in os.walk(content_path):
-                    zip_file.write(root, os.path.relpath(root, content_path))
-                    for f in files:
-                        f_path = os.path.join(root, f)
-                        zip_file.write(f_path, os.path.relpath(f_path, content_path))
+            with tarfile.open(fileobj=sandbox_archive, mode='w:gz') as tar_file:
+                tar_file.add(content_path, os.path.basename(content_path))
 
             # Put archive to FS
             sandbox_archive.seek(0)

--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -257,7 +257,7 @@ class Batch(TaskType):
                 Executable(executable_filename, digest)
 
         # Cleanup.
-        delete_sandbox(sandbox, job.success, job.keep_sandbox)
+        delete_sandbox(sandbox, job, job.success, job.keep_sandbox)
 
     def compile(self, job, file_cacher):
         """See TaskType.compile."""
@@ -380,7 +380,7 @@ class Batch(TaskType):
         job.plus = stats
 
         if sandbox is not None:
-            delete_sandbox(sandbox, job.success, job.keep_sandbox)
+            delete_sandbox(sandbox, job, job.success, job.keep_sandbox)
 
     def evaluate(self, job, file_cacher):
         """See TaskType.evaluate."""

--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -257,7 +257,7 @@ class Batch(TaskType):
                 Executable(executable_filename, digest)
 
         # Cleanup.
-        delete_sandbox(sandbox, job, job.success, job.keep_sandbox)
+        delete_sandbox(sandbox, job)
 
     def compile(self, job, file_cacher):
         """See TaskType.compile."""
@@ -380,7 +380,7 @@ class Batch(TaskType):
         job.plus = stats
 
         if sandbox is not None:
-            delete_sandbox(sandbox, job, job.success, job.keep_sandbox)
+            delete_sandbox(sandbox, job)
 
     def evaluate(self, job, file_cacher):
         """See TaskType.evaluate."""

--- a/cms/grading/tasktypes/Communication.py
+++ b/cms/grading/tasktypes/Communication.py
@@ -242,7 +242,7 @@ class Communication(TaskType):
                 Executable(executable_filename, digest)
 
         # Cleanup.
-        delete_sandbox(sandbox, job.success, job.keep_sandbox)
+        delete_sandbox(sandbox, job, job.success, job.keep_sandbox)
 
     def evaluate(self, job, file_cacher):
         """See TaskType.evaluate."""
@@ -434,9 +434,9 @@ class Communication(TaskType):
         job.text = text
         job.plus = stats_user
 
-        delete_sandbox(sandbox_mgr, job.success, job.keep_sandbox)
+        delete_sandbox(sandbox_mgr, job, job.success, job.keep_sandbox)
         for s in sandbox_user:
-            delete_sandbox(s, job.success, job.keep_sandbox)
+            delete_sandbox(s, job, job.success, job.keep_sandbox)
         if job.success and not config.keep_sandbox and not job.keep_sandbox:
             for d in fifo_dir:
                 rmtree(d)

--- a/cms/grading/tasktypes/Communication.py
+++ b/cms/grading/tasktypes/Communication.py
@@ -242,7 +242,7 @@ class Communication(TaskType):
                 Executable(executable_filename, digest)
 
         # Cleanup.
-        delete_sandbox(sandbox, job, job.success, job.keep_sandbox)
+        delete_sandbox(sandbox, job)
 
     def evaluate(self, job, file_cacher):
         """See TaskType.evaluate."""
@@ -434,9 +434,9 @@ class Communication(TaskType):
         job.text = text
         job.plus = stats_user
 
-        delete_sandbox(sandbox_mgr, job, job.success, job.keep_sandbox)
+        delete_sandbox(sandbox_mgr, job)
         for s in sandbox_user:
-            delete_sandbox(s, job, job.success, job.keep_sandbox)
+            delete_sandbox(s, job)
         if job.success and not config.keep_sandbox and not job.keep_sandbox:
             for d in fifo_dir:
                 rmtree(d)

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -210,7 +210,7 @@ class TwoSteps(TaskType):
                 Executable(executable_filename, digest)
 
         # Cleanup
-        delete_sandbox(sandbox, job.success, job.keep_sandbox)
+        delete_sandbox(sandbox, job, job.success, job.keep_sandbox)
 
     def evaluate(self, job, file_cacher):
         """See TaskType.evaluate."""
@@ -346,5 +346,5 @@ class TwoSteps(TaskType):
         job.text = text
         job.plus = stats
 
-        delete_sandbox(first_sandbox, job.success, job.keep_sandbox)
-        delete_sandbox(second_sandbox, job.success, job.keep_sandbox)
+        delete_sandbox(first_sandbox, job, job.success, job.keep_sandbox)
+        delete_sandbox(second_sandbox, job, job.success, job.keep_sandbox)

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -210,7 +210,7 @@ class TwoSteps(TaskType):
                 Executable(executable_filename, digest)
 
         # Cleanup
-        delete_sandbox(sandbox, job, job.success, job.keep_sandbox)
+        delete_sandbox(sandbox, job)
 
     def evaluate(self, job, file_cacher):
         """See TaskType.evaluate."""
@@ -346,5 +346,5 @@ class TwoSteps(TaskType):
         job.text = text
         job.plus = stats
 
-        delete_sandbox(first_sandbox, job, job.success, job.keep_sandbox)
-        delete_sandbox(second_sandbox, job, job.success, job.keep_sandbox)
+        delete_sandbox(first_sandbox, job)
+        delete_sandbox(second_sandbox, job)

--- a/cms/grading/tasktypes/util.py
+++ b/cms/grading/tasktypes/util.py
@@ -84,7 +84,8 @@ def delete_sandbox(sandbox: Sandbox, job: Job, success: bool | None = None):
     # Archive the sandbox if required
     if job.archive_sandbox:
         sandbox_digest = sandbox.archive()
-        job.sandbox_digests[sandbox.get_root_path()] = sandbox_digest
+        if sandbox_digest is not None:
+            job.sandbox_digests[sandbox.get_root_path()] = sandbox_digest
 
     # If the job was not successful, we keep the sandbox around.
     if not success:

--- a/cms/grading/tasktypes/util.py
+++ b/cms/grading/tasktypes/util.py
@@ -84,7 +84,7 @@ def delete_sandbox(sandbox: Sandbox, job: Job, success: bool | None = None):
     # Archive the sandbox if required
     if job.archive_sandbox:
         sandbox_digest = sandbox.archive()
-        job.sandbox_digests.append(sandbox_digest)
+        job.sandbox_digests[sandbox.get_root_path()] = sandbox_digest
 
     # If the job was not successful, we keep the sandbox around.
     if not success:

--- a/cms/grading/tasktypes/util.py
+++ b/cms/grading/tasktypes/util.py
@@ -69,16 +69,18 @@ def create_sandbox(file_cacher: FileCacher, name: str | None = None) -> Sandbox:
     return sandbox
 
 
-def delete_sandbox(sandbox: Sandbox, job: Job, success: bool = True, keep_sandbox: bool = False):
+def delete_sandbox(sandbox: Sandbox, job: Job, success: bool | None = None):
     """Delete the sandbox, if the configuration and job was ok.
 
     sandbox: the sandbox to delete.
     job: the job currently running.
-    success: if the job succeeded (no system errors).
-    keep_sandbox: whether to keep the sandbox regardless of other
-        conditions.
+    success: if the job succeeded (no system errors). If not provided,
+        job.success is used.
 
     """
+    if success is None:
+        success = job.success
+
     # Archive the sandbox if required
     if job.archive_sandbox:
         sandbox_digest = sandbox.archive()
@@ -89,7 +91,7 @@ def delete_sandbox(sandbox: Sandbox, job: Job, success: bool = True, keep_sandbo
         logger.warning("Sandbox %s kept around because job did not succeed.",
                        sandbox.get_root_path())
 
-    delete = success and not config.keep_sandbox and not keep_sandbox
+    delete = success and not config.keep_sandbox and not job.keep_sandbox
     try:
         sandbox.cleanup(delete=delete)
     except OSError:
@@ -276,7 +278,7 @@ def eval_output(
             sandbox, checker_digest, job.input, job.output,
             EVAL_USER_OUTPUT_FILENAME, extra_args)
 
-        delete_sandbox(sandbox, job, success, job.keep_sandbox)
+        delete_sandbox(sandbox, job, success)
         return success, outcome, text
 
     else:

--- a/cms/server/admin/templates/submission.html
+++ b/cms/server/admin/templates/submission.html
@@ -156,7 +156,7 @@
         <td>
           {% if sr.compilation_sandbox_digests %}
             {% for sandbox_digest in sr.compilation_sandbox_digests %}
-              {%- set filename = "submission_%s_compilation_sandbox_%s.zip"|format(sr.submission_id, loop.index) -%}
+              {%- set filename = "submission_%s_compilation_sandbox_%s.tar.gz"|format(sr.submission_id, loop.index) -%}
               <a href="{{ url("file", sandbox_digest, filename) }}">
                 {{- sr.compilation_sandbox_paths[loop.index0] -}}
               </a>
@@ -286,7 +286,7 @@
           <td>
             {% if ev.evaluation_sandbox_digests %}
               {% for sandbox_digest in ev.evaluation_sandbox_digests %}
-                {%- set filename = "submission_%s_testcase_%s_sandbox_%s.zip"|format(sr.submission_id, ev.codename, loop.index) -%}
+                {%- set filename = "submission_%s_testcase_%s_sandbox_%s.tar.gz"|format(sr.submission_id, ev.codename, loop.index) -%}
                 <a href="{{ url("file", sandbox_digest, filename) }}">
                   {{- ev.evaluation_sandbox_paths[loop.index0] -}}
                 </a>

--- a/cms/server/admin/templates/submission.html
+++ b/cms/server/admin/templates/submission.html
@@ -153,7 +153,34 @@
       </tr>
       <tr>
         <td>Compilation sandbox</td>
-        <td>{{ sr.compilation_sandbox }}</td>
+        <td>
+          {{ sr.compilation_sandbox }}
+
+          {% if sr.compilation_sandbox_digests %}
+            ({%- for sandbox_digest in sr.compilation_sandbox_digests -%}
+              {%- set filename = "submission_%s_compilation_sandbox_%s.zip"|format(sr.submission_id, loop.index) -%}
+              <a href="{{ url("file", sandbox_digest, filename) }}" style="margin: 0 2px;">
+              {{- loop.index -}}
+              </a>
+            {%- endfor -%})
+          {% endif %}
+
+          <button onclick="cmsrpc_request(
+                           'EvaluationService', 0,
+                           'invalidate_submission', {
+                             'submission_id': {{ s.id }},
+                             'dataset_id': {{ shown_dataset.id }},
+                             'level': 'compilation',
+                             'archive_sandbox': true
+                           },
+                           function(response) { utils.redirect_if_ok('{{ url("submission", s.id, shown_dataset.id) }}', response); }
+          );"
+          {% if not admin.permission_all %}
+          disabled
+          {% endif %}>
+            Rerun and archive
+          </button>
+        </td>
       </tr>
       <tr>
         <td>Failures during evaluation</td>
@@ -256,7 +283,36 @@
             ({{ ev.execution_memory // (1024 * 1024) }} MiB)
             {% endif %}
           </td>
-          <td>{{ ev.evaluation_sandbox }}</td>
+          <td>
+            {{ ev.evaluation_sandbox }}
+
+            {% if ev.evaluation_sandbox_digests %}
+              ({%- for sandbox_digest in ev.evaluation_sandbox_digests -%}
+                {%- set filename = "submission_%s_testcase_%s_sandbox_%s.zip"|format(sr.submission_id, ev.codename, loop.index) -%}
+                <a href="{{ url("file", sandbox_digest, filename) }}" style="margin: 0 2px;">
+                  {{- loop.index -}}
+                </a>
+              {%- endfor -%})
+            {% endif %}
+
+            <button
+              onclick="cmsrpc_request(
+                       'EvaluationService', 0,
+                       'invalidate_submission', {
+                         'submission_id': {{ s.id }},
+                         'dataset_id': {{ shown_dataset.id }},
+                         'testcase_id': {{ ev.testcase_id }},
+                         'level': 'evaluation',
+                         'archive_sandbox': true
+                       },
+                       function(response) { utils.redirect_if_ok('{{ url("submission", s.id, shown_dataset.id) }}', response); }
+            );"
+            {% if not admin.permission_all %}
+            disabled
+            {% endif %}>
+              Rerun and archive
+            </button>
+          </td>
         </tr>
         {% endfor %}
       {% endif %}

--- a/cms/server/admin/templates/submission.html
+++ b/cms/server/admin/templates/submission.html
@@ -154,15 +154,15 @@
       <tr>
         <td>Compilation sandbox</td>
         <td>
-          {{ sr.compilation_sandbox }}
-
           {% if sr.compilation_sandbox_digests %}
-            ({%- for sandbox_digest in sr.compilation_sandbox_digests -%}
+            {% for sandbox_digest in sr.compilation_sandbox_digests %}
               {%- set filename = "submission_%s_compilation_sandbox_%s.zip"|format(sr.submission_id, loop.index) -%}
-              <a href="{{ url("file", sandbox_digest, filename) }}" style="margin: 0 2px;">
-              {{- loop.index -}}
+              <a href="{{ url("file", sandbox_digest, filename) }}">
+                {{- sr.compilation_sandbox_paths[loop.index0] -}}
               </a>
-            {%- endfor -%})
+            {% endfor %}
+          {% else %}
+            {{ sr.compilation_sandbox_paths|join(" ") }}
           {% endif %}
 
           <button onclick="cmsrpc_request(
@@ -284,15 +284,15 @@
             {% endif %}
           </td>
           <td>
-            {{ ev.evaluation_sandbox }}
-
             {% if ev.evaluation_sandbox_digests %}
-              ({%- for sandbox_digest in ev.evaluation_sandbox_digests -%}
+              {% for sandbox_digest in ev.evaluation_sandbox_digests %}
                 {%- set filename = "submission_%s_testcase_%s_sandbox_%s.zip"|format(sr.submission_id, ev.codename, loop.index) -%}
-                <a href="{{ url("file", sandbox_digest, filename) }}" style="margin: 0 2px;">
-                  {{- loop.index -}}
+                <a href="{{ url("file", sandbox_digest, filename) }}">
+                  {{- ev.evaluation_sandbox_paths[loop.index0] -}}
                 </a>
-              {%- endfor -%})
+              {% endfor %}
+            {% else %}
+              {{ ev.evaluation_sandbox_paths|join(" ") }}
             {% endif %}
 
             <button

--- a/cms/server/admin/templates/user_test.html
+++ b/cms/server/admin/templates/user_test.html
@@ -86,11 +86,15 @@
       </tr>
       <tr>
         <td>Compilation sandbox</td>
-        <td>{{ utr.compilation_sandbox }}</td>
+        <td>{{ utr.compilation_sandbox_paths|join(" ") }}</td>
       </tr>
       <tr>
         <td>Failures during evaluation</td>
         <td>{{ utr.evaluation_tries }}</td>
+      </tr>
+      <tr>
+        <td>Evaluation sandbox</td>
+        <td>{{ utr.evaluation_sandbox_paths|join(" ") }}</td>
       </tr>
       {% endif %}
     </tbody>

--- a/cmscontrib/updaters/update_46.py
+++ b/cmscontrib/updaters/update_46.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2025 p. randla <prandla@r9.pm>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A class to update a dump created by CMS.
+
+Used by DumpImporter and DumpUpdater.
+
+Converts the '*_sandbox' columns to '*_sandbox_paths' columns.
+
+"""
+
+def convert(val: str | None):
+    if val is None:
+        return None
+    if val == '':
+        return []
+    return val.split(':')
+
+class Updater:
+
+    def __init__(self, data):
+        assert data["_version"] == 44
+        self.objs = data
+
+    def run(self):
+        for k, v in self.objs.items():
+            if k.startswith("_"):
+                continue
+            if v["_class"] == "SubmissionResult":
+                v['compilation_sandbox_paths'] = convert(v.get('compilation_sandbox'))
+                del v['compilation_sandbox']
+            elif v["_class"] == "Evaluation":
+                v['evaluation_sandbox_paths'] = convert(v.get('evaluation_sandbox'))
+                del v['evaluation_sandbox']
+            elif v["_class"] == "UserTestResult":
+                v['compilation_sandbox_paths'] = convert(v.get('compilation_sandbox'))
+                v['evaluation_sandbox_paths'] = convert(v.get('evaluation_sandbox'))
+                del v['compilation_sandbox']
+                del v['evaluation_sandbox']
+
+        return self.objs
+

--- a/cmscontrib/updaters/update_46.py
+++ b/cmscontrib/updaters/update_46.py
@@ -24,17 +24,22 @@ Converts the '*_sandbox' columns to '*_sandbox_paths' columns.
 
 """
 
-def convert(val: str | None):
-    if val is None:
-        return None
-    if val == '':
-        return []
-    return val.split(':')
+def convert(obj: dict, key: str):
+    old_val = obj.pop(key, None)
+
+    if old_val is None:
+        new_val = None
+    elif old_val == '':
+        new_val = []
+    else:
+        new_val = old_val.split(':')
+
+    obj[key + '_paths'] = new_val
 
 class Updater:
 
     def __init__(self, data):
-        assert data["_version"] == 44
+        assert data["_version"] == 45
         self.objs = data
 
     def run(self):
@@ -42,16 +47,12 @@ class Updater:
             if k.startswith("_"):
                 continue
             if v["_class"] == "SubmissionResult":
-                v['compilation_sandbox_paths'] = convert(v.get('compilation_sandbox'))
-                del v['compilation_sandbox']
+                convert(v, 'compilation_sandbox')
             elif v["_class"] == "Evaluation":
-                v['evaluation_sandbox_paths'] = convert(v.get('evaluation_sandbox'))
-                del v['evaluation_sandbox']
+                convert(v, 'evaluation_sandbox')
             elif v["_class"] == "UserTestResult":
-                v['compilation_sandbox_paths'] = convert(v.get('compilation_sandbox'))
-                v['evaluation_sandbox_paths'] = convert(v.get('evaluation_sandbox'))
-                del v['compilation_sandbox']
-                del v['evaluation_sandbox']
+                convert(v, 'compilation_sandbox')
+                convert(v, 'evaluation_sandbox')
 
         return self.objs
 

--- a/cmscontrib/updaters/update_from_1.5.sql
+++ b/cmscontrib/updaters/update_from_1.5.sql
@@ -24,4 +24,22 @@ UPDATE submissions SET opaque_id = id WHERE opaque_id IS NULL;
 ALTER TABLE submissions ADD CONSTRAINT participation_opaque_unique UNIQUE (participation_id, opaque_id);
 ALTER TABLE submissions ALTER COLUMN opaque_id SET NOT NULL;
 
+-- https://github.com/cms-dev/cms/pull/1456
+ALTER TABLE submission_results ADD COLUMN compilation_sandbox_paths VARCHAR[];
+ALTER TABLE submission_results ADD COLUMN compilation_sandbox_digests VARCHAR[];
+UPDATE submission_results SET compilation_sandbox_paths = string_to_array(compilation_sandbox, ':');
+ALTER TABLE submission_results DROP COLUMN compilation_sandbox;
+ALTER TABLE evaluations ADD COLUMN evaluation_sandbox_paths VARCHAR[];
+ALTER TABLE evaluations ADD COLUMN evaluation_sandbox_digests VARCHAR[];
+UPDATE evaluations SET evaluation_sandbox_paths = string_to_array(evaluation_sandbox, ':');
+ALTER TABLE evaluations DROP COLUMN evaluation_sandbox;
+ALTER TABLE user_test_results ADD COLUMN compilation_sandbox_paths VARCHAR[];
+ALTER TABLE user_test_results ADD COLUMN compilation_sandbox_digests VARCHAR[];
+UPDATE user_test_results SET compilation_sandbox_paths = string_to_array(compilation_sandbox, ':');
+ALTER TABLE user_test_results DROP COLUMN compilation_sandbox;
+ALTER TABLE user_test_results ADD COLUMN evaluation_sandbox_paths VARCHAR[];
+ALTER TABLE user_test_results ADD COLUMN evaluation_sandbox_digests VARCHAR[];
+UPDATE user_test_results SET evaluation_sandbox_paths = string_to_array(evaluation_sandbox, ':');
+ALTER TABLE user_test_results DROP COLUMN evaluation_sandbox;
+
 COMMIT;


### PR DESCRIPTION
Closes #1355.

This still needs a dump updater and SQL updater (because i changed the "sandbox paths" column from a :-separated string to an array). Other parts should be ready for review though.

I changed the UI a bit from the old implementation:
![image](https://github.com/user-attachments/assets/be5073ce-97ef-487d-a3a4-65aaea5bc454)
sandbox links are clickable when archived. There's also a similar button for the compile sandbox.

There's also most of the logic to archive user test sandboxes, but there's no RPC to invalidate them, so it can't actually be reached currently...