### PR TITLE
AWS: don't refresh the page when contest phase changes

### DIFF
--- a/cms/db/contest.py
+++ b/cms/db/contest.py
@@ -306,6 +306,7 @@ class Contest(Base):
 
         timestamp: the time we are iterested in.
         """
+        # NOTE: this logic is duplicated in aws_utils.js.
         if timestamp < self.start:
             return -1
         if timestamp <= self.stop:

--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -334,7 +334,6 @@ class BaseHandler(CommonRequestHandler):
         if self.current_user is not None:
             params["admin"] = self.current_user
         if self.contest is not None:
-            params["phase"] = self.contest.phase(params["timestamp"])
             params["unanswered"] = self.sql_session.query(Question)\
                 .join(Participation)\
                 .filter(Participation.contest_id == self.contest.id)\

--- a/cms/server/admin/static/aws_utils.js
+++ b/cms/server/admin/static/aws_utils.js
@@ -30,7 +30,7 @@ var CMS = CMS || {};
 CMS.AWSUtils = function(url_root, timestamp,
                         contest_start, contest_stop,
                         analysis_start, analysis_stop,
-                        phase) {
+                        analysis_enabled) {
     this.url = CMS.AWSUtils.create_url_builder(url_root);
     this.first_date = new Date();
     this.last_notification = timestamp;
@@ -39,7 +39,7 @@ CMS.AWSUtils = function(url_root, timestamp,
     this.contest_stop = contest_stop;
     this.analysis_start = analysis_start;
     this.analysis_stop = analysis_stop;
-    this.phase = phase;
+    this.analysis_enabled = analysis_enabled;
     this.file_asked_name = "";
     this.file_asked_url = "";
 
@@ -476,24 +476,23 @@ CMS.AWSUtils.prototype.two_digits = function(n) {
 
 /**
  * Update the remaining time showed in the "remaining" div.
- *
- * timer (int): handle for the timer that called this function, or -1 if none
  */
-CMS.AWSUtils.prototype.update_remaining_time = function(timer = -1) {
-    // We assume this.phase always is the correct phase (since this
-    // method also refreshes the page when the phase changes).
+CMS.AWSUtils.prototype.update_remaining_time = function() {
     var relevant_timestamp = null;
     var text = null;
-    if (this.phase === -1) {
+    var now_timestamp = this.timestamp + (new Date() - this.first_date) / 1000;
+
+    // based on the phase logic from cms/db/contest.py.
+    if (now_timestamp < this.contest_start) {
         relevant_timestamp = this.contest_start;
         text = "To start of contest: "
-    } else if (this.phase === 0) {
+    } else if (now_timestamp <= this.contest_stop) {
         relevant_timestamp = this.contest_stop;
         text = "To end of contest: "
-    } else if (this.phase === 1) {
+    } else if (this.analysis_enabled && now_timestamp < this.analysis_start) {
         relevant_timestamp = this.analysis_start;
         text = "To start of analysis: "
-    } else if (this.phase === 2) {
+    } else if (this.analysis_enabled && now_timestamp <= this.analysis_stop) {
         relevant_timestamp = this.analysis_stop;
         text = "To end of analysis: "
     }
@@ -503,15 +502,7 @@ CMS.AWSUtils.prototype.update_remaining_time = function(timer = -1) {
         return;
     }
 
-    // Compute actual seconds to next phase value, and if negative we
-    // refresh to update the phase.
-    var now = new Date();
-    var countdown_sec =
-        relevant_timestamp - this.timestamp - (now - this.first_date) / 1000;
-    if (countdown_sec <= 0) {
-        clearInterval(timer);
-        location.reload();
-    }
+    var countdown_sec = relevant_timestamp - now_timestamp;
 
     $("#remaining_text").text(text);
     $("#remaining_value").text(this.format_countdown(countdown_sec));

--- a/cms/server/admin/templates/base.html
+++ b/cms/server/admin/templates/base.html
@@ -26,22 +26,18 @@
 function init()
 {
     {% if contest is none %}
-    utils = new CMS.AWSUtils("{{ url() }}", {{ timestamp|make_timestamp }}, 0, 0, 0, 0, -1);
-    utils.update_notifications();
-    setInterval(function() { utils.update_notifications(); }, 15000);
+    utils = new CMS.AWSUtils("{{ url() }}", {{ timestamp|make_timestamp }}, 0, 0, 0, 0, 0);
     {% else %}
     utils = new CMS.AWSUtils("{{ url() }}", {{ timestamp|make_timestamp }},
         {{ contest.start|make_timestamp }}, {{ contest.stop|make_timestamp }},
         {{ contest.analysis_start|make_timestamp }}, {{ contest.analysis_stop|make_timestamp }},
-        {{ phase }});
+        {{ contest.analysis_enabled | int }});
 
-    {% if phase < 3 %}
     utils.update_remaining_time();
-    var timer = setInterval(function() { utils.update_remaining_time(timer); }, 1000);
+    setInterval(function() { utils.update_remaining_time(); }, 1000);
     {% endif %}
     utils.update_notifications();
     setInterval(function() { utils.update_notifications(); }, 15000);
-    {% endif %}
 
     $(document).click(utils.hide_subpage);
 


### PR DESCRIPTION
We frequently have a problem where the AWS service gets overloaded right at the end of a contest. I suspect this is because the client-side logic tries to refresh the page the instant the contest ends, when most jury members will have multiple tabs of AWS open (I usually end up with over 10...).

The phase of the contest is used solely to show the remaining time countdown. So instead I computed the phase in the countdown logic itself. This required duplicating the "current phase" logic from python to javascript, but I don't think it's a big deal, because half of this logic was duplicated in that javascript function already.