### PR TITLE
AWS shouldn't show all languages checked when task is inheriting from contest

### DIFF
--- a/cms/server/admin/templates/task.html
+++ b/cms/server/admin/templates/task.html
@@ -134,12 +134,12 @@ $("select[name=task_type_{{ dataset.id }}]").change(function() {
         <td>
           <span class="info" title="Programming languages that contestants can use to solve this task.
                                     If none are selected, all contest languages are allowed.
-                                    Otherwise, only the selected languages (which must be a subset of contest languages) are allowed."></span>
+                                    Otherwise, only the selected languages are allowed."></span>
           Allowed programming languages
         </td>
         <td class="wrapping-options">
           {% for lang in LANGUAGES %}
-            <label><input type="checkbox" name="allowed_languages" value="{{ lang.name }}" {{ "checked" if task.allowed_languages is none or lang.name in (task.allowed_languages or []) else "" }}>{{ lang.name }}</label>
+            <label><input type="checkbox" name="allowed_languages" value="{{ lang.name }}" {{ "checked" if task.allowed_languages is not none and lang.name in task.allowed_languages else "" }}>{{ lang.name }}</label>
           {% endfor %}
         </td>
       </tr>


### PR DESCRIPTION
The current behaviour is that AWS just shows every language checked when the actual list is null meaning that the task is inheriting the allowed languages from the contest. This does not match the help section which states that in this case no box is checked, and this is also very annoying because if you update the task from AWS without unchecking all boxes it actually sets every language as allowed.
I also removed the constraint of task-specific languages being a subset of contest languages from the help section since it is not true anyway.