### PR TITLE
don't install testlib.h

### DIFF
--- a/install.py
+++ b/install.py
@@ -119,12 +119,6 @@ def install_config() -> None:
             shutil.copyfile(sample, config_path)
 
 
-def install_testlib() -> None:
-    progress("Installing testlib")
-    shutil.copyfile('cmscontrib/loaders/polygon/testlib.h',
-                    target_path / 'include/testlib.h')
-
-
 def check_isolate(args: Namespace) -> None:
     progress('Checking if isolate is available')
     isolate = shutil.which('isolate', mode=os.F_OK)
@@ -144,7 +138,6 @@ def install_cms(args: Namespace) -> None:
     create_venv()
     install_package()
     install_config()
-    install_testlib()
 
 
 def install_venv_with_deps(args: Namespace) -> None:

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ PACKAGE_DATA = {
     "cms.locale": [
         "*/LC_MESSAGES/*.*",
     ],
+    "cmscontrib": [
+        "loaders/polygon/testlib.h",
+    ],
     "cmsranking": [
         "static/img/*.*",
         "static/lib/*.*",


### PR DESCRIPTION
closes #1379.

Admittedly I think the original problem (testlib.h being accessible to solutions) was already fixed by the new installation method (now that it's forced to install in a venv, the header is in venv/include, which shouldn't be in the isolate sandbox), but doing it like this feels cleaner anyways.