### PR TITLE
Update pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,7 @@ devel = [
 [build-system]
 requires = ["setuptools>=80,<81", "babel==2.12.1"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+python_files = ["test_*.py", "*_test.py", "*Test.py"]
+testpaths = ["cmstestsuite/unit_tests"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-python_files = test_*.py *_test.py *Test.py


### PR DESCRIPTION
* Move settings into pyproject.toml (one less file in the repo root :)
* Set testpaths to avoid the "please monkey-patch earlier" warning from gevent (caused by pytest importing unnecessary files, including one that imported requests somewhere)

ps. feel free to ignore this until end of ioi if it makes your life easier in any way