### PR TITLE
AWS: fix some rows of submission details not showing up properly

### DIFF
--- a/cms/server/admin/templates/submission.html
+++ b/cms/server/admin/templates/submission.html
@@ -143,6 +143,8 @@
           {{ (sr.scored_at - s.timestamp).total_seconds()|format_duration }}
         </td>
       </tr>
+      {% endif %}
+      {% if sr is not none %}
       <tr>
         <td>Failures during compilation</td>
         <td>{{ sr.compilation_tries }}</td>


### PR DESCRIPTION
#1393 changed `{% if sr is not none %}` into `{% if sr is not none and sr.scored_at is not none %}`, however this `if` was guarding multiple table rows which then didn't show up if scored_at was missing.