### PR TITLE
Run Github Actions on Debian

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ Dockerfile
 .vagrant/
 codecov/
 .dev/
+.venv/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ jobs:
   test:
     runs-on: ubuntu-24.04
 
+    strategy:
+      matrix:
+        base_image: ["ubuntu:noble", "debian:bookworm"]
+
     steps:
       - uses: actions/checkout@v2
 
@@ -17,7 +21,8 @@ jobs:
 
       - name: Build docker image
         run: |
-          docker compose -p cms -f docker/docker-compose.test.yml build testcms
+          docker compose -p cms -f docker/docker-compose.test.yml build \
+              --build-arg BASE_IMAGE=${{ matrix.base_image }} testcms
 
       - name: Run tests
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,75 @@
 # syntax=docker/dockerfile:1
-FROM ubuntu:24.04
+# Supported combinations: ubuntu:noble, debian:bookworm.
+ARG BASE_IMAGE=ubuntu:noble
+FROM ${BASE_IMAGE}
 
-RUN \
-    export DEBIAN_FRONTEND=noninteractive ; \
-    apt update && \
-    apt upgrade -y && \
-    apt install -y \
-        build-essential \
-        cgroup-lite \
-        cppreference-doc-en-html \
-        curl \
-        fp-compiler \
-        git \
-        ghc \
-        libcap-dev \
-        libcups2-dev \
-        libffi-dev \
-        libpq-dev \
-        libyaml-dev \
-        mono-mcs \
-        openjdk-8-jdk-headless \
-        php-cli \
-        postgresql-client \
-        pypy3 \
-        python3-pip \
-        python3-venv \
-        python3.12 \
-        python3.12-dev \
-        rustc \
-        shared-mime-info \
-        sudo \
-        wait-for-it \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked <<EOF
+#!/bin/bash -ex
+    export DEBIAN_FRONTEND=noninteractive
+    # Don't delete all the .deb files after install, as that would make the
+    # cache useless.
+    rm -f /etc/apt/apt.conf.d/docker-clean
+    # Note that we use apt-get here instead of plain apt, because plain apt
+    # also deletes .deb files after successful install.
+    apt-get update
+    apt-get upgrade -y
+    PACKAGES=(
+        build-essential
+        cppreference-doc-en-html
+        curl
+        default-jdk-headless
+        fp-compiler
+        ghc
+        git
+        libcap-dev
+        libcups2-dev
+        libffi-dev
+        libpq-dev
+        libyaml-dev
+        mono-mcs
+        php-cli
+        postgresql-client
+        pypy3
+        python3
+        python3-dev
+        python3-pip
+        python3-venv
+        rustc
+        shared-mime-info
+        sudo
+        wait-for-it
         zip
+    )
+    apt-get install -y "${PACKAGES[@]}"
+EOF
 
-RUN \
-    export DEBIAN_FRONTEND=noninteractive ; \
-    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/isolate.asc] http://www.ucw.cz/isolate/debian/ bookworm-isolate main" >/etc/apt/sources.list.d/isolate.list && \
-    curl https://www.ucw.cz/isolate/debian/signing-key.asc >/etc/apt/keyrings/isolate.asc && \
-    apt update && \
-    apt install -y isolate && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked <<EOF
+#!/bin/bash -ex
+    export DEBIAN_FRONTEND=noninteractive
+    CODENAME=$(source /etc/os-release; echo $VERSION_CODENAME)
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/isolate.asc]" \
+        "http://www.ucw.cz/isolate/debian/ ${CODENAME}-isolate main" \
+        >/etc/apt/sources.list.d/isolate.list
+    curl https://www.ucw.cz/isolate/debian/signing-key.asc \
+        >/etc/apt/keyrings/isolate.asc
+    apt-get update
+    apt-get install -y isolate
     sed -i 's@^cg_root .*@cg_root = /sys/fs/cgroup@' /etc/isolate
+EOF
 
 # Create cmsuser user with sudo privileges and access to isolate
