### PR TITLE
cmsAddSubmission: Add the --lang parameter

### DIFF
--- a/cms/grading/languagemanager.py
+++ b/cms/grading/languagemanager.py
@@ -50,7 +50,7 @@ def get_language(name: str) -> Language:
     return _BY_NAME[name]
 
 
-def filename_to_language(filename: str) -> Language | None:
+def filename_to_language(filename: str, available_languages: list[Language] | None=None) -> Language | None:
     """Return one of the languages inferred from the given filename.
 
     filename: the file to test.
@@ -59,12 +59,14 @@ def filename_to_language(filename: str) -> Language | None:
     matching the given filename, or None if none match.
 
     """
+    if available_languages is None:
+        available_languages = LANGUAGES
     ext_index = filename.rfind(".")
     if ext_index == -1:
         return None
     ext = filename[ext_index:]
     names = sorted(language.name
-                   for language in LANGUAGES
+                   for language in available_languages
                    if ext in language.source_extensions)
     return None if len(names) == 0 else get_language(names[0])
 

--- a/cmscontrib/AddSubmission.py
+++ b/cmscontrib/AddSubmission.py
@@ -46,7 +46,7 @@ def maybe_send_notification(submission_id: int):
     rs.disconnect()
 
 
-def language_from_submitted_files(files: dict[str, str]) -> Language | None:
+def language_from_submitted_files(files: dict[str, str], contest_languages: list[Language]) -> Language | None:
     """Return the language inferred from the submitted files.
 
     files: dictionary mapping the expected filename to a path in
@@ -61,7 +61,7 @@ def language_from_submitted_files(files: dict[str, str]) -> Language | None:
     # TODO: deduplicate with the code in SubmitHandler.
     language = None
     for filename in files.keys():
-        this_language = filename_to_language(files[filename])
+        this_language = filename_to_language(files[filename], contest_languages)
         if this_language is None and ".%l" in filename:
             raise ValueError(
                 "Cannot recognize language for file `%s'." % filename)
@@ -126,7 +126,11 @@ def add_submission(
                 if given_language is not None:
                     language = get_language(given_language)
                 else:
-                    language = language_from_submitted_files(files)
+                    contest_languages = [
+                        get_language(language)
+                        for language in task.contest.languages
+                    ]
+                    language = language_from_submitted_files(files, contest_languages)
             except ValueError as e:
                 logger.critical(e)
                 return False

--- a/cmstestsuite/unit_tests/cmscontrib/AddSubmissionTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/AddSubmissionTest.py
@@ -38,10 +38,11 @@ _CONTENT_3 = b"this is one more"
 _DIGEST_1 = bytes_digest(_CONTENT_1)
 _DIGEST_2 = bytes_digest(_CONTENT_2)
 _DIGEST_3 = bytes_digest(_CONTENT_3)
-_FILENAME_1 = "file.c"
+_FILENAME_1 = "file.cpp"
 _FILENAME_2 = "file"
 _FILENAME_3 = "file.py"
-_LANGUAGE_1 = "C11 / gcc"
+_LANGUAGE_1 = "C++20 / g++"
+_LANGUAGE_1_ALT = "C++17 / g++"
 
 
 class TestAddSubmissionMixin(DatabaseMixin, FileSystemMixin):
@@ -106,43 +107,50 @@ class TestAddSubmissionSingleSourceWithLanguage(
     def test_success(self):
         self.assertTrue(add_submission(
             self.contest.id, self.user.username, self.task.name, _TS,
-            {"source.%l": self.get_path(_FILENAME_1)}))
+            {"source.%l": self.get_path(_FILENAME_1)}, None))
         self.assertSubmissionInDb(_TS, self.task, _LANGUAGE_1,
+                                  {"source.%l": _DIGEST_1})
+
+    def test_success_override_language(self):
+        self.assertTrue(add_submission(
+            self.contest.id, self.user.username, self.task.name, _TS,
+            {"source.%l": self.get_path(_FILENAME_1)}, _LANGUAGE_1_ALT))
+        self.assertSubmissionInDb(_TS, self.task, _LANGUAGE_1_ALT,
                                   {"source.%l": _DIGEST_1})
 
     def test_fail_no_task(self):
         # We pass a non-existing task name.
         self.assertFalse(add_submission(
             self.contest.id, self.user.username, self.task.name + "_wrong",
-            _TS, {}))
+            _TS, {}, None))
         self.assertSubmissionNotInDb(_TS)
 
     def test_fail_no_user(self):
         # We pass a non-existing username.
         self.assertFalse(add_submission(
             self.contest.id, self.user.username + "_wrong", self.task.name,
-            _TS, {}))
+            _TS, {}, None))
         self.assertSubmissionNotInDb(_TS)
 
     def test_fail_no_contest(self):
         # We pass a non-existing contest id.
         self.assertFalse(add_submission(
             self.contest.id + 100, self.user.username, self.task.name, _TS,
-            {}))
+            {}, None))
         self.assertSubmissionNotInDb(_TS)
 
     def test_fail_task_not_in_contest(self):
         # We pass a contest that does not contain the task.
         self.assertFalse(add_submission(
             self.other_contest.id, self.user.username, self.task.name, _TS,
-            {}))
+            {}, None))
         self.assertSubmissionNotInDb(_TS)
 
     def test_fail_no_language_inferrable_missing_source(self):
         # Task requires a language, but we don't provide any file that
         # indicate it.
         self.assertFalse(add_submission(
-            self.contest.id, self.user.username, self.task.name, _TS, {}))
+            self.contest.id, self.user.username, self.task.name, _TS, {}, None))
         self.assertSubmissionNotInDb(_TS)
 
     def test_fail_no_language_inferrable_missing_extension(self):
@@ -150,21 +158,21 @@ class TestAddSubmissionSingleSourceWithLanguage(
         # an extension defining the language.
         self.assertFalse(add_submission(
             self.contest.id, self.user.username, self.task.name, _TS,
-            {"source.%l": self.get_path(_FILENAME_2)}))
+            {"source.%l": self.get_path(_FILENAME_2)}, None))
         self.assertSubmissionNotInDb(_TS)
 
     def test_fail_file_not_found(self):
         # We provide a path, but the file does not exist.
         self.assertFalse(add_submission(
             self.contest.id, self.user.username, self.task.name, _TS,
-            {"source.%l": self.get_path("source_not_existing.c")}))
+            {"source.%l": self.get_path("source_not_existing.c")}, None))
         self.assertSubmissionNotInDb(_TS)
 
     def test_fail_file_not_in_submission_format(self):
         # We provide a file, but for the wrong filename.
         self.assertFalse(add_submission(
             self.contest.id, self.user.username, self.task.name, _TS,
-            {"wrong_source.%l": self.get_path(_FILENAME_1)}))
+            {"wrong_source.%l": self.get_path(_FILENAME_1)}, None))
         self.assertSubmissionNotInDb(_TS)
 
 
@@ -186,7 +194,7 @@ class TestAddSubmissionTwoSourcesWithLanguage(
             self.contest.id, self.user.username, self.task.name, _TS, {
                 "source1.%l": self.get_path(_FILENAME_1),
                 "source2.%l": self.get_path(_FILENAME_1),
-             }))
+             }, None))
         self.assertSubmissionInDb(_TS, self.task, _LANGUAGE_1, {
             "source1.%l": _DIGEST_1,
             "source2.%l": _DIGEST_1,
@@ -197,7 +205,7 @@ class TestAddSubmissionTwoSourcesWithLanguage(
         # the language.
         self.assertTrue(add_submission(
             self.contest.id, self.user.username, self.task.name, _TS,
-            {"source1.%l": self.get_path(_FILENAME_1)}))
+            {"source1.%l": self.get_path(_FILENAME_1)}, None))
         self.assertSubmissionInDb(_TS, self.task, _LANGUAGE_1,
                                   {"source1.%l": _DIGEST_1})
 
@@ -206,7 +214,7 @@ class TestAddSubmissionTwoSourcesWithLanguage(
             self.contest.id, self.user.username, self.task.name, _TS, {
                 "source1.%l": self.get_path(_FILENAME_1),
                 "source2.%l": self.get_path(_FILENAME_2),
-             }))
+             }, None))
         self.assertSubmissionNotInDb(_TS)
 
     def test_fail_inconsistent_language(self):
@@ -215,7 +223,7 @@ class TestAddSubmissionTwoSourcesWithLanguage(
             self.contest.id, self.user.username, self.task.name, _TS, {
                 "source1.%l": self.get_path(_FILENAME_1),
                 "source2.%l": self.get_path(_FILENAME_3),
-            }))
+            }, None))
         self.assertSubmissionNotInDb(_TS)
 
 
@@ -237,7 +245,7 @@ class TestAddSubmissionTwoSourcesOneLanguage(
             self.contest.id, self.user.username, self.task.name, _TS, {
                 "source1.%l": self.get_path(_FILENAME_1),
                 "source2": self.get_path(_FILENAME_2),
-             }))
+             }, None))
         self.assertSubmissionInDb(_TS, self.task, _LANGUAGE_1, {
             "source1.%l": _DIGEST_1,
             "source2": _DIGEST_2,
@@ -248,7 +256,7 @@ class TestAddSubmissionTwoSourcesOneLanguage(
         # the language.
         self.assertTrue(add_submission(
             self.contest.id, self.user.username, self.task.name, _TS,
-            {"source1.%l": self.get_path(_FILENAME_1)}))
+            {"source1.%l": self.get_path(_FILENAME_1)}, None))
         self.assertSubmissionInDb(_TS, self.task, _LANGUAGE_1,
                                   {"source1.%l": _DIGEST_1})
 
@@ -257,7 +265,7 @@ class TestAddSubmissionTwoSourcesOneLanguage(
         # the language.
         self.assertFalse(add_submission(
             self.contest.id, self.user.username, self.task.name, _TS,
-            {"source2": self.get_path(_FILENAME_2)}))
+            {"source2": self.get_path(_FILENAME_2)}, None))
         self.assertSubmissionNotInDb(_TS)
 
 
@@ -276,13 +284,13 @@ class TestAddSubmissionOutputOnly(
     def test_success_no_language(self):
         self.assertTrue(add_submission(
             self.contest.id, self.user.username, self.task.name, _TS,
-            {"source": self.get_path(_FILENAME_2)}))
+            {"source": self.get_path(_FILENAME_2)}, None))
         self.assertSubmissionInDb(_TS, self.task, None, {"source": _DIGEST_2})
 
     def test_success_no_source(self):
         # Here we don't provide any file, but language is not required.
         self.assertTrue(add_submission(
-            self.contest.id, self.user.username, self.task.name, _TS, {}))
+            self.contest.id, self.user.username, self.task.name, _TS, {}, None))
         self.assertSubmissionInDb(_TS, self.task, None, {})
 
 


### PR DESCRIPTION
When multiple versions of C++ are enabled in a contest, it is impossible to guess the language by filename extension.

It is not checked that the language is really enabled in the contest. We consider this a feature (and document it as such), because it allows the administrator to test languages before they are made available to the contestants.

See issue #1372.