### PR TITLE
clean up some imports

### DIFF
--- a/cms/io/web_service.py
+++ b/cms/io/web_service.py
@@ -28,10 +28,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.wsgi as tornado_wsgi
-except ImportError:
-    import tornado.wsgi as tornado_wsgi
+import tornado.wsgi
 from gevent.pywsgi import WSGIServer
 from werkzeug.contrib.fixers import ProxyFix
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
@@ -71,7 +68,7 @@ class WebService(Service):
         is_proxy_used = parameters.pop('is_proxy_used', None)
         num_proxies_used = parameters.pop('num_proxies_used', None)
 
-        self.wsgi_app = tornado_wsgi.WSGIApplication(handlers, **parameters)
+        self.wsgi_app = tornado.wsgi.WSGIApplication(handlers, **parameters)
         self.wsgi_app.service = self
 
         for entry in static_files:

--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -46,10 +46,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.web as tornado_web
-except ImportError:
-    import tornado.web as tornado_web
+import tornado.web
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Query, subqueryload
 
@@ -81,7 +78,7 @@ def argument_reader(func: Callable[[str], typing.Any], empty: object = None):
     """
 
     def helper(
-        self: tornado_web.RequestHandler, dest: dict, name: str, empty: object = empty
+        self: tornado.web.RequestHandler, dest: dict, name: str, empty: object = empty
     ):
         """Read the argument called "name" and save it in "dest".
 
