### PR TITLE
Use github actions cache to cache docker layers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,17 @@ jobs:
         run: |
           mount | grep cgroup
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build docker image
-        run: |
-          docker compose -p cms -f docker/docker-compose.test.yml build testcms
+        uses: docker/build-push-action@v6
+        with:
+          # This action used to be `docker compose -p cms build testcms`, so the tag name is cms-testcms.
+          tags: cms-testcms
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha
 
       - name: Run tests
         run: |

--- a/docker/_cms-test-internal.sh
+++ b/docker/_cms-test-internal.sh
@@ -13,7 +13,7 @@ dropdb --host=testdb --username=postgres cmsdbfortesting
 createdb --host=testdb --username=postgres cmsdbfortesting
 cmsInitDB
 
-cmsRunFunctionalTests -v --coverage codecov/functionaltests.xml
+cmsRunFunctionalTests -vvv --coverage codecov/functionaltests.xml
 FUNC=$?
 
 # This check is needed because otherwise failing unit tests aren't reported in


### PR DESCRIPTION
This could save up to 2 minutes on each actions run (unless there's a new Ubuntu image, or we update our requirements).

I don't expect this to work first try :), but this stuff is hard to test locally.