### PR TITLE
Use isolate's cg-oom-killed to detect "memory limit exceeded" conditions

### DIFF
--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -188,6 +188,7 @@ class SandboxBase(metaclass=ABCMeta):
     EXIT_SIGNAL = 'signal'
     EXIT_TIMEOUT = 'timeout'
     EXIT_TIMEOUT_WALL = 'wall timeout'
+    EXIT_MEM_LIMIT = 'memory limit exceeded'
     EXIT_NONZERO_RETURN = 'nonzero return'
 
     def __init__(
@@ -1283,7 +1284,10 @@ class IsolateSandbox(SandboxBase):
             else:
                 return self.EXIT_TIMEOUT
         elif 'SG' in status_list:
-            return self.EXIT_SIGNAL
+            if 'cg-oom-killed' in self.log:
+                return self.EXIT_MEM_LIMIT
+            else:
+                return self.EXIT_SIGNAL
         elif 'RE' in status_list:
             return self.EXIT_NONZERO_RETURN
         # OK status is not reported in the log file, it's implicit.

--- a/cms/grading/languages/php.py
+++ b/cms/grading/languages/php.py
@@ -59,4 +59,4 @@ class Php(Language):
             self, executable_filename, main=None, args=None):
         """See Language.get_evaluation_commands."""
         args = args if args is not None else []
-        return [["/usr/bin/php", executable_filename] + args]
+        return [["/usr/bin/php", "-d", "memory_limit=-1", executable_filename] + args]

--- a/cms/grading/steps/evaluation.py
+++ b/cms/grading/steps/evaluation.py
@@ -67,15 +67,12 @@ EVALUATION_MESSAGES = MessageCollection([
                     "for example. Note that in this case the CPU time "
                     "visible in the submission details might be much smaller "
                     "than the time limit.")),
+    HumanMessage("memorylimit",
+                 N_("Memory limit exceeded"),
+                 N_("Your submission used too much memory.")),
     HumanMessage("signal",
-                 N_("Execution killed (could be triggered by violating memory "
-                    "limits)"),
-                 N_("The evaluation was killed by a signal. "
-                    "Among other things, this might be caused by exceeding "
-                    "the memory limit. Note that if this is the reason, "
-                    "the memory usage visible in the submission details is "
-                    "the usage before the allocation that caused the "
-                    "signal.")),
+                 N_("Execution killed by signal"),
+                 N_("The evaluation was killed by a signal.")),
     HumanMessage("returncode",
                  N_("Execution failed because the return code was nonzero"),
                  N_("Your submission failed because it exited with a return "
@@ -244,6 +241,7 @@ def evaluation_step_after_run(
             Sandbox.EXIT_TIMEOUT,
             Sandbox.EXIT_TIMEOUT_WALL,
             Sandbox.EXIT_NONZERO_RETURN,
+            Sandbox.EXIT_MEM_LIMIT,
             Sandbox.EXIT_SIGNAL]:
         # Evaluation succeeded, and user program was interrupted for some error
         # condition. We report the success, the task type should decide how to
@@ -288,6 +286,8 @@ def human_evaluation_message(stats: StatsDict) -> list[str]:
     elif exit_status == Sandbox.EXIT_SANDBOX_ERROR:
         # Contestants won't see this, the submission will still be evaluating.
         return []
+    elif exit_status == Sandbox.EXIT_MEM_LIMIT:
+        return [EVALUATION_MESSAGES.get("memorylimit").message]
     elif exit_status == Sandbox.EXIT_NONZERO_RETURN:
         # Don't tell which code: would be too much information!
         return [EVALUATION_MESSAGES.get("returncode").message]

--- a/cmstestsuite/Test.py
+++ b/cmstestsuite/Test.py
@@ -136,6 +136,13 @@ class CheckNonzeroReturn(CheckAbstractEvaluationFailure):
             "Execution failed because the return code was nonzero")
 
 
+class CheckMemoryLimit(CheckAbstractEvaluationFailure):
+    def __init__(self):
+        CheckAbstractEvaluationFailure.__init__(
+            self, "memory limit exceeded",
+            "Memory limit exceeded")
+
+
 class CheckUserTest(ABC):
     @abstractmethod
     def check(self, *args, **kwargs):

--- a/cmstestsuite/Tests.py
+++ b/cmstestsuite/Tests.py
@@ -37,7 +37,7 @@ import cmstestsuite.tasks.outputonly as outputonly
 import cmstestsuite.tasks.outputonly_comparator as outputonly_comparator
 import cmstestsuite.tasks.twosteps as twosteps
 import cmstestsuite.tasks.twosteps_comparator as twosteps_comparator
-from cmstestsuite.Test import Test, CheckOverallScore, CheckCompilationFail, \
+from cmstestsuite.Test import CheckMemoryLimit, Test, CheckOverallScore, CheckCompilationFail, \
     CheckTimeout, CheckTimeoutWall, CheckNonzeroReturn, CheckUserTestEvaluated
 
 
@@ -257,12 +257,12 @@ ALL_TESTS = [
          task=batch_stdio, filenames=['oom-static.%l'],
          languages=(LANG_C, LANG_CPP, LANG_CPP14,
                     LANG_CPP17, LANG_CPP20, LANG_PASCAL),
-         checks=[CheckOverallScore(0, 100)]),
+         checks=[CheckOverallScore(0, 100), CheckMemoryLimit()]),
 
     Test('oom-heap',
          task=batch_stdio, filenames=['oom-heap.%l'],
          languages=ALL_LANGUAGES,
-         checks=[CheckOverallScore(0, 100)]),
+         checks=[CheckOverallScore(0, 100), CheckMemoryLimit()]),
 
     # Tasks with graders.
 


### PR DESCRIPTION
Closes #912.

I deleted the extra text from killed-by-signal's help text because it's not relevant there anymore (I hope). I didn't re-add it to the new error's help text because in my experience, it's not true: in all cases I have tried, the oom killer has been precise enough that the reported memory use is exactly the task's memory limit (up to the rounding precision, at least). The behaviour that was described in that deleted paragraph might have been possible with non-cgroups isolate? I'm not sure.

Also, PHP has a `memory_limit` setting that limits the amount of memory the interpreter even tries to allocate; this limit is 128M by default. Exceeding this causes PHP to exit with code 255 (and print a message on stdout). This broke the new tests (and in fact, this could have been caught earlier: all the other oom tests were killed by signal, whereas php was nonzero exit code, but this fact was not checked by the test). Actually, this was a bigger problem, in that PHP enforced a 128MB memory limit, ignoring whatever the task's memory limit was. This would be possible to fix in php.ini on worker machines, but the contest administrators would have to be aware of it. I fixed it by changing the limit to -1 (meaning "infinite") using a command-line argument.