@@ -194,7 +191,7 @@ def require_permission(permission: str = "authenticated", self_allowed: bool = F
 
         """
         @wraps(func)
-        @tornado_web.authenticated
+        @tornado.web.authenticated
         def newfunc(self: _T, *args: _P.args, **kwargs: _P.kwargs):
             """Check if the permission is present before calling the function.
 
@@ -213,7 +210,7 @@ def require_permission(permission: str = "authenticated", self_allowed: bool = F
                     # the current user id.
                     return func(self, *args, **kwargs)
                 else:
-                    raise tornado_web.HTTPError(403, "Admin is not authorized")
+                    raise tornado.web.HTTPError(403, "Admin is not authorized")
 
         return newfunc
 
@@ -302,7 +299,7 @@ class BaseHandler(CommonRequestHandler):
             session = self.sql_session
         entity = cls.get_from_id(ident, session)
         if entity is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
         return entity
 
     def prepare(self):
@@ -354,7 +351,7 @@ class BaseHandler(CommonRequestHandler):
 
     def write_error(self, status_code, **kwargs):
         if "exc_info" in kwargs and \
-                kwargs["exc_info"][0] != tornado_web.HTTPError:
+                kwargs["exc_info"][0] != tornado.web.HTTPError:
             exc_info = kwargs["exc_info"]
             logger.error(
                 "Uncaught exception (%r) while processing a request: %s",

--- a/cms/server/admin/handlers/contestannouncement.py
+++ b/cms/server/admin/handlers/contestannouncement.py
@@ -33,10 +33,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.web as tornado_web
-except ImportError:
-    import tornado.web as tornado_web
+import tornado.web
 
 from cms.db import Contest, Announcement
 from cmscommon.datetime import make_datetime
@@ -77,7 +74,7 @@ class AnnouncementHandler(BaseHandler):
 
         # Protect against URLs providing incompatible parameters.
         if self.contest is not ann.contest:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         self.sql_session.delete(ann)
         self.try_commit()

--- a/cms/server/admin/handlers/contestquestion.py
+++ b/cms/server/admin/handlers/contestquestion.py
@@ -35,10 +35,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.web as tornado_web
-except ImportError:
-    import tornado.web as tornado_web
+import tornado.web
 
 from cms.db import Contest, Question, Participation
 from cmscommon.datetime import make_datetime
@@ -88,7 +85,7 @@ class QuestionActionHandler(BaseHandler, metaclass=ABCMeta):
 
         # Protect against URLs providing incompatible parameters.
         if self.contest is not question.participation.contest:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         self.process_question(question)
         self.redirect(ref)
@@ -148,7 +145,7 @@ class QuestionClaimHandler(QuestionActionHandler):
     def process_question(self, question):
         # Can claim/unclaim only a question not ignored or answered.
         if question.ignored or question.reply_timestamp is not None:
-            raise tornado_web.HTTPError(405)
+            raise tornado.web.HTTPError(405)
 
         should_claim = self.get_argument("claim", "no") == "yes"
 

--- a/cms/server/admin/handlers/contestuser.py
+++ b/cms/server/admin/handlers/contestuser.py
@@ -38,10 +38,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.web as tornado_web
-except ImportError:
-    import tornado.web as tornado_web
+import tornado.web
 
 from cms.db import Contest, Message, Participation, Submission, User, Team
 from cmscommon.datetime import make_datetime
@@ -113,7 +110,7 @@ class RemoveParticipationHandler(BaseHandler):
         )
         # Check that the participation is valid.
         if participation is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         submission_query = self.sql_session.query(Submission)\
             .filter(Submission.participation == participation)
@@ -193,7 +190,7 @@ class ParticipationHandler(BaseHandler):
 
         # Check that the participation is valid.
         if participation is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         submission_query = self.sql_session.query(Submission)\
             .filter(Submission.participation == participation)
@@ -220,7 +217,7 @@ class ParticipationHandler(BaseHandler):
 
         # Check that the participation is valid.
         if participation is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         try:
             attrs = participation.get_attrs()
@@ -281,7 +278,7 @@ class MessageHandler(BaseHandler):
 
         # check that the participation is valid
         if participation is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         message = Message(make_datetime(),
                           self.get_argument("message_subject", ""),

--- a/cms/server/admin/handlers/dataset.py
+++ b/cms/server/admin/handlers/dataset.py
@@ -39,10 +39,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.web as tornado_web
-except ImportError:
-    import tornado.web as tornado_web
+import tornado.web
 
 from cms.db import Dataset, Manager, Message, Participation, \
     Session, Submission, Task, Testcase
@@ -102,7 +99,7 @@ class CloneDatasetHandler(BaseHandler):
                 self.safe_get_item(Dataset, dataset_id_to_copy)
             description = "Copy of %s" % original_dataset.description
         except ValueError:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         self.r_params = self.render_params()
         self.r_params["task"] = task
@@ -125,7 +122,7 @@ class CloneDatasetHandler(BaseHandler):
             original_dataset = \
                 self.safe_get_item(Dataset, dataset_id_to_copy)
         except ValueError:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         try:
             attrs = dict()
@@ -406,7 +403,7 @@ class DeleteManagerHandler(BaseHandler):
 
         # Protect against URLs providing incompatible parameters.
         if manager.dataset is not dataset:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         task_id = dataset.task_id
 
@@ -562,7 +559,7 @@ class DeleteTestcaseHandler(BaseHandler):
 
         # Protect against URLs providing incompatible parameters.
         if dataset is not testcase.dataset:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         task_id = testcase.dataset.task_id
 

--- a/cms/server/admin/handlers/task.py
+++ b/cms/server/admin/handlers/task.py
@@ -36,10 +36,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.web as tornado_web
-except ImportError:
-    import tornado.web as tornado_web
+import tornado.web
 
 from cms.db import Attachment, Dataset, Session, Statement, Submission, Task
 from cmscommon.datetime import make_datetime
@@ -296,7 +293,7 @@ class StatementHandler(BaseHandler):
 
         # Protect against URLs providing incompatible parameters.
         if task is not statement.task:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         self.sql_session.delete(statement)
         self.try_commit()
@@ -368,7 +365,7 @@ class AttachmentHandler(BaseHandler):
 
         # Protect against URLs providing incompatible parameters.
         if attachment.task is not task:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         self.sql_session.delete(attachment)
         self.try_commit()

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -42,10 +42,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.web as tornado_web
-except ImportError:
-    import tornado.web as tornado_web
+import tornado.web
 from werkzeug.datastructures import LanguageAccept
 from werkzeug.http import parse_accept_header
 
@@ -159,7 +156,7 @@ class BaseHandler(CommonRequestHandler):
 
     def write_error(self, status_code, **kwargs):
         if "exc_info" in kwargs and \
-                kwargs["exc_info"][0] != tornado_web.HTTPError:
+                kwargs["exc_info"][0] != tornado.web.HTTPError:
             exc_info = kwargs["exc_info"]
             logger.error(
                 "Uncaught exception (%r) while processing a request: %s",

--- a/cms/server/contest/handlers/communication.py
+++ b/cms/server/contest/handlers/communication.py
@@ -36,10 +36,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.web as tornado_web
-except ImportError:
-    import tornado.web as tornado_web
+import tornado.web
 
 from cms.server import multi_contest
 from cms.server.contest.communication import accept_question, \
@@ -60,7 +57,7 @@ class CommunicationHandler(ContestHandler):
     and the contest managers..
 
     """
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @multi_contest
     def get(self):
         self.render("communication.html", **self.r_params)
@@ -70,7 +67,7 @@ class QuestionHandler(ContestHandler):
     """Called when the user submits a question.
 
     """
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @multi_contest
     def post(self):
         try:
@@ -79,7 +76,7 @@ class QuestionHandler(ContestHandler):
                             self.get_argument("question_text", ""))
             self.sql_session.commit()
         except QuestionsNotAllowed:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
         except UnacceptableQuestion as e:
             self.notify_error(e.subject, e.text, e.text_params)
         else:

--- a/cms/server/contest/handlers/contest.py
+++ b/cms/server/contest/handlers/contest.py
@@ -44,10 +44,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.web as tornado_web
-except ImportError:
-    import tornado.web as tornado_web
+import tornado.web
 
 from cms import config, TOKEN_MODE_MIXED
 from cms.db import Contest, Submission, Task, UserTest, contest
@@ -126,7 +123,7 @@ class ContestHandler(BaseHandler):
                 # the one from the base class is enough to display a 404 page.
                 super().prepare()
                 self.r_params = super().render_params()
-                raise tornado_web.HTTPError(404)
+                raise tornado.web.HTTPError(404)
         else:
             # Select the contest specified on the command line
             self.contest = Contest.get_from_id(
@@ -164,7 +161,7 @@ class ContestHandler(BaseHandler):
         authorization_header = self.request.headers.get(
             "X-CMS-Authorization", None)
         if authorization_header is not None:
-            authorization_header = tornado_web.decode_signed_value(self.application.settings["cookie_secret"],
+            authorization_header = tornado.web.decode_signed_value(self.application.settings["cookie_secret"],
                                                                    cookie_name, authorization_header)
 
         try:

--- a/cms/server/contest/handlers/task.py
+++ b/cms/server/contest/handlers/task.py
@@ -37,10 +37,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.web as tornado_web
-except ImportError:
-    import tornado.web as tornado_web
+import tornado.web
 
 from cms.server import multi_contest
 from cmscommon.mimetypes import get_type_for_file_name
@@ -55,13 +52,13 @@ class TaskDescriptionHandler(ContestHandler):
     """Shows the data of a task in the contest.
 
     """
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0, 1, 2, 3, 4)
     @multi_contest
     def get(self, task_name):
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         self.render("task_description.html", task=task, **self.r_params)
 
@@ -70,16 +67,16 @@ class TaskStatementViewHandler(FileHandler):
     """Shows the statement file of a task in the contest.
 
     """
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0, 1, 2, 3, 4)
     @multi_contest
     def get(self, task_name: str, lang_code: str):
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         if lang_code not in task.statements:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         statement = task.statements[lang_code].digest
         self.sql_session.close()
@@ -96,16 +93,16 @@ class TaskAttachmentViewHandler(FileHandler):
     """Shows an attachment file of a task in the contest.
 
     """
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0, 1, 2, 3, 4)
     @multi_contest
     def get(self, task_name: str, filename: str):
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         if filename not in task.attachments:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         attachment = task.attachments[filename].digest
         self.sql_session.close()

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -43,10 +43,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.web as tornado_web
-except ImportError:
-    import tornado.web as tornado_web
+import tornado.web
 from sqlalchemy.orm import joinedload
 
 from cms import config, FEEDBACK_LEVEL_FULL
@@ -77,7 +74,7 @@ class SubmitHandler(ContestHandler):
 
     """
 
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0, 1, 2, 3)
     @multi_contest
     def post(self, task_name):
@@ -89,7 +86,7 @@ class SubmitHandler(ContestHandler):
 
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         # Only set the official bit when the user can compete and we are not in
         # analysis mode.
@@ -126,7 +123,7 @@ class TaskSubmissionsHandler(ContestHandler):
     """Shows the data of a task in the contest.
 
     """
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0, 1, 2, 3, 4)
     @multi_contest
     def get(self, task_name):
@@ -134,7 +131,7 @@ class TaskSubmissionsHandler(ContestHandler):
 
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         submissions: list[Submission] = (
             self.sql_session.query(Submission)
@@ -239,17 +236,17 @@ class SubmissionStatusHandler(ContestHandler):
             data["task_tokened_score"], score_type.max_score, None,
             task.score_precision, translation=self.translation)
 
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0, 1, 2, 3, 4)
     @multi_contest
     def get(self, task_name, opaque_id):
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         submission = self.get_submission(task, opaque_id)
         if submission is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         sr = submission.get_result(task.active_dataset)
 
@@ -299,17 +296,17 @@ class SubmissionDetailsHandler(ContestHandler):
 
     refresh_cookie = False
 
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0, 1, 2, 3, 4)
     @multi_contest
     def get(self, task_name, opaque_id):
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         submission = self.get_submission(task, opaque_id)
         if submission is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         sr = submission.get_result(task.active_dataset)
         score_type = task.active_dataset.score_type_object
