### PR TITLE
make AWS more resilient towards missing ScoreTypes and Languages

### DIFF
--- a/cms/grading/languagemanager.py
+++ b/cms/grading/languagemanager.py
@@ -18,15 +18,18 @@
 
 """Provide utilities to work with programming language classes."""
 
+import logging
 from cms import plugin_list
 from cms.grading.language import Language
-
 
 __all__ = [
     "LANGUAGES",
     "HEADER_EXTS", "SOURCE_EXTS", "OBJECT_EXTS",
     "get_language", "filename_to_language"
 ]
+
+
+logger = logging.getLogger(__name__)
 
 
 LANGUAGES: list[Language] = list()
@@ -48,6 +51,25 @@ def get_language(name: str) -> Language:
     if name not in _BY_NAME:
         raise KeyError("Language `%s' not supported." % name)
     return _BY_NAME[name]
+
+
+def safe_get_lang_filename(lang: str | None, filename: str) -> str:
+    """Get the filename of a file in a specific programming language,
+    avoiding errors if the language isn't recognized.
+
+    lang: name of the programming language
+    filename: filename template (containing .%l)
+    return: filename with the template replaced.
+    """
+    if lang is None:
+        return filename
+    try:
+        language = get_language(lang)
+        source_ext = language.source_extension
+    except KeyError:
+        logger.warning(f"Found invalid language {lang}!")
+        source_ext = ".invalid_language"
+    return filename.replace(".%l", source_ext)
 
 
 def filename_to_language(filename: str, available_languages: list[Language] | None=None) -> Language | None:

--- a/cms/server/admin/handlers/submission.py
+++ b/cms/server/admin/handlers/submission.py
@@ -31,7 +31,7 @@ import logging
 import difflib
 
 from cms.db import Dataset, File, Submission
-from cms.server.jinja2_toolbox import safe_get_lang_filename
+from cms.grading.languagemanager import safe_get_lang_filename
 from cmscommon.datetime import make_datetime
 from .base import BaseHandler, FileHandler, require_permission
 
@@ -80,7 +80,7 @@ class SubmissionFileHandler(FileHandler):
         sub_file = self.safe_get_item(File, file_id)
         submission = sub_file.submission
 
-        real_filename = safe_get_lang_filename(submission, sub_file.filename)
+        real_filename = safe_get_lang_filename(submission.language, sub_file.filename)
         digest = sub_file.digest
 
         self.sql_session.close()
@@ -127,7 +127,7 @@ class SubmissionDiffHandler(BaseHandler):
         for fname in files_to_compare:
             if ".%l" in fname:
                 if sub_old.language == sub_new.language and sub_old.language is not None:
-                    real_fname = safe_get_lang_filename(sub_old, fname)
+                    real_fname = safe_get_lang_filename(sub_old.language, fname)
                 else:
                     real_fname = fname.replace(".%l", ".txt")
             else:

