### PR TITLE
Fix AWS error when viewing un-evaluated user test

### DIFF
--- a/cms/server/admin/templates/user_test.html
+++ b/cms/server/admin/templates/user_test.html
@@ -92,10 +92,12 @@
         <td>Failures during evaluation</td>
         <td>{{ utr.evaluation_tries }}</td>
       </tr>
-      <tr>
-        <td>Evaluation sandbox</td>
-        <td>{{ utr.evaluation_sandbox_paths|join(" ") }}</td>
-      </tr>
+        {% if utr.evaluated() %}
+        <tr>
+          <td>Evaluation sandbox</td>
+          <td>{{ utr.evaluation_sandbox_paths|join(" ") }}</td>
+        </tr>
+        {% endif %}
       {% endif %}
     </tbody>
   </table>


### PR DESCRIPTION
evaluation_sandbox_paths is only set after evaluation has finished, so the `|join(" ")` would be trying to iterate a None value. Notably, this error happens when trying to view a user test where compilation failed.