@@ -340,20 +337,20 @@ class SubmissionFileHandler(FileHandler):
     """Send back a submission file.
 
     """
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0, 1, 2, 3, 4)
     @multi_contest
     def get(self, task_name, opaque_id, filename):
         if not self.contest.submissions_download_allowed:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         submission = self.get_submission(task, opaque_id)
         if submission is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         # The following code assumes that submission.files is a subset
         # of task.submission_format. CWS will always ensure that for new
@@ -370,7 +367,7 @@ class SubmissionFileHandler(FileHandler):
             stored_filename = re.sub(r'%s$' % extension, '.%l', filename)
 
         if stored_filename not in submission.files:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         digest = submission.files[stored_filename].digest
         self.sql_session.close()
@@ -386,17 +383,17 @@ class UseTokenHandler(ContestHandler):
     """Called when the user try to use a token on a submission.
 
     """
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0)
     @multi_contest
     def post(self, task_name, opaque_id):
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         submission = self.get_submission(task, opaque_id)
         if submission is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         try:
             accept_token(self.sql_session, submission, self.timestamp)

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -38,10 +38,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    import tornado4.web as tornado_web
-except ImportError:
-    import tornado.web as tornado_web
+import tornado.web
 
 from cms import config
 from cms.db import UserTest, UserTestResult