-RUN \
-    useradd -ms /bin/bash cmsuser && \
-    usermod -aG sudo cmsuser && \
-    usermod -aG isolate cmsuser && \
-    # Disable sudo password \
+RUN <<EOF
+#!/bin/bash -ex
+    # Need to set user ID manually: otherwise it'd be 1000 on debian
+    # and 1001 on ubuntu.
+    useradd -ms /bin/bash -u 1001 cmsuser
+    usermod -aG sudo cmsuser
+    usermod -aG isolate cmsuser
+    # Disable sudo password
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+EOF
 
 # Set cmsuser as default user
 USER cmsuser
@@ -58,15 +80,21 @@ COPY --chown=cmsuser:cmsuser install.py constraints.txt /home/cmsuser/src/
 
 WORKDIR /home/cmsuser/src
 
-RUN ./install.py venv
+RUN --mount=type=cache,target=/home/cmsuser/.cache/pip,uid=1001 ./install.py venv
 ENV PATH="/home/cmsuser/cms/bin:$PATH"
 
 COPY --chown=cmsuser:cmsuser . /home/cmsuser/src
 
-RUN ./install.py cms --devel
+RUN --mount=type=cache,target=/home/cmsuser/.cache/pip,uid=1001 ./install.py cms --devel
 
-RUN sed 's|/cmsuser:your_password_here@localhost:5432/cmsdb"|/postgres@testdb:5432/cmsdbfortesting"|' ./config/cms.sample.toml >../cms/etc/cms-testdb.toml
-RUN sed -e 's|/cmsuser:your_password_here@localhost:5432/cmsdb"|/postgres@devdb:5432/cmsdb"|' -e 's/127.0.0.1/0.0.0.0/' ./config/cms.sample.toml >../cms/etc/cms-devdb.toml
-RUN sed -i 's/127.0.0.1/0.0.0.0/' ../cms/etc/cms_ranking.toml
+RUN <<EOF
+#!/bin/bash -ex
+    sed 's|/cmsuser:your_password_here@localhost:5432/cmsdb"|/postgres@testdb:5432/cmsdbfortesting"|' \
+        ./config/cms.sample.toml >../cms/etc/cms-testdb.toml
+    sed -e 's|/cmsuser:your_password_here@localhost:5432/cmsdb"|/postgres@devdb:5432/cmsdb"|' \
+        -e 's/127.0.0.1/0.0.0.0/' \
+        ./config/cms.sample.toml >../cms/etc/cms-devdb.toml
+    sed -i 's/127.0.0.1/0.0.0.0/' ../cms/etc/cms_ranking.toml
+EOF
 
 CMD ["/bin/bash"]

--- a/cmstestsuite/unit_tests/server/contest/submission/file_retrieval_test.py
+++ b/cmstestsuite/unit_tests/server/contest/submission/file_retrieval_test.py
@@ -19,6 +19,7 @@
 
 import base64
 import io
+import sys
 import tarfile
 import unittest
 import zipfile
@@ -94,6 +95,7 @@ class TestExtractFilesFromArchive(unittest.TestCase):
             extract_files_from_archive(archive_data.getvalue()),
             [ReceivedFile(None, "foo", b"some content")])
 
+    @unittest.skipIf(sys.version_info < (3, 12), "this archive crashes zipfile before py3.12")
     def test_empty_filename(self):
         archive_data = io.BytesIO()
         with zipfile.ZipFile(archive_data, "w") as f:


### PR DESCRIPTION
* Refactored the Dockerfile to allow building both Debian- and Ubuntu-based images from the same file.
* Various other cleanups in the dockerfile:
  * Use cache mounts to avoid re-downloading packages when rebuilding. Note that this is not the same type of caching I tried in a previous PR, in particular this one doesn't help with CI at all, but it helps a lot locally to speed up rebuilds when tinkering with the dockerfile.
  * made the shell commands a bit cleaner using heredoc syntax.
  * use the correct isolate repository for the current distro, instead of hardcoding bookworm
  * tweaked the installed package list a bit for debian, see the commit message for details. Notably, upgrade java from version 8 to 17 or 21 (debian only packages one version of java).

One test actually broke on debian because of python 3.11, because of changes in zipfile.py in python 3.12 which I inadvertently depended on (namely the "archive with empty filename" test). I don't think either behavior is a problem though, it shouldn't really matter which way this edge case is resolved, the user will get an error message either way in the end.

And finally, run the CI with both ubuntu and debian images. We'll see if it works first try :)