--- a/cms/server/admin/handlers/usertest.py
+++ b/cms/server/admin/handlers/usertest.py
@@ -21,7 +21,7 @@
 """
 
 from cms.db import Dataset, UserTestFile, UserTest
-from cms.server.jinja2_toolbox import safe_get_lang_filename
+from cms.grading.languagemanager import safe_get_lang_filename
 
 from .base import BaseHandler, FileHandler, require_permission
 
@@ -60,7 +60,7 @@ class UserTestFileHandler(FileHandler):
         user_test_file = self.safe_get_item(UserTestFile, file_id)
         user_test = user_test_file.user_test
 
-        real_filename = safe_get_lang_filename(user_test, user_test_file.filename)
+        real_filename = safe_get_lang_filename(user_test.language, user_test_file.filename)
         digest = user_test_file.digest
 
         self.sql_session.close()

--- a/cms/server/admin/templates/fragments/user_test_row.html
+++ b/cms/server/admin/templates/fragments/user_test_row.html
@@ -52,7 +52,7 @@
   </td>
   <td>
     {% for filename, sub_file in ut.files|dictsort(by="key") %}
-      {% set real_filename = get_lang_filename(ut, filename) %}
+      {% set real_filename = get_lang_filename(ut.language, filename) %}
     <a href="javascript:void(0);" onclick="utils.show_file('{{ real_filename }}','{{ url("user_test_file", sub_file.id) }}')">{{ real_filename }}</a><br/>
     {% endfor %}
   </td>

--- a/cms/server/admin/templates/macro/submission.html
+++ b/cms/server/admin/templates/macro/submission.html
@@ -165,7 +165,7 @@ dataset (Dataset|None): the dataset to show results for, or if not defined use
   </td>
   <td>
     {% for filename, sub_file in s.files|dictsort(by="key") %}
-      {% set real_filename = get_lang_filename(s, filename) %}
+      {% set real_filename = get_lang_filename(s.language, filename) %}
     <a href="javascript:void(0);" onclick="utils.show_file('{{ real_filename }}','{{ url("submission_file", sub_file.id) }}')">{{ real_filename }}</a><br/>
     {% endfor %}
   </td>

--- a/cms/server/admin/templates/submission.html
+++ b/cms/server/admin/templates/submission.html
@@ -48,7 +48,7 @@
         <td>
           {% for filename in s.task.submission_format %}
             {% if filename in s.files %}
-              {% set real_filename = get_lang_filename(s, filename) %}
+              {% set real_filename = get_lang_filename(s.language, filename) %}
           <a href="javascript:void(0);" onclick="utils.show_file('{{ real_filename }}','{{ url("submission_file", s.files[filename].id) }}')">
             {{ real_filename }}
           </a>

--- a/cms/server/admin/templates/user_test.html
+++ b/cms/server/admin/templates/user_test.html
@@ -41,7 +41,7 @@
         <td>
           {% for filename in ut.task.submission_format %}
             {% if filename in ut.files %}
-              {% set real_filename = get_lang_filename(ut, filename) %}
+              {% set real_filename = get_lang_filename(ut.language, filename) %}
           <a href="javascript:void(0);" onclick="utils.show_file('{{ real_filename }}','{{ url("user_test_file", ut.files[filename].id) }}')">
             {{ real_filename }}
           </a>

--- a/cms/server/jinja2_toolbox.py
+++ b/cms/server/jinja2_toolbox.py
@@ -35,11 +35,9 @@ from cms import TOKEN_MODE_DISABLED, TOKEN_MODE_FINITE, TOKEN_MODE_INFINITE, \
     TOKEN_MODE_MIXED, FEEDBACK_LEVEL_FULL, FEEDBACK_LEVEL_RESTRICTED, \
     FEEDBACK_LEVEL_OI_RESTRICTED
 from cms.db import SubmissionResult, UserTestResult
-from cms.db.submission import Submission
 from cms.db.task import Dataset
-from cms.db.usertest import UserTest
 from cms.grading import format_status_text
-from cms.grading.languagemanager import get_language
+from cms.grading.languagemanager import get_language, safe_get_lang_filename
 from cms.locale import Translation, DEFAULT_TRANSLATION
 from cmscommon.constants import \
     SCORE_MODE_MAX, SCORE_MODE_MAX_SUBTASK, SCORE_MODE_MAX_TOKENED_LAST
@@ -205,16 +203,6 @@ def safe_get_score_type(env: Environment, *, dataset: Dataset):
     # arbitrary exception, hence we stay as general as possible.
     except Exception as err:
         return env.undefined("ScoreType not found: %s" % err)
-
-def safe_get_lang_filename(submission: Submission | UserTest, filename: str) -> str:
-    if submission.language is None:
-        return filename
-    try:
-        lang = get_language(submission.language)
-        source_ext = lang.source_extension
-    except KeyError:
-        source_ext = ".txt"
-    return filename.replace(".%l", source_ext)
 
 def instrument_cms_toolbox(env: Environment):
     env.globals["get_task_type"] = safe_get_task_type


### PR DESCRIPTION
Closes #1095.

Fixed all cases where AWS relied on a Language object to get the source file extension, made it default to `.txt`.

There was also one case where an invalid ScoreType would throw errors on the submission details page, fixed that too.

Invalid TaskTypes seem to already be handled correctly.