@@ -67,14 +64,14 @@ class UserTestInterfaceHandler(ContestHandler):
     """Serve the interface to test programs.
 
     """
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0)
     @multi_contest
     def get(self):
         participation = self.current_user
 
         if not self.r_params["testing_enabled"]:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         user_tests = dict()
         user_tests_left = dict()
@@ -123,16 +120,16 @@ class UserTestHandler(ContestHandler):
 
     refresh_cookie = False
 
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0)
     @multi_contest
     def post(self, task_name):
         if not self.r_params["testing_enabled"]:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         query_args = dict()
 
@@ -145,7 +142,7 @@ class UserTestHandler(ContestHandler):
         except TestingNotAllowed:
             logger.warning("User %s tried to make test on task %s.",
                            self.current_user.user.username, task_name)
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
         except UnacceptableUserTest as e:
             logger.info("Sent error: `%s' - `%s'", e.subject, e.formatted_text)
             self.notify_error(e.subject, e.text, e.text_params)
@@ -169,20 +166,20 @@ class UserTestStatusHandler(ContestHandler):
 
     refresh_cookie = False
 
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0)
     @multi_contest
     def get(self, task_name, user_test_num):
         if not self.r_params["testing_enabled"]:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         user_test = self.get_user_test(task, user_test_num)
         if user_test is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         ur = user_test.get_result(task.active_dataset)
         data = dict()
@@ -224,20 +221,20 @@ class UserTestDetailsHandler(ContestHandler):
 
     refresh_cookie = False
 
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0)
     @multi_contest
     def get(self, task_name, user_test_num):
         if not self.r_params["testing_enabled"]:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         user_test = self.get_user_test(task, user_test_num)
         if user_test is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         tr = user_test.get_result(task.active_dataset)
 
@@ -249,20 +246,20 @@ class UserTestIOHandler(FileHandler):
     """Send back a submission file.
 
     """
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0)
     @multi_contest
     def get(self, task_name, user_test_num, io):
         if not self.r_params["testing_enabled"]:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         user_test = self.get_user_test(task, user_test_num)
         if user_test is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         if io == "input":
             digest = user_test.input
@@ -272,7 +269,7 @@ class UserTestIOHandler(FileHandler):
         self.sql_session.close()
 
         if digest is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         mimetype = 'text/plain'
 
@@ -283,20 +280,20 @@ class UserTestFileHandler(FileHandler):
     """Send back a submission file.
 
     """
-    @tornado_web.authenticated
+    @tornado.web.authenticated
     @actual_phase_required(0)
     @multi_contest
     def get(self, task_name, user_test_num, filename):
         if not self.r_params["testing_enabled"]:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         task = self.get_task(task_name)
         if task is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         user_test = self.get_user_test(task, user_test_num)
         if user_test is None:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
 
         # filename is the name used by the browser, hence is something
         # like 'foo.c' (and the extension is CMS's preferred extension
@@ -314,7 +311,7 @@ class UserTestFileHandler(FileHandler):
             # Instead, the original name is used
             digest = user_test.managers[filename].digest
         else:
-            raise tornado_web.HTTPError(404)
+            raise tornado.web.HTTPError(404)
         self.sql_session.close()
 
         mimetype = get_type_for_file_name(filename)

--- a/cms/server/util.py
+++ b/cms/server/util.py
@@ -39,13 +39,7 @@ except:
 
 import typing
 
-if typing.TYPE_CHECKING:
-    from tornado.web import RequestHandler
-else:
-    try:
-        from tornado4.web import RequestHandler
-    except ImportError:
-        from tornado.web import RequestHandler
+from tornado.web import RequestHandler
 
 from cms.db import Session
 from cms.server.file_middleware import FileServerMiddleware

--- a/cmstestsuite/unit_tests/cmscontrib/AddAdminTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/AddAdminTest.py
@@ -20,7 +20,6 @@
 
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Admin

--- a/cmstestsuite/unit_tests/cmscontrib/AddParticipationTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/AddParticipationTest.py
@@ -21,7 +21,6 @@
 import ipaddress
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Participation

--- a/cmstestsuite/unit_tests/cmscontrib/AddStatementTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/AddStatementTest.py
@@ -20,7 +20,6 @@
 
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Statement

--- a/cmstestsuite/unit_tests/cmscontrib/AddSubmissionTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/AddSubmissionTest.py
@@ -20,7 +20,6 @@
 
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import File, Submission

--- a/cmstestsuite/unit_tests/cmscontrib/DumpExporterTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/DumpExporterTest.py
@@ -22,7 +22,6 @@ import json
 import os
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Contest, Executable, Participation, Statement, Submission, \

--- a/cmstestsuite/unit_tests/cmscontrib/DumpImporterTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/DumpImporterTest.py
@@ -22,7 +22,6 @@ import json
 import os
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Contest, User, FSObject, Session, version

--- a/cmstestsuite/unit_tests/cmscontrib/ImportContestTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/ImportContestTest.py
@@ -20,7 +20,6 @@
 
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Contest, SessionGen, Submission, User

--- a/cmstestsuite/unit_tests/cmscontrib/ImportDatasetTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/ImportDatasetTest.py
@@ -20,7 +20,6 @@
 
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Dataset, SessionGen

--- a/cmstestsuite/unit_tests/cmscontrib/ImportTaskTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/ImportTaskTest.py
@@ -20,7 +20,6 @@
 
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import SessionGen, Submission, Task

--- a/cmstestsuite/unit_tests/cmscontrib/ImportTeamTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/ImportTeamTest.py
@@ -20,7 +20,6 @@
 
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import SessionGen, Team

--- a/cmstestsuite/unit_tests/cmscontrib/ImportUserTest.py
+++ b/cmstestsuite/unit_tests/cmscontrib/ImportUserTest.py
@@ -20,7 +20,6 @@
 
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Participation, SessionGen, User

--- a/cmstestsuite/unit_tests/db/filecacher_test.py
+++ b/cmstestsuite/unit_tests/db/filecacher_test.py
@@ -29,7 +29,6 @@ import shutil
 import unittest
 from io import BytesIO
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db.filecacher import FileCacher

--- a/cmstestsuite/unit_tests/grading/ParameterTypesTest.py
+++ b/cmstestsuite/unit_tests/grading/ParameterTypesTest.py
@@ -27,10 +27,7 @@ except:
     # Monkey-patch: Tornado 4.5.3 does not work on Python 3.11 by default
     collections.MutableMapping = collections.abc.MutableMapping
 
-try:
-    from tornado4.web import MissingArgumentError
-except ImportError:
-    from tornado.web import MissingArgumentError
+from tornado.web import MissingArgumentError
 
 from cms.grading.ParameterTypes import ParameterTypeString, \
     ParameterTypeInt, ParameterTypeChoice, ParameterTypeCollection

--- a/cmstestsuite/unit_tests/grading/scoring_test.py
+++ b/cmstestsuite/unit_tests/grading/scoring_test.py
@@ -23,7 +23,6 @@
 import unittest
 from datetime import timedelta
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.grading.scoring import task_score

--- a/cmstestsuite/unit_tests/server/contest/authentication_test.py
+++ b/cmstestsuite/unit_tests/server/contest/authentication_test.py
@@ -25,7 +25,6 @@ import unittest
 from datetime import timedelta
 from unittest.mock import patch
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms import config

--- a/cmstestsuite/unit_tests/server/contest/communication_test.py
+++ b/cmstestsuite/unit_tests/server/contest/communication_test.py
@@ -23,7 +23,6 @@
 import unittest
 from datetime import timedelta
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import Question

--- a/cmstestsuite/unit_tests/server/contest/printing_test.py
+++ b/cmstestsuite/unit_tests/server/contest/printing_test.py
@@ -24,7 +24,6 @@ import unittest
 from collections import namedtuple
 from unittest.mock import Mock, patch
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms import config

--- a/cmstestsuite/unit_tests/server/contest/submission/check_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission/check_test.py
@@ -20,7 +20,6 @@ import unittest
 from datetime import timedelta
 from unittest.mock import call, patch
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.db import UserTest, Submission

--- a/cmstestsuite/unit_tests/server/contest/submission/utils_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission/utils_test.py
@@ -22,7 +22,6 @@ import unittest
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms import config

--- a/cmstestsuite/unit_tests/server/contest/submission/workflow_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission/workflow_test.py
@@ -21,7 +21,6 @@ from collections import namedtuple
 from datetime import timedelta
 from unittest.mock import MagicMock, PropertyMock, patch, sentinel, ANY
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms import config

--- a/cmstestsuite/unit_tests/server/contest/tokening_test.py
+++ b/cmstestsuite/unit_tests/server/contest/tokening_test.py
@@ -24,7 +24,6 @@ import unittest
 from datetime import timedelta
 from unittest.mock import patch
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms import TOKEN_MODE_INFINITE, TOKEN_MODE_DISABLED, TOKEN_MODE_FINITE

--- a/cmstestsuite/unit_tests/service/ProxyServiceTest.py
+++ b/cmstestsuite/unit_tests/service/ProxyServiceTest.py
@@ -30,7 +30,6 @@ from unittest.mock import patch, PropertyMock
 
 import gevent
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.service.ProxyService import ProxyService

--- a/cmstestsuite/unit_tests/service/ScoringServiceTest.py
+++ b/cmstestsuite/unit_tests/service/ScoringServiceTest.py
@@ -32,7 +32,6 @@ from unittest.mock import patch, PropertyMock
 
 import gevent
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.service.ScoringService import ScoringService

--- a/cmstestsuite/unit_tests/service/esoperations_test.py
+++ b/cmstestsuite/unit_tests/service/esoperations_test.py
@@ -23,7 +23,6 @@ functions to compute them).
 
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.io.priorityqueue import PriorityQueue

--- a/cmstestsuite/unit_tests/service/scoringoperations_test.py
+++ b/cmstestsuite/unit_tests/service/scoringoperations_test.py
@@ -23,7 +23,6 @@ and the function to compute them).
 
 import unittest
 
-# Needs to be first to allow for monkey patching the DB connection string.
 from cmstestsuite.unit_tests.databasemixin import DatabaseMixin
 
 from cms.service.scoringoperations import ScoringOperation, get_operations


### PR DESCRIPTION
* Remove unneeded import attempts from "tornado4". From what I can tell, this was only ever useful when using system packages on ubuntu 20.04. We don't support installation using system packages anymore (and ubuntu 20.04 is EOL).
* Remove misleading comment about monkey-patching the DB connection string in the test suite. We don't monkey-patch it anymore (instead we assume someone else fixed it and assert that it's correct).