### PR TITLE
Make cms.pot string order consistent, update .pot and .po files

### DIFF
--- a/cms/locale/ar/LC_MESSAGES/cms.po
+++ b/cms/locale/ar/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: ar\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: ar TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "لا يوجد"
 
-msgid "Correct"
-msgstr "صحيح"
-
 msgid "Not correct"
 msgstr "غير صحيح"
+
+msgid "Correct"
+msgstr "صحيح"
 
 msgid "Partially correct"
 msgstr "صحيح جزئيًا"
 
-msgid "Outcome"
-msgstr "نتيجة"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "نتيجة"
 
 msgid "Details"
 msgstr "التفاصيل"
@@ -38,6 +41,9 @@ msgstr "الوقت المستغرق للتنفيذ"
 msgid "Memory used"
 msgstr "الذاكرة المستعملة"
 
+msgid "Score details temporarily unavailable."
+msgstr ""
+
 #, python-format
 msgid "Subtask %(index)s"
 msgstr "المسألة الفرعية رقم %(index)s"
@@ -45,20 +51,53 @@ msgstr "المسألة الفرعية رقم %(index)s"
 msgid "Compilation succeeded"
 msgstr "نجح التحويل"
 
+msgid "Your submission successfully compiled to an executable."
+msgstr ""
+
 msgid "Compilation failed"
 msgstr "فشل التحويل"
+
+#, fuzzy
+msgid "Your submission did not compile correctly."
+msgstr "تسليمك استغرق من وقت المعالج أكثر من الحد"
 
 msgid "Compilation timed out"
 msgstr "التحويل تجاوز حد الوقت"
 
+msgid "Your submission exceeded the time limit while compiling. This might be caused by an excessive use of C++ templates, for example."
+msgstr ""
+
+#, fuzzy, python-format
+msgid "Compilation killed with signal %s (could be triggered by violating memory limits)"
+msgstr "أوقف التنفيذ (قد يكون بسبب الوصول لذاكرة غير مصرح بها)"
+
+msgid "Your submission was killed with the specified signal. Among other things, this might be caused by exceeding the memory limit for the compilation, and in turn by an excessive use of C++ templates, for example."
+msgstr ""
+
 msgid "Output is correct"
 msgstr "المخرجات صحيحة"
+
+msgid "Your submission ran and gave the correct answer"
+msgstr ""
 
 msgid "Output is partially correct"
 msgstr "المخرجات صحيحة جزئيًا"
 
+msgid "Your submission ran and gave the partially correct answer"
+msgstr ""
+
 msgid "Output isn't correct"
 msgstr "المخرجات غير صحيحة"
+
+msgid "Your submission ran, but gave the wrong answer"
+msgstr ""
+
+#, python-format
+msgid "Evaluation didn't produce file %s"
+msgstr ""
+
+msgid "Your submission ran, but did not write on the correct output file"
+msgstr ""
 
 msgid "Execution timed out"
 msgstr "التنفيذ تجاوز حد الوقت"
@@ -66,14 +105,90 @@ msgstr "التنفيذ تجاوز حد الوقت"
 msgid "Your submission used too much CPU time."
 msgstr "تسليمك استغرق من وقت المعالج أكثر من الحد"
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "أوقف التنفيذ (قد يكون بسبب الوصول لذاكرة غير مصرح بها)"
+msgid "Execution timed out (wall clock limit exceeded)"
+msgstr ""
+
+msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
+msgstr ""
+
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "حد الذاكرة"
+
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "تسليمك استغرق من وقت المعالج أكثر من الحد"
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "التنفيذ تجاوز حد الوقت"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "فشل التنفيذ لأن كود الخروج لم يساوي صفر"
 
+msgid "Your submission failed because it exited with a return code different from 0."
+msgstr ""
+
+msgid "Execution completed successfully"
+msgstr ""
+
+#, fuzzy
+msgid "No compilation needed"
+msgstr "نجح التحويل"
+
+msgid "File not submitted"
+msgstr ""
+
 msgid "Question too long!"
 msgstr "السؤال طويل جدًا!"
+
+#, python-format
+msgid "Subject must be at most %(max_subject_length)d characters, content at most %(max_text_length)d."
+msgstr ""
+
+msgid "contest-token"
+msgstr ""
+
+#, fuzzy
+msgid "contest-tokens"
+msgstr "حتى نهاية المسابقة:"
+
+msgid "task-token"
+msgstr ""
+
+msgid "task-tokens"
+msgstr ""
+
+msgid "token"
+msgstr ""
+
+msgid "tokens"
+msgstr ""
+
+#, python-format
+msgid "You don't have %(type_pl)s available for this task."
+msgstr ""
+
+#, fuzzy, python-format
+msgid "You have an infinite number of %(type_pl)s for this task."
+msgstr "لديك عدد لا نهائي من الtokens"
+
+#, python-format
+msgid "You start with no %(type_pl)s."
+msgstr ""
+
+#, python-format
+msgid "You start with one %(type_s)s."
+msgid_plural "You start with %(gen_initial)d %(type_pl)s."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
 
 #, python-format
 msgid "Every minute "
@@ -85,32 +200,260 @@ msgstr[3] "كل %(gen_interval)g دقائق "
 msgstr[4] ""
 msgstr[5] "كل %(gen_interval)g دقيقة "
 
-msgid "File too big!"
-msgstr "ملف ضخم جدًا!"
+#, python-format
+msgid "you get another %(type_s)s, "
+msgid_plural "you get %(gen_number)d other %(type_pl)s, "
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
 
-msgid "Please try again."
-msgstr "فضلًا جرب مرة أخرى."
+#, python-format
+msgid "up to a maximum of one %(type_s)s."
+msgid_plural "up to a maximum of %(gen_max)d %(type_pl)s."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#, python-format
+msgid "you get another %(type_s)s."
+msgid_plural "you get %(gen_number)d other %(type_pl)s."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr ""
+
+#, python-format
+msgid "You can use a %(type_s)s every second "
+msgid_plural "You can use a %(type_s)s every %(min_interval)g seconds "
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#, python-format
+msgid "and no more than one %(type_s)s in total."
+msgid_plural "and no more than %(max_number)d %(type_pl)s in total."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#, python-format
+msgid "You can use a %(type_s)s every second."
+msgid_plural "You can use a %(type_s)s every %(min_interval)g seconds."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#, python-format
+msgid "You can use no more than one %(type_s)s in total."
+msgid_plural "You can use no more than %(max_number)d %(type_pl)s in total."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+msgid "You have no limitations on how you use them."
+msgstr ""
 
 msgid "Question received"
 msgstr "استقبلت سؤالًا"
 
+msgid "Your question has been received, you will be notified when it is answered."
+msgstr ""
+
+#, fuzzy
+msgid "Print job received"
+msgstr "استقبلت سؤالًا"
+
+msgid "Your print job has been received."
+msgstr ""
+
 msgid "Submission received"
 msgstr "التسليم استقبل"
+
+msgid "Your submission has been received and is currently being evaluated."
+msgstr ""
+
+#, fuzzy
+msgid "Compiling..."
+msgstr "يحمل..."
+
+#, fuzzy
+msgid "Evaluating..."
+msgstr "يحمل..."
+
+#, fuzzy
+msgid "Scoring..."
+msgstr "يحمل..."
+
+msgid "Evaluated"
+msgstr ""
+
+#, fuzzy
+msgid "status"
+msgstr "الحالة"
+
+#, fuzzy
+msgid "Token request received"
+msgstr "استقبلت سؤالًا"
+
+msgid "Your request has been received and applied to the submission."
+msgstr ""
+
+#, fuzzy
+msgid "Test received"
+msgstr "استقبلت سؤالًا"
+
+msgid "Your test has been received and is currently being executed."
+msgstr ""
 
 msgid "details"
 msgstr "التفاصيل"
 
+#, fuzzy
+msgid "Executing..."
+msgstr "الوقت المستغرق للتنفيذ"
+
 msgid "Executed"
 msgstr "نُفّذ"
+
+msgid "Too many print jobs!"
+msgstr ""
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr ""
+
+#, fuzzy
+msgid "Invalid format!"
+msgstr "ملف غير صالح"
+
+msgid "Please select the correct files."
+msgstr ""
+
+msgid "File too big!"
+msgstr "ملف ضخم جدًا!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr ""
+
+msgid "Print job storage failed!"
+msgstr ""
+
+msgid "Please try again."
+msgstr "فضلًا جرب مرة أخرى."
 
 msgid "Too many submissions!"
 msgstr "كثرت تسليمات!"
 
+#, python-format
+msgid "You have reached the maximum limit of at most %d submissions among all tasks."
+msgstr ""
+
+#, fuzzy, python-format
+msgid "You have reached the maximum limit of at most %d submissions on this task."
+msgstr "يمكنك تسليم %(submissions)s حلول بحد أقصى أثناء المسابقة"
+
 msgid "Submissions too frequent!"
 msgstr "تسليماتك كثيرة في وقت قليل"
 
+#, python-format
+msgid "Among all tasks, you can submit again after %d seconds from last submission."
+msgstr ""
+
+#, python-format
+msgid "For this task, you can submit again after %d seconds from last submission."
+msgstr ""
+
 msgid "Submission too big!"
 msgstr "تسليم جدًا ضخم!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr ""
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
+msgid "Invalid archive format!"
+msgstr ""
+
+msgid "The submitted archive could not be opened."
+msgstr ""
+
+#, fuzzy
+msgid "Invalid submission format!"
+msgstr "التسليمات الرسمية"
+
+#, fuzzy
+msgid "Submission storage failed!"
+msgstr "تسليم جدًا ضخم!"
+
+#, fuzzy
+msgid "Too many tests!"
+msgstr "كثرت تسليمات!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d tests among all tasks."
+msgstr ""
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d tests on this task."
+msgstr ""
+
+#, fuzzy
+msgid "Tests too frequent!"
+msgstr "تسليماتك كثيرة في وقت قليل"
+
+#, python-format
+msgid "Among all tasks, you can test again after %d seconds from last test."
+msgstr ""
+
+#, python-format
+msgid "For this task, you can test again after %d seconds from last test."
+msgstr ""
+
+msgid "Invalid test format!"
+msgstr ""
+
+#, fuzzy
+msgid "Test too big!"
+msgstr "ملف ضخم جدًا!"
+
+#, fuzzy
+msgid "Input too big!"
+msgstr "ملف ضخم جدًا!"
+
+#, python-format
+msgid "The input file must be at most %d bytes long."
+msgstr ""
+
+msgid "Test storage failed!"
+msgstr ""
 
 msgid "Communication"
 msgstr "التواصل"
@@ -141,6 +484,10 @@ msgstr "لا إجابة بعد"
 
 msgid "Messages"
 msgstr "الرسائل"
+
+#, python-format
+msgid "Automatic (%(lang)s)"
+msgstr ""
 
 msgid "Logout"
 msgstr "تسجيل خروج"
@@ -189,11 +536,11 @@ msgstr "%d غير مقروءة"
 msgid "Until contest starts:"
 msgstr "حتى بداية المسابقة:"
 
-msgid "Until analysis starts:"
-msgstr "حتى بداية المراجعة:"
-
 msgid "Until contest ends:"
 msgstr "حتى نهاية المسابقة:"
+
+msgid "Until analysis starts:"
+msgstr "حتى بداية المراجعة:"
 
 msgid "Until analysis ends:"
 msgstr "حتى نهاية المراجعة:"
@@ -216,11 +563,18 @@ msgstr "التسليمات"
 msgid "Documentation"
 msgstr "دليل الاستخدام"
 
+#, fuzzy
+msgid "Testing"
+msgstr "الأسئلة"
+
 msgid "Printing"
 msgstr "طباعة"
 
 msgid "Contest Management System"
 msgstr "نظام إدارة المسابقات"
+
+msgid "is released under the"
+msgstr ""
 
 msgid "GNU Affero General Public License"
 msgstr "رخصة جنو أفيرو العامة"
@@ -230,9 +584,6 @@ msgstr "اختر مسابقة"
 
 msgid "Programming languages and libraries"
 msgstr "اللغات البرمجية والمكتبات"
-
-msgid "Standard Template Library"
-msgstr "المكتبة الأساسية"
 
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "اسم الكلاس في Java يجب أن يطابق اسم المسألة"
@@ -256,8 +607,35 @@ msgstr "خطأ %(status_code)s"
 msgid "An error occured while the server was handling your request."
 msgstr "حصل خطأ من النظام حين معالجة طلبك"
 
+msgid "Note that attempts to tamper with Contest Management System (such as probing the server with customized URLs) may be considered cheating and may lead to disqualification."
+msgstr ""
+
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "إذا واجهت هذه المشكلة أثناء الاستخدام الطبيعي، فضلًا أبلغ المسؤولين عن المسابقة."
+
+msgid "Public score"
+msgstr "الدرجة الظاهرة"
+
+msgid "Total score"
+msgstr "الدرجة الكلية"
+
+msgid "Score"
+msgstr "الدرجة"
+
+msgid "Token"
+msgstr ""
+
+msgid "no submissions"
+msgstr "لا تسليمات"
+
+msgid "Played"
+msgstr ""
+
+msgid "Play!"
+msgstr ""
+
+msgid "No tokens"
+msgstr ""
 
 msgid "General information"
 msgstr "معلومات عامة"
@@ -265,21 +643,91 @@ msgstr "معلومات عامة"
 msgid "The contest hasn't started yet."
 msgstr "المسابقة لم تبدأ بعد"
 
+#, python-format
+msgid "The contest will start at %(start_time)s and will end at %(stop_time)s."
+msgstr ""
+
 msgid "The contest is currently running."
 msgstr "المسابقة حية الآن."
+
+#, python-format
+msgid "The contest started at %(start_time)s and will end at %(stop_time)s."
+msgstr ""
 
 msgid "The contest has already ended."
 msgstr "المسابقة قد انتهت."
 
+#, python-format
+msgid "The contest started at %(start_time)s and ended at %(stop_time)s."
+msgstr ""
+
+#, fuzzy
+msgid "The analysis mode hasn't started yet."
+msgstr "المسابقة لم تبدأ بعد"
+
+#, python-format
+msgid "The analysis mode will start at %(start_time)s and will end at %(stop_time)s."
+msgstr ""
+
+#, fuzzy
+msgid "The analysis mode is currently running."
+msgstr "المسابقة حية الآن."
+
+#, python-format
+msgid "The analysis mode started at %(start_time)s and will end at %(stop_time)s."
+msgstr ""
+
+#, fuzzy
+msgid "The analysis mode has already ended."
+msgstr "المسابقة قد انتهت."
+
+#, python-format
+msgid "The analysis mode started at %(start_time)s and ended at %(stop_time)s."
+msgstr ""
+
 msgid "You have an infinite number of tokens."
 msgstr "لديك عدد لا نهائي من الtokens"
+
+msgid "You can see the detailed result of a submission by using a token on it."
+msgstr ""
+
+msgid "Your score for each task will be the maximum among the tokened submissions and the last one."
+msgstr ""
+
+#, fuzzy
+msgid "You have a distinct set of tokens for each task."
+msgstr "لديك عدد لا نهائي من الtokens"
+
+#, python-format
+msgid "You can find the rules for the %(type_pl)s on each task's description page."
+msgstr ""
+
+msgid "You have a set of tokens shared among all tasks."
+msgstr ""
+
+msgid "You have two types of tokens: a set of <em>contest-tokens</em> shared among all tasks and a distinct set of <em>task-tokens</em> for each task."
+msgstr ""
+
+msgid "You can see the detailed result of a submission by using two tokens on it, one of each type."
+msgstr ""
 
 #, python-format
 msgid "You can submit at most %(submissions)s solutions during this contest."
 msgstr "يمكنك تسليم %(submissions)s حلول بحد أقصى أثناء المسابقة"
 
+#, fuzzy, python-format
+msgid "You can submit at most %(user_tests)s user tests during this contest."
+msgstr "يمكنك تسليم %(submissions)s حلول بحد أقصى أثناء المسابقة"
+
+#, python-format
+msgid "Every user is allowed to compete (i.e. submit solutions) for a uninterrupted time frame of %(per_user_time)s."
+msgstr ""
+
 msgid "As soon as the contest starts you can choose to start your time frame."
 msgstr "حينما تبدأ المسابقة بإمكانك اختيار الإطار الزمني للبدء"
+
+msgid "Once you start, you can submit solutions until the end of the time frame or until the end of the contest, whatever comes first."
+msgstr ""
 
 msgid "By clicking on the button below you can start your time frame."
 msgstr "بمجرد ضغطك للزر في الأسفل سيبدأ الإطار الزمني الخاص بك وسيبدأ الوقت."
@@ -288,8 +736,19 @@ msgstr "بمجرد ضغطك للزر في الأسفل سيبدأ الإطار �
 msgid "You started your time frame at %(start_time)s."
 msgstr "لقد بدأت إطارك الزمني في %(start_time)s"
 
+msgid "You can submit solutions until the end of the time frame or until the end of the contest, whatever comes first."
+msgstr ""
+
+#, fuzzy, python-format
+msgid "You started your time frame at %(start_time)s and you already finished it."
+msgstr "لقد بدأت إطارك الزمني في %(start_time)s"
+
 msgid "There's nothing you can do now."
 msgstr "لا يمكنك فعل شيء."
+
+#, fuzzy
+msgid "You never started your time frame. Now it's too late."
+msgstr "لقد بدأت إطارك الزمني في %(start_time)s"
 
 msgid "Start!"
 msgstr "ابدأ!"
@@ -315,6 +774,9 @@ msgstr "النوع"
 msgid "Files"
 msgstr "الملفات"
 
+msgid "Tokens"
+msgstr ""
+
 msgid "Yes"
 msgstr "نعم"
 
@@ -328,6 +790,10 @@ msgstr "اطبع"
 msgid "You can print %(remaining_jobs)s more text or PDF files of up to %(max_pages)s pages each."
 msgstr "يمكنك طباعة %(remaining_jobs)s ملفات نصية أو PDF زيادة، وكل منها لا يتجاوز %(max_pages)s صفحات."
 
+#, fuzzy, python-format
+msgid "You can print %(remaining_jobs)s more text files of up to %(max_pages)s pages each."
+msgstr "يمكنك طباعة %(remaining_jobs)s ملفات نصية أو PDF زيادة، وكل منها لا يتجاوز %(max_pages)s صفحات."
+
 msgid "File (text or PDF)"
 msgstr "ملف (نصي أو PDF)"
 
@@ -336,6 +802,12 @@ msgstr "ملف (نصي)"
 
 msgid "Submit"
 msgstr "تسليم"
+
+msgid "You cannot print anything any more as you have used up your printing quota."
+msgstr ""
+
+msgid "Previous print jobs"
+msgstr ""
 
 msgid "Date and time"
 msgstr "التاريخ والوقت"
@@ -352,8 +824,15 @@ msgstr "الحالة"
 msgid "Preparing..."
 msgstr "يجهز..."
 
+#, fuzzy
+msgid "no print jobs yet"
+msgstr "لا إجابة بعد"
+
 msgid "The passwords do not match!"
 msgstr "كلمتي المرور غير متطابقة!"
+
+msgid "This username is already taken, please choose a different one."
+msgstr ""
 
 msgid "This user is already registered in the contest."
 msgstr "المستخدم قد سجل للمسابقة من قبل."
@@ -384,6 +863,20 @@ msgstr "الاسم الأخير"
 
 msgid "E-mail"
 msgstr "البريد الإلكتروني"
+
+#, fuzzy
+msgid "Representing"
+msgstr "طباعة"
+
+#, python-format
+msgid "Must be one character or more."
+msgid_plural "Must be %(min_length)s characters or more."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
 
 msgid "Confirm password"
 msgstr "تأكيد كلمة المرور"
@@ -434,6 +927,9 @@ msgstr "نص المسألة متوفر بعدة نسخ للغات مختلفة."
 msgid "You can see (and download) all of them using the list on the right."
 msgstr "يمكنك رؤيتها (وتنزيلها) كلها من القائمة على اليمين."
 
+msgid "Some suggested translations follow."
+msgstr ""
+
 #, python-format
 msgid "Statement in <b>%(lang)s</b>"
 msgstr "المسألة بلغة <b>%(lang)s</b>"
@@ -456,6 +952,13 @@ msgstr "بعض التفاصيل"
 msgid "Compilation commands"
 msgstr "أوامر التحويل"
 
+#, python-format
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
+msgstr ""
+
+msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
+msgstr ""
+
 msgid "Attachments"
 msgstr "المرفقات"
 
@@ -465,11 +968,19 @@ msgstr "غير معروف"
 msgid "loading..."
 msgstr "يحمل..."
 
+#, fuzzy, python-format
+msgid "%(name)s (%(short_name)s) <small>submissions</small>"
+msgstr "%(name)s (%(short_name)s) <small>الوصف</small>"
+
 msgid "Score:"
 msgstr "الدرجة:"
 
 msgid "Public score:"
 msgstr "الدرجة الظاهرة:"
+
+#, fuzzy
+msgid "Score of tokened submissions:"
+msgstr "التسليمات السابقة"
 
 msgid "Total score:"
 msgstr "الدرجة الكلية:"
@@ -480,11 +991,46 @@ msgstr "سلم حلًّا"
 msgid "You may submit any subset of outputs in a single submission."
 msgstr "يمكنك أن تسلم أي جزء من المخرجات في التسليم الواحد"
 
+#, fuzzy, python-format
+msgid "You can submit %(submissions_left)s more solution(s)."
+msgstr "يمكنك تسليم %(submissions)s حلول بحد أقصى أثناء المسابقة"
+
 msgid "submission.zip"
 msgstr "submission.zip"
 
 msgid "Previous submissions"
 msgstr "التسليمات السابقة"
+
+msgid "Tokens are not allowed on this task."
+msgstr ""
+
+msgid "Right now, you have infinite tokens available on this task."
+msgstr ""
+
+msgid "Right now, you have one token available on this task."
+msgstr ""
+
+#, python-format
+msgid "Right now, you have %(tokens)s tokens available on this task."
+msgstr ""
+
+#, python-format
+msgid "But you have to wait until %(expiration_time)s to use them."
+msgstr ""
+
+#, python-format
+msgid "You will receive a new token at %(gen_time)s."
+msgstr ""
+
+msgid "In the current situation, no more tokens will be generated."
+msgstr ""
+
+msgid "Right now, you do not have tokens available for this task."
+msgstr ""
+
+#, python-format
+msgid "But you will have to wait until %(expiration_time)s to use it."
+msgstr ""
 
 msgid "Unofficial submissions"
 msgstr "التسليمات غير الرسمية"
@@ -501,8 +1047,20 @@ msgstr "إغلاق"
 msgid "Download"
 msgstr "تنزيل"
 
+#, fuzzy
+msgid "Submit a test"
+msgstr "سلم حلًّا"
+
+#, python-format
+msgid "You can submit %(user_tests_left)s more test(s)."
+msgstr ""
+
 msgid "input"
 msgstr "المدخلات"
+
+#, fuzzy
+msgid "Previous tests"
+msgstr "التسليمات السابقة"
 
 msgid "Input"
 msgstr "المدخلات"
@@ -510,24 +1068,42 @@ msgstr "المدخلات"
 msgid "Output"
 msgstr "المخرجات"
 
+#, fuzzy
+msgid "no tests yet"
+msgstr "لا إجابة بعد"
+
+#, fuzzy
+msgid "Test details"
+msgstr "بعض التفاصيل"
+
+#, fuzzy
+msgid "Evaluation outcome"
+msgstr "نتيجة التحويل:"
+
 msgid "Wait..."
 msgstr "انتظر..."
 
 msgid "None"
 msgstr "لا شيء"
 
-msgid "Public score"
-msgstr "الدرجة الظاهرة"
+msgid "Token request discarded"
+msgstr ""
 
-msgid "Total score"
-msgstr "الدرجة الكلية"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr ""
 
-msgid "Score"
-msgstr "الدرجة"
-
-msgid "no submissions"
-msgstr "لا تسليمات"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr ""
 
 msgid "Invalid file"
 msgstr "ملف غير صالح"
+
+msgid "Print job has too many pages"
+msgstr ""
+
+msgid "Sent to printer"
+msgstr ""
+
+#~ msgid "Standard Template Library"
+#~ msgstr "المكتبة الأساسية"
 

--- a/cms/locale/bg/LC_MESSAGES/cms.po
+++ b/cms/locale/bg/LC_MESSAGES/cms.po
@@ -1,27 +1,33 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: bg_BG\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: bg_BG TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "Неизвестно"
 
-msgid "Correct"
-msgstr "Вярно"
-
 msgid "Not correct"
 msgstr "Грешно"
 
+msgid "Correct"
+msgstr "Вярно"
+
 msgid "Partially correct"
 msgstr "Частично вярно"
+
+msgid "#"
+msgstr ""
 
 msgid "Outcome"
 msgstr "Резултат"
@@ -34,6 +40,9 @@ msgstr "Време за изпълнение"
 
 msgid "Memory used"
 msgstr "Използвана памет"
+
+msgid "Score details temporarily unavailable."
+msgstr ""
 
 #, python-format
 msgid "Subtask %(index)s"
@@ -54,6 +63,10 @@ msgstr "Вашето решение не се компилира успешно.
 msgid "Compilation timed out"
 msgstr "Превишено време за компилиране"
 
+#, fuzzy
+msgid "Your submission exceeded the time limit while compiling. This might be caused by an excessive use of C++ templates, for example."
+msgstr "Компилирането на вашето решение беше прекратено с указания сигнал. Това може да бъде причинено от превишаване на ограниченията за памет на компилирането, което от своя страна да е резултат от прекомерна употреба на на C++ темплейти."
+
 #, python-format
 msgid "Compilation killed with signal %s (could be triggered by violating memory limits)"
 msgstr "Компилирането беше прекратено със сигнал %s (може да бъде причинено от нарушаване на ограниченията за памет)"
@@ -65,6 +78,14 @@ msgid "Output is correct"
 msgstr "Верен отговор"
 
 msgid "Your submission ran and gave the correct answer"
+msgstr "Вашето решение тръгна и даде верен отговор"
+
+#, fuzzy
+msgid "Output is partially correct"
+msgstr "Частично вярно"
+
+#, fuzzy
+msgid "Your submission ran and gave the partially correct answer"
 msgstr "Вашето решение тръгна и даде верен отговор"
 
 msgid "Output isn't correct"
@@ -86,8 +107,32 @@ msgstr "Превишено време за изпълнение"
 msgid "Your submission used too much CPU time."
 msgstr "Вашето решение използва твърде много процесорно време."
 
+msgid "Execution timed out (wall clock limit exceeded)"
+msgstr ""
+
+msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
+msgstr ""
+
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Ограничение за памет"
+
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Вашето решение използва твърде много процесорно време."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Превишено време за изпълнение"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
+
 msgid "Execution failed because the return code was nonzero"
 msgstr "Изпълнението се провали, защото програмата върна ненулев резултат."
+
+msgid "Your submission failed because it exited with a return code different from 0."
+msgstr ""
 
 msgid "Execution completed successfully"
 msgstr "Изпълнението завърши успешно"
@@ -98,26 +143,122 @@ msgstr "Не е необходимо компилиране"
 msgid "File not submitted"
 msgstr "Файлът не е предаден"
 
-msgid "Too many print jobs!"
-msgstr "Твърде много задачи за принтиране!"
+#, fuzzy
+msgid "Question too long!"
+msgstr "Програмата за тестване е твърде голяма!"
 
-msgid "Invalid format!"
-msgstr "Невалиден формат!"
+#, python-format
+msgid "Subject must be at most %(max_subject_length)d characters, content at most %(max_text_length)d."
+msgstr ""
 
-msgid "Please select the correct files."
-msgstr "Моля изберете правилните файлове."
+msgid "contest-token"
+msgstr ""
 
-msgid "File too big!"
-msgstr "Файлът е твърде голям!"
+#, fuzzy
+msgid "contest-tokens"
+msgstr "До край на състезанието:"
 
-msgid "Please try again."
-msgstr "Моля опитайте отново."
+#, fuzzy
+msgid "task-token"
+msgstr "Жетон"
+
+#, fuzzy
+msgid "task-tokens"
+msgstr "Жетони"
+
+#, fuzzy
+msgid "token"
+msgstr "Жетон"
+
+#, fuzzy
+msgid "tokens"
+msgstr "Жетони"
+
+#, python-format
+msgid "You don't have %(type_pl)s available for this task."
+msgstr ""
+
+#, fuzzy, python-format
+msgid "You have an infinite number of %(type_pl)s for this task."
+msgstr "Имате безкрайно количество жетони."
+
+#, python-format
+msgid "You start with no %(type_pl)s."
+msgstr ""
+
+#, python-format
+msgid "You start with one %(type_s)s."
+msgid_plural "You start with %(gen_initial)d %(type_pl)s."
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-format
+msgid "Every minute "
+msgid_plural "Every %(gen_interval)g minutes "
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-format
+msgid "you get another %(type_s)s, "
+msgid_plural "you get %(gen_number)d other %(type_pl)s, "
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-format
+msgid "up to a maximum of one %(type_s)s."
+msgid_plural "up to a maximum of %(gen_max)d %(type_pl)s."
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-format
+msgid "you get another %(type_s)s."
+msgid_plural "you get %(gen_number)d other %(type_pl)s."
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr ""
+
+#, python-format
+msgid "You can use a %(type_s)s every second "
+msgid_plural "You can use a %(type_s)s every %(min_interval)g seconds "
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-format
+msgid "and no more than one %(type_s)s in total."
+msgid_plural "and no more than %(max_number)d %(type_pl)s in total."
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-format
+msgid "You can use a %(type_s)s every second."
+msgid_plural "You can use a %(type_s)s every %(min_interval)g seconds."
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-format
+msgid "You can use no more than one %(type_s)s in total."
+msgid_plural "You can use no more than %(max_number)d %(type_pl)s in total."
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "You have no limitations on how you use them."
+msgstr ""
 
 msgid "Question received"
 msgstr "Въпросът е получен"
 
 msgid "Your question has been received, you will be notified when it is answered."
 msgstr "Вашият въпрос беше получен, ще бъдете уведомени, когато имате отговор."
+
+#, fuzzy
+msgid "Print job received"
+msgstr "Тестът е получен"
+
+msgid "Your print job has been received."
+msgstr ""
 
 msgid "Submission received"
 msgstr "Решението получено"
@@ -137,6 +278,18 @@ msgstr "Оценяване..."
 msgid "Evaluated"
 msgstr "Оценено"
 
+#, fuzzy
+msgid "status"
+msgstr "Статус"
+
+#, fuzzy
+msgid "Token request received"
+msgstr "Тестът е получен"
+
+#, fuzzy
+msgid "Your request has been received and applied to the submission."
+msgstr "Вашият въпрос беше получен, ще бъдете уведомени, когато имате отговор."
+
 msgid "Test received"
 msgstr "Тестът е получен"
 
@@ -152,6 +305,33 @@ msgstr "Изпълняване"
 msgid "Executed"
 msgstr "Изпълнено"
 
+msgid "Too many print jobs!"
+msgstr "Твърде много задачи за принтиране!"
+
+#, fuzzy, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Достигнахте максималния лимит от най-много %d изпращания на решения на всички задачи."
+
+msgid "Invalid format!"
+msgstr "Невалиден формат!"
+
+msgid "Please select the correct files."
+msgstr "Моля изберете правилните файлове."
+
+msgid "File too big!"
+msgstr "Файлът е твърде голям!"
+
+#, fuzzy, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Всеки файл с код трябва да бъде най-много %d байта голям."
+
+#, fuzzy
+msgid "Print job storage failed!"
+msgstr "Съхраняватено на тестове се провали!"
+
+msgid "Please try again."
+msgstr "Моля опитайте отново."
+
 msgid "Too many submissions!"
 msgstr "Твърде много изпращания на решение!"
 
@@ -159,8 +339,31 @@ msgstr "Твърде много изпращания на решение!"
 msgid "You have reached the maximum limit of at most %d submissions among all tasks."
 msgstr "Достигнахте максималния лимит от най-много %d изпращания на решения на всички задачи."
 
+#, fuzzy, python-format
+msgid "You have reached the maximum limit of at most %d submissions on this task."
+msgstr "Достигнахте максималния лимит от най-много %d изпращания на решения на всички задачи."
+
 msgid "Submissions too frequent!"
 msgstr "Твърде чести изпращания на решение!"
+
+#, python-format
+msgid "Among all tasks, you can submit again after %d seconds from last submission."
+msgstr ""
+
+#, python-format
+msgid "For this task, you can submit again after %d seconds from last submission."
+msgstr ""
+
+msgid "Submission too big!"
+msgstr "Изпратеното решение е твърде голямо!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Всеки файл с код трябва да бъде най-много %d байта голям."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
 
 msgid "Invalid archive format!"
 msgstr "Невалиден формат на архива!"
@@ -171,21 +374,30 @@ msgstr "Това решение не може да бъде отворено."
 msgid "Invalid submission format!"
 msgstr "Невалиден формат на решението!"
 
-msgid "Submission too big!"
-msgstr "Изпратеното решение е твърде голямо!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Всеки файл с код трябва да бъде най-много %d байта голям."
-
 msgid "Submission storage failed!"
 msgstr "Съхраняването на решение се провали!"
 
 msgid "Too many tests!"
 msgstr "Твърде много тестове!"
 
+#, fuzzy, python-format
+msgid "You have reached the maximum limit of at most %d tests among all tasks."
+msgstr "Достигнахте максималния лимит от най-много %d изпращания на решения на всички задачи."
+
+#, fuzzy, python-format
+msgid "You have reached the maximum limit of at most %d tests on this task."
+msgstr "Достигнахте максималния лимит от най-много %d изпращания на решения на всички задачи."
+
 msgid "Tests too frequent!"
 msgstr "Твърде често тестване!"
+
+#, python-format
+msgid "Among all tasks, you can test again after %d seconds from last test."
+msgstr ""
+
+#, python-format
+msgid "For this task, you can test again after %d seconds from last test."
+msgstr ""
 
 msgid "Invalid test format!"
 msgstr "Невалиден формат на теста!"
@@ -262,6 +474,13 @@ msgstr "Парола"
 msgid "Login"
 msgstr "Вход"
 
+msgid "Don't have an account?"
+msgstr ""
+
+#, fuzzy
+msgid "Register"
+msgstr "Изчисти"
+
 msgid "New message"
 msgstr "Ново съобщение"
 
@@ -279,6 +498,14 @@ msgid "Until contest starts:"
 msgstr "До започване на състезанието:"
 
 msgid "Until contest ends:"
+msgstr "До край на състезанието:"
+
+#, fuzzy
+msgid "Until analysis starts:"
+msgstr "До започване на състезанието:"
+
+#, fuzzy
+msgid "Until analysis ends:"
 msgstr "До край на състезанието:"
 
 msgid "Time left:"
@@ -305,11 +532,32 @@ msgstr "Тестване"
 msgid "Printing"
 msgstr "Принтиране"
 
+msgid "Contest Management System"
+msgstr ""
+
+msgid "is released under the"
+msgstr ""
+
+msgid "GNU Affero General Public License"
+msgstr ""
+
+msgid "Choose a contest"
+msgstr ""
+
+msgid "Programming languages and libraries"
+msgstr ""
+
+msgid "The main Java class of the solution should have exactly the same name as the task."
+msgstr ""
+
 msgid "Submission details for compilation"
 msgstr "Детайли на решенията"
 
 msgid "Message"
 msgstr "Съобщения"
+
+msgid "Explanation"
+msgstr ""
 
 msgid "Submission details for evaluation"
 msgstr "Детайли на решенията"
@@ -323,6 +571,35 @@ msgstr "Възникна грешка докато сървърът се опи�
 
 msgid "Note that attempts to tamper with Contest Management System (such as probing the server with customized URLs) may be considered cheating and may lead to disqualification."
 msgstr "Отбележете, че опити да нарушавате работата на системата за състезанието като да изпращате нестандартни заявки) може да бъде считано за измама и да доведе до дисквалификация."
+
+msgid "If you encountered this error during normal usage, please notify the contest administrators."
+msgstr ""
+
+msgid "Public score"
+msgstr "Публичен резултат"
+
+msgid "Total score"
+msgstr "Общ резултат"
+
+msgid "Score"
+msgstr "Резултат"
+
+msgid "Token"
+msgstr "Жетон"
+
+#, fuzzy
+msgid "no submissions"
+msgstr "Предадени решения"
+
+msgid "Played"
+msgstr "Изиграно"
+
+msgid "Play!"
+msgstr "Играй!"
+
+#, fuzzy
+msgid "No tokens"
+msgstr "Жетони"
 
 msgid "General information"
 msgstr "Основна информация"
@@ -348,12 +625,93 @@ msgstr "Състезанието вече завърши."
 msgid "The contest started at %(start_time)s and ended at %(stop_time)s."
 msgstr "Състезанието започна в %(start_time)s и завърши в %(stop_time)s."
 
+#, fuzzy
+msgid "The analysis mode hasn't started yet."
+msgstr "Състезанието не е започнало още"
+
+#, fuzzy, python-format
+msgid "The analysis mode will start at %(start_time)s and will end at %(stop_time)s."
+msgstr "Състезанието ще започне в %(start_time)s и ще завърши в %(stop_time)s."
+
+#, fuzzy
+msgid "The analysis mode is currently running."
+msgstr "Състезанието в момента тече."
+
+#, fuzzy, python-format
+msgid "The analysis mode started at %(start_time)s and will end at %(stop_time)s."
+msgstr "Състезанието започна в %(start_time)s и ще завърши в %(stop_time)s."
+
+#, fuzzy
+msgid "The analysis mode has already ended."
+msgstr "Състезанието вече завърши."
+
+#, fuzzy, python-format
+msgid "The analysis mode started at %(start_time)s and ended at %(stop_time)s."
+msgstr "Състезанието започна в %(start_time)s и завърши в %(stop_time)s."
+
 msgid "You have an infinite number of tokens."
 msgstr "Имате безкрайно количество жетони."
+
+msgid "You can see the detailed result of a submission by using a token on it."
+msgstr ""
+
+msgid "Your score for each task will be the maximum among the tokened submissions and the last one."
+msgstr ""
+
+#, fuzzy
+msgid "You have a distinct set of tokens for each task."
+msgstr "Имате безкрайно количество жетони."
+
+#, python-format
+msgid "You can find the rules for the %(type_pl)s on each task's description page."
+msgstr ""
+
+msgid "You have a set of tokens shared among all tasks."
+msgstr ""
+
+msgid "You have two types of tokens: a set of <em>contest-tokens</em> shared among all tasks and a distinct set of <em>task-tokens</em> for each task."
+msgstr ""
+
+msgid "You can see the detailed result of a submission by using two tokens on it, one of each type."
+msgstr ""
 
 #, python-format
 msgid "You can submit at most %(submissions)s solutions during this contest."
 msgstr "Можете да изпратите най-много %(submissions)s решения през това състезание."
+
+#, fuzzy, python-format
+msgid "You can submit at most %(user_tests)s user tests during this contest."
+msgstr "Можете да изпратите най-много %(submissions)s решения през това състезание."
+
+#, python-format
+msgid "Every user is allowed to compete (i.e. submit solutions) for a uninterrupted time frame of %(per_user_time)s."
+msgstr ""
+
+msgid "As soon as the contest starts you can choose to start your time frame."
+msgstr ""
+
+msgid "Once you start, you can submit solutions until the end of the time frame or until the end of the contest, whatever comes first."
+msgstr ""
+
+msgid "By clicking on the button below you can start your time frame."
+msgstr ""
+
+#, python-format
+msgid "You started your time frame at %(start_time)s."
+msgstr ""
+
+msgid "You can submit solutions until the end of the time frame or until the end of the contest, whatever comes first."
+msgstr ""
+
+#, python-format
+msgid "You started your time frame at %(start_time)s and you already finished it."
+msgstr ""
+
+msgid "There's nothing you can do now."
+msgstr ""
+
+msgid "You never started your time frame. Now it's too late."
+msgstr ""
 
 msgid "Start!"
 msgstr "Старт!"
@@ -391,6 +749,14 @@ msgstr "Не"
 msgid "Print"
 msgstr "Принтирай"
 
+#, python-format
+msgid "You can print %(remaining_jobs)s more text or PDF files of up to %(max_pages)s pages each."
+msgstr ""
+
+#, python-format
+msgid "You can print %(remaining_jobs)s more text files of up to %(max_pages)s pages each."
+msgstr ""
+
 msgid "File (text or PDF)"
 msgstr "Файл (текстов или PDF)"
 
@@ -400,11 +766,22 @@ msgstr "Файл (текстов)"
 msgid "Submit"
 msgstr "Изпрати"
 
+msgid "You cannot print anything any more as you have used up your printing quota."
+msgstr ""
+
+#, fuzzy
+msgid "Previous print jobs"
+msgstr "Предишни тестове"
+
 msgid "Date and time"
 msgstr "Дата и час"
 
 msgid "Time"
 msgstr "Време"
+
+#, fuzzy
+msgid "File name"
+msgstr "Име"
 
 msgid "Status"
 msgstr "Статус"
@@ -414,6 +791,73 @@ msgstr "Подготовка..."
 
 msgid "no print jobs yet"
 msgstr "няма отговор все още"
+
+msgid "The passwords do not match!"
+msgstr ""
+
+msgid "This username is already taken, please choose a different one."
+msgstr ""
+
+msgid "This user is already registered in the contest."
+msgstr ""
+
+msgid "No such user."
+msgstr ""
+
+msgid "The password is not correct."
+msgstr ""
+
+msgid "Registration"
+msgstr ""
+
+msgid "Please fill in the fields to register"
+msgstr ""
+
+#, fuzzy
+msgid "New user"
+msgstr "Нов отговор"
+
+msgid "Join contest"
+msgstr ""
+
+msgid "First name"
+msgstr ""
+
+#, fuzzy
+msgid "Last name"
+msgstr "Име"
+
+#, fuzzy
+msgid "E-mail"
+msgstr "детайли"
+
+#, fuzzy
+msgid "Representing"
+msgstr "Принтиране"
+
+#, python-format
+msgid "Must be one character or more."
+msgid_plural "Must be %(min_length)s characters or more."
+msgstr[0] ""
+msgstr[1] ""
+
+#, fuzzy
+msgid "Confirm password"
+msgstr "Парола"
+
+msgid "Registered in the contest successfully!"
+msgstr ""
+
+#, fuzzy
+msgid "Your username is:"
+msgstr "Потребителско име"
+
+msgid "Your password is stored securely."
+msgstr ""
+
+#, fuzzy
+msgid "Back to login"
+msgstr "Неуспешно влизате"
 
 msgid "Compilation output"
 msgstr "Изход от компилирането"
@@ -449,6 +893,9 @@ msgstr "Условието на тази задача е налично в мн�
 msgid "You can see (and download) all of them using the list on the right."
 msgstr "Можете да видите (и свалите) всички от тях използвайки списъкът от дясно."
 
+msgid "Some suggested translations follow."
+msgstr ""
+
 #, python-format
 msgid "Statement in <b>%(lang)s</b>"
 msgstr "Условие на <b>%(lang)s</b>"
@@ -471,8 +918,18 @@ msgstr "Някои детайли"
 msgid "Compilation commands"
 msgstr "Команди за компилиране"
 
+#, python-format
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
+msgstr ""
+
+msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
+msgstr ""
+
 msgid "Attachments"
 msgstr "Прикачени файлове"
+
+msgid "unknown"
+msgstr ""
 
 msgid "loading..."
 msgstr "зареждане..."
@@ -481,15 +938,77 @@ msgstr "зареждане..."
 msgid "%(name)s (%(short_name)s) <small>submissions</small>"
 msgstr "%(name)s (%(short_name)s) <small>предадени решения</small>"
 
+#, fuzzy
+msgid "Score:"
+msgstr "Резултат"
+
+#, fuzzy
+msgid "Public score:"
+msgstr "Публичен резултат"
+
+#, fuzzy
+msgid "Score of tokened submissions:"
+msgstr "Предишни решения"
+
+#, fuzzy
+msgid "Total score:"
+msgstr "Общ резултат"
+
 msgid "Submit a solution"
 msgstr "Предай решение"
+
+msgid "You may submit any subset of outputs in a single submission."
+msgstr ""
 
 #, python-format
 msgid "You can submit %(submissions_left)s more solution(s)."
 msgstr "Можете да предадете още %(submissions_left)s решения."
 
+#, fuzzy
+msgid "submission.zip"
+msgstr "Предадени решения"
+
 msgid "Previous submissions"
 msgstr "Предишни решения"
+
+msgid "Tokens are not allowed on this task."
+msgstr ""
+
+msgid "Right now, you have infinite tokens available on this task."
+msgstr ""
+
+msgid "Right now, you have one token available on this task."
+msgstr ""
+
+#, python-format
+msgid "Right now, you have %(tokens)s tokens available on this task."
+msgstr ""
+
+#, python-format
+msgid "But you have to wait until %(expiration_time)s to use them."
+msgstr ""
+
+#, python-format
+msgid "You will receive a new token at %(gen_time)s."
+msgstr ""
+
+msgid "In the current situation, no more tokens will be generated."
+msgstr ""
+
+msgid "Right now, you do not have tokens available for this task."
+msgstr ""
+
+#, python-format
+msgid "But you will have to wait until %(expiration_time)s to use it."
+msgstr ""
+
+#, fuzzy
+msgid "Unofficial submissions"
+msgstr "Предадени решения"
+
+#, fuzzy
+msgid "Official submissions"
+msgstr "Предадени решения"
 
 msgid "Submission details"
 msgstr "Детайли на решенията"
@@ -502,6 +1021,10 @@ msgstr "Свали"
 
 msgid "Submit a test"
 msgstr "Изпрати тест"
+
+#, fuzzy, python-format
+msgid "You can submit %(user_tests_left)s more test(s)."
+msgstr "Можете да предадете още %(submissions_left)s решения."
 
 msgid "input"
 msgstr "вход"
@@ -527,21 +1050,26 @@ msgstr "Резултат от оценяването"
 msgid "Wait..."
 msgstr "Изчакай..."
 
-msgid "Public score"
-msgstr "Публичен резултат"
+#, fuzzy
+msgid "None"
+msgstr "Не"
 
-msgid "Total score"
-msgstr "Общ резултат"
+msgid "Token request discarded"
+msgstr ""
 
-msgid "Score"
-msgstr "Резултат"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr ""
 
-msgid "Token"
-msgstr "Жетон"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr ""
 
-msgid "Played"
-msgstr "Изиграно"
+#, fuzzy
+msgid "Invalid file"
+msgstr "Невалиден формат!"
 
-msgid "Play!"
-msgstr "Играй!"
+msgid "Print job has too many pages"
+msgstr ""
+
+msgid "Sent to printer"
+msgstr ""
 

--- a/cms/locale/bs/LC_MESSAGES/cms.po
+++ b/cms/locale/bs/LC_MESSAGES/cms.po
@@ -1,27 +1,33 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: bs_BA\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: bs_BA TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "Nedostupno"
 
-msgid "Correct"
-msgstr "Ispravno"
-
 msgid "Not correct"
 msgstr "Nije ispravno"
 
+msgid "Correct"
+msgstr "Ispravno"
+
 msgid "Partially correct"
 msgstr "Djelomično ispravno"
+
+msgid "#"
+msgstr ""
 
 msgid "Outcome"
 msgstr "Ishod"
@@ -35,6 +41,9 @@ msgstr "Vrijeme izvršenja"
 msgid "Memory used"
 msgstr "Korištena memorija"
 
+msgid "Score details temporarily unavailable."
+msgstr ""
+
 #, python-format
 msgid "Subtask %(index)s"
 msgstr "Podzadatak %(index)s"
@@ -42,31 +51,85 @@ msgstr "Podzadatak %(index)s"
 msgid "Compilation succeeded"
 msgstr "Kompajliranje uspješno"
 
+msgid "Your submission successfully compiled to an executable."
+msgstr ""
+
 msgid "Compilation failed"
 msgstr "Kompajliranje nije uspješno"
 
+msgid "Your submission did not compile correctly."
+msgstr ""
+
 msgid "Compilation timed out"
 msgstr "Kompajliranje je trajalo predugo"
+
+msgid "Your submission exceeded the time limit while compiling. This might be caused by an excessive use of C++ templates, for example."
+msgstr ""
 
 #, python-format
 msgid "Compilation killed with signal %s (could be triggered by violating memory limits)"
 msgstr "Kompajliranje prekinuto signalom %s (možda je izazvano prekoračenjem dozvoljene memorije)"
 
+msgid "Your submission was killed with the specified signal. Among other things, this might be caused by exceeding the memory limit for the compilation, and in turn by an excessive use of C++ templates, for example."
+msgstr ""
+
 msgid "Output is correct"
 msgstr "Izlaz je ispravan"
 
+msgid "Your submission ran and gave the correct answer"
+msgstr ""
+
+#, fuzzy
+msgid "Output is partially correct"
+msgstr "Djelomično ispravno"
+
+msgid "Your submission ran and gave the partially correct answer"
+msgstr ""
+
 msgid "Output isn't correct"
 msgstr "Izlaz nije ispravan"
+
+msgid "Your submission ran, but gave the wrong answer"
+msgstr ""
 
 #, python-format
 msgid "Evaluation didn't produce file %s"
 msgstr "Evaluacija nije proizvela datoteku %s"
 
+msgid "Your submission ran, but did not write on the correct output file"
+msgstr ""
+
 msgid "Execution timed out"
 msgstr "Vrijeme za izvršavanje je isteklo"
 
+msgid "Your submission used too much CPU time."
+msgstr ""
+
+msgid "Execution timed out (wall clock limit exceeded)"
+msgstr ""
+
+msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
+msgstr ""
+
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Memorijsko ograničenje"
+
+msgid "Your submission used too much memory."
+msgstr ""
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Vrijeme za izvršavanje je isteklo"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
+
 msgid "Execution failed because the return code was nonzero"
 msgstr "Izvršenje nije uspjelo jer povratni kod nije bio nula"
+
+msgid "Your submission failed because it exited with a return code different from 0."
+msgstr ""
 
 msgid "Execution completed successfully"
 msgstr "Izvršavanje uspješno završeno"
@@ -76,6 +139,14 @@ msgstr "Nije potrebno kompajliranje"
 
 msgid "File not submitted"
 msgstr "Datoteka nije poslana"
+
+#, fuzzy
+msgid "Question too long!"
+msgstr "Test je prevelik!"
+
+#, python-format
+msgid "Subject must be at most %(max_subject_length)d characters, content at most %(max_text_length)d."
+msgstr ""
 
 msgid "contest-token"
 msgstr "contest-token"
@@ -102,6 +173,10 @@ msgstr "Nemate %(type_pl)s dostupnih za ovaj zadatak."
 #, python-format
 msgid "You have an infinite number of %(type_pl)s for this task."
 msgstr "Imate beskonačan broj %(type_pl)s za ovaj zadatak."
+
+#, fuzzy, python-format
+msgid "You start with no %(type_pl)s."
+msgstr "Počinjete sa %(gen_initial)d %(type_pl)s."
 
 #, python-format
 msgid "You start with one %(type_s)s."
@@ -132,15 +207,15 @@ msgstr[1] "do maksimalnih %(gen_max)d %(type_pl)s."
 msgstr[2] "do maksimalnih %(gen_max)d %(type_pl)s."
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Nećete dobiti druge %(type_pl)s."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "dobićete %(gen_number)d drugih %(type_pl)s, "
 msgstr[1] "dobićete %(gen_number)d drugih %(type_pl)s, "
 msgstr[2] "dobićete %(gen_number)d drugih %(type_pl)s, "
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Nećete dobiti druge %(type_pl)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -173,26 +248,18 @@ msgstr[2] "Ne možete koristiti više od %(max_number)d %(type_pl)s ukupno."
 msgid "You have no limitations on how you use them."
 msgstr "Nemate ograničenja na njihovu upotrebu."
 
-msgid "Please select the correct files."
-msgstr "Molimo izaberite korektne datoteke."
-
-msgid "Please try again."
-msgstr "Molimo pokušajte ponovo."
-
-msgid "Token request discarded"
-msgstr "Zahtjev za tokenom odbijen"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Vaš zahtjev je odbijen jer nemate više slobodnih tokena."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Vaš zahtjev je odbijen jer ste već iskoristili token na toj prijavi."
-
 msgid "Question received"
 msgstr "Primljeno pitanje"
 
 msgid "Your question has been received, you will be notified when it is answered."
 msgstr "Vaše pitanje je primljeno, bićete obaviješteni kada dobijete odgovor."
+
+#, fuzzy
+msgid "Print job received"
+msgstr "Test primljen"
+
+msgid "Your print job has been received."
+msgstr ""
 
 msgid "Submission received"
 msgstr "Primljena prijava"
@@ -212,11 +279,15 @@ msgstr "Bodujem..."
 msgid "Evaluated"
 msgstr "Evaluirano"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Vaš zahtjev je primljen i primijenjen na prijavu."
+#, fuzzy
+msgid "status"
+msgstr "Status"
 
 msgid "Token request received"
 msgstr "Primljen zahtjev za tokenom"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Vaš zahtjev je primljen i primijenjen na prijavu."
 
 msgid "Test received"
 msgstr "Test primljen"
@@ -232,6 +303,36 @@ msgstr "Izvršavam..."
 
 msgid "Executed"
 msgstr "Izvršeno"
+
+#, fuzzy
+msgid "Too many print jobs!"
+msgstr "Previše testova!"
+
+#, fuzzy, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Dosegli ste gornju granicu od maksimalnih %d testova za sve zadatke."
+
+#, fuzzy
+msgid "Invalid format!"
+msgstr "Neispravan format testa!"
+
+msgid "Please select the correct files."
+msgstr "Molimo izaberite korektne datoteke."
+
+#, fuzzy
+msgid "File too big!"
+msgstr "Test je prevelik!"
+
+#, fuzzy, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Svaka izvorna datoteka može biti velika najviše %d bajta."
+
+#, fuzzy
+msgid "Print job storage failed!"
+msgstr "Smještaj testa neuspješan!"
+
+msgid "Please try again."
+msgstr "Molimo pokušajte ponovo."
 
 msgid "Too many submissions!"
 msgstr "Previše prijava!"
@@ -255,6 +356,17 @@ msgstr "Za sve zadatke možete slati novu prijavu nakon %d sekundi od posljednje
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Za ovaj zadatak možete slati novu prijavu nakon %d sekundi od posljednje prijave."
 
+msgid "Submission too big!"
+msgstr "Prijava prevelika!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Svaka izvorna datoteka može biti velika najviše %d bajta."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Neispravan format arhive!"
 
@@ -263,13 +375,6 @@ msgstr "Poslana arhiva se nije mogla otvoriti."
 
 msgid "Invalid submission format!"
 msgstr "Neispravan format prijave!"
-
-msgid "Submission too big!"
-msgstr "Prijava prevelika!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Svaka izvorna datoteka može biti velika najviše %d bajta."
 
 msgid "Submission storage failed!"
 msgstr "Smještaj prijave neuspješan!"
@@ -312,8 +417,41 @@ msgstr "Ulazna datoteka može biti velika najviše %d bajta."
 msgid "Test storage failed!"
 msgstr "Smještaj testa neuspješan!"
 
+#, fuzzy
+msgid "Communication"
+msgstr "Vrijeme kompajliranja:"
+
+#, fuzzy
+msgid "Announcements"
+msgstr "Novo obavještenje"
+
+msgid "(no subject)"
+msgstr ""
+
+#, fuzzy
+msgid "Questions"
+msgstr "Primljeno pitanje"
+
+#, fuzzy
+msgid "Subject"
+msgstr "Pošalji"
+
+msgid "Text"
+msgstr ""
+
+msgid "Ask question"
+msgstr ""
+
 msgid "Reset"
 msgstr "Poništi"
+
+#, fuzzy
+msgid "no answer yet"
+msgstr "Novi odgovor"
+
+#, fuzzy
+msgid "Messages"
+msgstr "Nova poruka"
 
 #, python-format
 msgid "Automatic (%(lang)s)"
@@ -344,6 +482,13 @@ msgstr "Lozinka"
 msgid "Login"
 msgstr "Prijava"
 
+msgid "Don't have an account?"
+msgstr ""
+
+#, fuzzy
+msgid "Register"
+msgstr "Poništi"
+
 msgid "New message"
 msgstr "Nova poruka"
 
@@ -363,8 +508,237 @@ msgstr "Do početka takmičenja:"
 msgid "Until contest ends:"
 msgstr "Do kraja takmičenja:"
 
+#, fuzzy
+msgid "Until analysis starts:"
+msgstr "Do početka takmičenja:"
+
+#, fuzzy
+msgid "Until analysis ends:"
+msgstr "Do kraja takmičenja:"
+
+#, fuzzy
+msgid "Time left:"
+msgstr "Vremensko ograničenje"
+
+msgid "Server time:"
+msgstr ""
+
+#, fuzzy
+msgid "Overview"
+msgstr "Pregled zadatka"
+
+#, fuzzy
+msgid "Statement"
+msgstr "Specifikacija u %(lang)s"
+
+#, fuzzy
+msgid "Submissions"
+msgstr "prijava.zip"
+
+msgid "Documentation"
+msgstr ""
+
+#, fuzzy
+msgid "Testing"
+msgstr "Test je prevelik!"
+
+msgid "Printing"
+msgstr ""
+
+msgid "Contest Management System"
+msgstr ""
+
+msgid "is released under the"
+msgstr ""
+
+msgid "GNU Affero General Public License"
+msgstr ""
+
+msgid "Choose a contest"
+msgstr ""
+
+msgid "Programming languages and libraries"
+msgstr ""
+
+msgid "The main Java class of the solution should have exactly the same name as the task."
+msgstr ""
+
+#, fuzzy
+msgid "Submission details for compilation"
+msgstr "Detalji prijave"
+
+#, fuzzy
+msgid "Message"
+msgstr "Nova poruka"
+
+msgid "Explanation"
+msgstr ""
+
+#, fuzzy
+msgid "Submission details for evaluation"
+msgstr "Detalji prijave"
+
+#, python-format
+msgid "Error %(status_code)s"
+msgstr ""
+
+msgid "An error occured while the server was handling your request."
+msgstr ""
+
+msgid "Note that attempts to tamper with Contest Management System (such as probing the server with customized URLs) may be considered cheating and may lead to disqualification."
+msgstr ""
+
+msgid "If you encountered this error during normal usage, please notify the contest administrators."
+msgstr ""
+
+msgid "Public score"
+msgstr "Javni bodovi"
+
+msgid "Total score"
+msgstr "Ukupni bodovi"
+
+msgid "Score"
+msgstr "Bodovi"
+
+msgid "Token"
+msgstr "Token"
+
+#, fuzzy
+msgid "no submissions"
+msgstr "Prethodne prijave"
+
+msgid "Played"
+msgstr "Iskorišteno"
+
+msgid "Play!"
+msgstr "Iskoristi!"
+
+msgid "No tokens"
+msgstr "Nema tokena"
+
+msgid "General information"
+msgstr ""
+
+msgid "The contest hasn't started yet."
+msgstr ""
+
+#, python-format
+msgid "The contest will start at %(start_time)s and will end at %(stop_time)s."
+msgstr ""
+
+msgid "The contest is currently running."
+msgstr ""
+
+#, python-format
+msgid "The contest started at %(start_time)s and will end at %(stop_time)s."
+msgstr ""
+
+msgid "The contest has already ended."
+msgstr ""
+
+#, python-format
+msgid "The contest started at %(start_time)s and ended at %(stop_time)s."
+msgstr ""
+
+msgid "The analysis mode hasn't started yet."
+msgstr ""
+
+#, python-format
+msgid "The analysis mode will start at %(start_time)s and will end at %(stop_time)s."
+msgstr ""
+
+msgid "The analysis mode is currently running."
+msgstr ""
+
+#, python-format
+msgid "The analysis mode started at %(start_time)s and will end at %(stop_time)s."
+msgstr ""
+
+msgid "The analysis mode has already ended."
+msgstr ""
+
+#, python-format
+msgid "The analysis mode started at %(start_time)s and ended at %(stop_time)s."
+msgstr ""
+
+#, fuzzy
+msgid "You have an infinite number of tokens."
+msgstr "Imate beskonačan broj %(type_pl)s za ovaj zadatak."
+
+#, fuzzy
+msgid "You can see the detailed result of a submission by using a token on it."
+msgstr "Zapamtite da ne možete vidjeti detaljan rezultat prijave osim ako iskoristite i contest-token i task-token."
+
+#, fuzzy
+msgid "Your score for each task will be the maximum among the tokened submissions and the last one."
+msgstr "Dosegli ste gornju granicu od maksimalnih %d prijava za ovaj zadatak."
+
+#, fuzzy
+msgid "You have a distinct set of tokens for each task."
+msgstr "Imate beskonačan broj %(type_pl)s za ovaj zadatak."
+
+#, python-format
+msgid "You can find the rules for the %(type_pl)s on each task's description page."
+msgstr ""
+
+msgid "You have a set of tokens shared among all tasks."
+msgstr ""
+
+msgid "You have two types of tokens: a set of <em>contest-tokens</em> shared among all tasks and a distinct set of <em>task-tokens</em> for each task."
+msgstr ""
+
+#, fuzzy
+msgid "You can see the detailed result of a submission by using two tokens on it, one of each type."
+msgstr "Zapamtite da ne možete vidjeti detaljan rezultat prijave osim ako iskoristite i contest-token i task-token."
+
+#, fuzzy, python-format
+msgid "You can submit at most %(submissions)s solutions during this contest."
+msgstr "Dosegli ste gornju granicu od maksimalnih %d prijava za ovaj zadatak."
+
+#, python-format
+msgid "You can submit at most %(user_tests)s user tests during this contest."
+msgstr ""
+
+#, python-format
+msgid "Every user is allowed to compete (i.e. submit solutions) for a uninterrupted time frame of %(per_user_time)s."
+msgstr ""
+
+msgid "As soon as the contest starts you can choose to start your time frame."
+msgstr ""
+
+msgid "Once you start, you can submit solutions until the end of the time frame or until the end of the contest, whatever comes first."
+msgstr ""
+
+msgid "By clicking on the button below you can start your time frame."
+msgstr ""
+
+#, python-format
+msgid "You started your time frame at %(start_time)s."
+msgstr ""
+
+msgid "You can submit solutions until the end of the time frame or until the end of the contest, whatever comes first."
+msgstr ""
+
+#, python-format
+msgid "You started your time frame at %(start_time)s and you already finished it."
+msgstr ""
+
+msgid "There's nothing you can do now."
+msgstr ""
+
+msgid "You never started your time frame. Now it's too late."
+msgstr ""
+
+#, fuzzy
+msgid "Start!"
+msgstr "Status"
+
 msgid "Task overview"
 msgstr "Pregled zadatka"
+
+#, fuzzy
+msgid "Task"
+msgstr "Status"
 
 msgid "Name"
 msgstr "Ime"
@@ -390,8 +764,33 @@ msgstr "Da"
 msgid "No"
 msgstr "Ne"
 
+#, fuzzy
+msgid "Print"
+msgstr "Ulaz"
+
+#, python-format
+msgid "You can print %(remaining_jobs)s more text or PDF files of up to %(max_pages)s pages each."
+msgstr ""
+
+#, python-format
+msgid "You can print %(remaining_jobs)s more text files of up to %(max_pages)s pages each."
+msgstr ""
+
+msgid "File (text or PDF)"
+msgstr ""
+
+msgid "File (text)"
+msgstr ""
+
 msgid "Submit"
 msgstr "Pošalji"
+
+msgid "You cannot print anything any more as you have used up your printing quota."
+msgstr ""
+
+#, fuzzy
+msgid "Previous print jobs"
+msgstr "Prethodni testovi"
 
 msgid "Date and time"
 msgstr "Datum i vrijeme"
@@ -399,8 +798,87 @@ msgstr "Datum i vrijeme"
 msgid "Time"
 msgstr "Vrijeme"
 
+#, fuzzy
+msgid "File name"
+msgstr "Ime"
+
 msgid "Status"
 msgstr "Status"
+
+#, fuzzy
+msgid "Preparing..."
+msgstr "Evaluiram..."
+
+#, fuzzy
+msgid "no print jobs yet"
+msgstr "još uvijek nema testova"
+
+msgid "The passwords do not match!"
+msgstr ""
+
+msgid "This username is already taken, please choose a different one."
+msgstr ""
+
+msgid "This user is already registered in the contest."
+msgstr ""
+
+msgid "No such user."
+msgstr ""
+
+msgid "The password is not correct."
+msgstr ""
+
+msgid "Registration"
+msgstr ""
+
+msgid "Please fill in the fields to register"
+msgstr ""
+
+#, fuzzy
+msgid "New user"
+msgstr "Novi odgovor"
+
+msgid "Join contest"
+msgstr ""
+
+msgid "First name"
+msgstr ""
+
+#, fuzzy
+msgid "Last name"
+msgstr "Ime"
+
+#, fuzzy
+msgid "E-mail"
+msgstr "detalji"
+
+msgid "Representing"
+msgstr ""
+
+#, python-format
+msgid "Must be one character or more."
+msgid_plural "Must be %(min_length)s characters or more."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, fuzzy
+msgid "Confirm password"
+msgstr "Lozinka"
+
+msgid "Registered in the contest successfully!"
+msgstr ""
+
+#, fuzzy
+msgid "Your username is:"
+msgstr "Korisničko ime"
+
+msgid "Your password is stored securely."
+msgstr ""
+
+#, fuzzy
+msgid "Back to login"
+msgstr "Prijava neuspješna."
 
 msgid "Compilation output"
 msgstr "Izlaz kompajlera"
@@ -461,11 +939,18 @@ msgstr "Neki detalji"
 msgid "Compilation commands"
 msgstr "Naredbe kompajlera"
 
+#, python-format
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
+msgstr ""
+
 msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
 msgstr "Zapamtite da ne možete vidjeti detaljan rezultat prijave osim ako iskoristite i contest-token i task-token."
 
 msgid "Attachments"
 msgstr "Prilozi"
+
+msgid "unknown"
+msgstr ""
 
 msgid "loading..."
 msgstr "učitavam..."
@@ -474,14 +959,40 @@ msgstr "učitavam..."
 msgid "%(name)s (%(short_name)s) <small>submissions</small>"
 msgstr "%(name)s (%(short_name)s) <small>prijave</small>"
 
+#, fuzzy
+msgid "Score:"
+msgstr "Bodovi"
+
+#, fuzzy
+msgid "Public score:"
+msgstr "Javni bodovi"
+
+#, fuzzy
+msgid "Score of tokened submissions:"
+msgstr "Prethodne prijave"
+
+#, fuzzy
+msgid "Total score:"
+msgstr "Ukupni bodovi"
+
 msgid "Submit a solution"
 msgstr "Pošalji rješenje"
+
+msgid "You may submit any subset of outputs in a single submission."
+msgstr ""
+
+#, python-format
+msgid "You can submit %(submissions_left)s more solution(s)."
+msgstr ""
 
 msgid "submission.zip"
 msgstr "prijava.zip"
 
 msgid "Previous submissions"
 msgstr "Prethodne prijave"
+
+msgid "Tokens are not allowed on this task."
+msgstr ""
 
 msgid "Right now, you have infinite tokens available on this task."
 msgstr "Trenutno imate beskonačno mnogo tokena za ovaj zadatak."
@@ -511,6 +1022,14 @@ msgstr "Trenutno nemate nijedan token za ovaj zadatak."
 msgid "But you will have to wait until %(expiration_time)s to use it."
 msgstr "Ali morate sačekati do %(expiration_time)s da biste ih koristili."
 
+#, fuzzy
+msgid "Unofficial submissions"
+msgstr "Previše prijava!"
+
+#, fuzzy
+msgid "Official submissions"
+msgstr "Previše prijava!"
+
 msgid "Submission details"
 msgstr "Detalji prijave"
 
@@ -522,6 +1041,10 @@ msgstr "Download"
 
 msgid "Submit a test"
 msgstr "Pošalji test"
+
+#, python-format
+msgid "You can submit %(user_tests_left)s more test(s)."
+msgstr ""
 
 msgid "input"
 msgstr "ulaz"
@@ -550,24 +1073,21 @@ msgstr "Čekaj..."
 msgid "None"
 msgstr "Bez"
 
-msgid "Public score"
-msgstr "Javni bodovi"
+msgid "Token request discarded"
+msgstr "Zahtjev za tokenom odbijen"
 
-msgid "Total score"
-msgstr "Ukupni bodovi"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Vaš zahtjev je odbijen jer nemate više slobodnih tokena."
 
-msgid "Score"
-msgstr "Bodovi"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Vaš zahtjev je odbijen jer ste već iskoristili token na toj prijavi."
 
-msgid "Token"
-msgstr "Token"
+msgid "Invalid file"
+msgstr ""
 
-msgid "Played"
-msgstr "Iskorišteno"
+msgid "Print job has too many pages"
+msgstr ""
 
-msgid "Play!"
-msgstr "Iskoristi!"
-
-msgid "No tokens"
-msgstr "Nema tokena"
+msgid "Sent to printer"
+msgstr ""
 

--- a/cms/locale/cms.pot
+++ b/cms/locale/cms.pot
@@ -1,22 +1,21 @@
 # Translations template for Contest Management System.
-# Copyright (C) 2021 CMS development group
-# This file is distributed under the same license as the Contest Management
-# System project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+# Copyright (C) 2025 CMS development group
+# This file is distributed under the same license as the Contest Management System project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Contest Management System 1.5.dev0\n"
+"Project-Id-Version: Contest Management System 1.5.1\n"
 "Report-Msgid-Bugs-To: contestms@googlegroups.com\n"
-"POT-Creation-Date: 2021-12-20 17:01+0200\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.6.0\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr ""
@@ -67,21 +66,14 @@ msgstr ""
 msgid "Compilation timed out"
 msgstr ""
 
-msgid ""
-"Your submission exceeded the time limit while compiling. This might be "
-"caused by an excessive use of C++ templates, for example."
+msgid "Your submission exceeded the time limit while compiling. This might be caused by an excessive use of C++ templates, for example."
 msgstr ""
 
 #, python-format
-msgid ""
-"Compilation killed with signal %s (could be triggered by violating memory "
-"limits)"
+msgid "Compilation killed with signal %s (could be triggered by violating memory limits)"
 msgstr ""
 
-msgid ""
-"Your submission was killed with the specified signal. Among other things, "
-"this might be caused by exceeding the memory limit for the compilation, and "
-"in turn by an excessive use of C++ templates, for example."
+msgid "Your submission was killed with the specified signal. Among other things, this might be caused by exceeding the memory limit for the compilation, and in turn by an excessive use of C++ templates, for example."
 msgstr ""
 
 msgid "Output is correct"
@@ -118,21 +110,19 @@ msgstr ""
 msgid "Execution timed out (wall clock limit exceeded)"
 msgstr ""
 
-msgid ""
-"Your submission used too much total time. This might be triggered by "
-"undefined code, or buffer overflow, for example. Note that in this case the "
-"CPU time visible in the submission details might be much smaller than the "
-"time limit."
+msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr ""
 
-msgid "Execution killed (could be triggered by violating memory limits)"
+msgid "Memory limit exceeded"
 msgstr ""
 
-msgid ""
-"The evaluation was killed by a signal. Among other things, this might be "
-"caused by exceeding the memory limit. Note that if this is the reason, the "
-"memory usage visible in the submission details is the usage before the "
-"allocation that caused the signal."
+msgid "Your submission used too much memory."
+msgstr ""
+
+msgid "Execution killed by signal"
+msgstr ""
+
+msgid "The evaluation was killed by a signal."
 msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
@@ -154,9 +144,7 @@ msgid "Question too long!"
 msgstr ""
 
 #, python-format
-msgid ""
-"Subject must be at most %(max_subject_length)d characters, content at most "
-"%(max_text_length)d."
+msgid "Subject must be at most %(max_subject_length)d characters, content at most %(max_text_length)d."
 msgstr ""
 
 msgid "contest-token"
@@ -250,43 +238,6 @@ msgstr[1] ""
 msgid "You have no limitations on how you use them."
 msgstr ""
 
-msgid "Too many print jobs!"
-msgstr ""
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr ""
-
-msgid "Invalid format!"
-msgstr ""
-
-msgid "Please select the correct files."
-msgstr ""
-
-msgid "File too big!"
-msgstr ""
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr ""
-
-msgid "Print job storage failed!"
-msgstr ""
-
-msgid "Please try again."
-msgstr ""
-
-msgid "Token request discarded"
-msgstr ""
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr ""
-
-msgid ""
-"Your request has been discarded because you already used a token on that "
-"submission."
-msgstr ""
-
 msgid "Question received"
 msgstr ""
 
@@ -341,6 +292,32 @@ msgstr ""
 msgid "Executed"
 msgstr ""
 
+msgid "Too many print jobs!"
+msgstr ""
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr ""
+
+msgid "Invalid format!"
+msgstr ""
+
+msgid "Please select the correct files."
+msgstr ""
+
+msgid "File too big!"
+msgstr ""
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr ""
+
+msgid "Print job storage failed!"
+msgstr ""
+
+msgid "Please try again."
+msgstr ""
+
 msgid "Too many submissions!"
 msgstr ""
 
@@ -363,6 +340,17 @@ msgstr ""
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr ""
 
+msgid "Submission too big!"
+msgstr ""
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr ""
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr ""
 
@@ -370,13 +358,6 @@ msgid "The submitted archive could not be opened."
 msgstr ""
 
 msgid "Invalid submission format!"
-msgstr ""
-
-msgid "Submission too big!"
-msgstr ""
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
 msgstr ""
 
 msgid "Submission storage failed!"
@@ -458,9 +439,7 @@ msgid "Logout"
 msgstr ""
 
 #, python-format
-msgid ""
-"Logged in as <strong>%(first_name)s %(last_name)s</strong> "
-"<em>(%(username)s)</em>"
+msgid "Logged in as <strong>%(first_name)s %(last_name)s</strong> <em>(%(username)s)</em>"
 msgstr ""
 
 msgid "Failed to log in."
@@ -551,12 +530,7 @@ msgstr ""
 msgid "Programming languages and libraries"
 msgstr ""
 
-msgid "Standard Template Library"
-msgstr ""
-
-msgid ""
-"The main Java class of the solution should have exactly the same name as the"
-" task."
+msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr ""
 
 msgid "Submission details for compilation"
@@ -578,15 +552,34 @@ msgstr ""
 msgid "An error occured while the server was handling your request."
 msgstr ""
 
-msgid ""
-"Note that attempts to tamper with Contest Management System (such as probing"
-" the server with customized URLs) may be considered cheating and may lead to"
-" disqualification."
+msgid "Note that attempts to tamper with Contest Management System (such as probing the server with customized URLs) may be considered cheating and may lead to disqualification."
 msgstr ""
 
-msgid ""
-"If you encountered this error during normal usage, please notify the contest"
-" administrators."
+msgid "If you encountered this error during normal usage, please notify the contest administrators."
+msgstr ""
+
+msgid "Public score"
+msgstr ""
+
+msgid "Total score"
+msgstr ""
+
+msgid "Score"
+msgstr ""
+
+msgid "Token"
+msgstr ""
+
+msgid "no submissions"
+msgstr ""
+
+msgid "Played"
+msgstr ""
+
+msgid "Play!"
+msgstr ""
+
+msgid "No tokens"
 msgstr ""
 
 msgid "General information"
@@ -640,9 +633,7 @@ msgstr ""
 msgid "You can see the detailed result of a submission by using a token on it."
 msgstr ""
 
-msgid ""
-"Your score for each task will be the maximum among the tokened submissions "
-"and the last one."
+msgid "Your score for each task will be the maximum among the tokened submissions and the last one."
 msgstr ""
 
 msgid "You have a distinct set of tokens for each task."
@@ -655,14 +646,10 @@ msgstr ""
 msgid "You have a set of tokens shared among all tasks."
 msgstr ""
 
-msgid ""
-"You have two types of tokens: a set of <em>contest-tokens</em> shared among "
-"all tasks and a distinct set of <em>task-tokens</em> for each task."
+msgid "You have two types of tokens: a set of <em>contest-tokens</em> shared among all tasks and a distinct set of <em>task-tokens</em> for each task."
 msgstr ""
 
-msgid ""
-"You can see the detailed result of a submission by using two tokens on it, "
-"one of each type."
+msgid "You can see the detailed result of a submission by using two tokens on it, one of each type."
 msgstr ""
 
 #, python-format
@@ -674,17 +661,13 @@ msgid "You can submit at most %(user_tests)s user tests during this contest."
 msgstr ""
 
 #, python-format
-msgid ""
-"Every user is allowed to compete (i.e. submit solutions) for a uninterrupted"
-" time frame of %(per_user_time)s."
+msgid "Every user is allowed to compete (i.e. submit solutions) for a uninterrupted time frame of %(per_user_time)s."
 msgstr ""
 
 msgid "As soon as the contest starts you can choose to start your time frame."
 msgstr ""
 
-msgid ""
-"Once you start, you can submit solutions until the end of the time frame or "
-"until the end of the contest, whatever comes first."
+msgid "Once you start, you can submit solutions until the end of the time frame or until the end of the contest, whatever comes first."
 msgstr ""
 
 msgid "By clicking on the button below you can start your time frame."
@@ -694,9 +677,7 @@ msgstr ""
 msgid "You started your time frame at %(start_time)s."
 msgstr ""
 
-msgid ""
-"You can submit solutions until the end of the time frame or until the end of"
-" the contest, whatever comes first."
+msgid "You can submit solutions until the end of the time frame or until the end of the contest, whatever comes first."
 msgstr ""
 
 #, python-format
@@ -746,15 +727,11 @@ msgid "Print"
 msgstr ""
 
 #, python-format
-msgid ""
-"You can print %(remaining_jobs)s more text or PDF files of up to "
-"%(max_pages)s pages each."
+msgid "You can print %(remaining_jobs)s more text or PDF files of up to %(max_pages)s pages each."
 msgstr ""
 
 #, python-format
-msgid ""
-"You can print %(remaining_jobs)s more text files of up to %(max_pages)s "
-"pages each."
+msgid "You can print %(remaining_jobs)s more text files of up to %(max_pages)s pages each."
 msgstr ""
 
 msgid "File (text or PDF)"
@@ -878,9 +855,7 @@ msgstr ""
 msgid "Download task statement"
 msgstr ""
 
-msgid ""
-"The statement for this task is available in multiple versions, in different "
-"languages."
+msgid "The statement for this task is available in multiple versions, in different languages."
 msgstr ""
 
 msgid "You can see (and download) all of them using the list on the right."
@@ -912,14 +887,10 @@ msgid "Compilation commands"
 msgstr ""
 
 #, python-format
-msgid ""
-"You can find the rules for the %(type_pl)s on the <a "
-"href=\"%(contest_root)s\">contest overview page</a>."
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
 msgstr ""
 
-msgid ""
-"Remember that to see the detailed result of a submission you need to use "
-"both a contest-token and a task-token."
+msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
 msgstr ""
 
 msgid "Attachments"
@@ -1043,28 +1014,13 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-msgid "Public score"
+msgid "Token request discarded"
 msgstr ""
 
-msgid "Total score"
+msgid "Your request has been discarded because you have no tokens available."
 msgstr ""
 
-msgid "Score"
-msgstr ""
-
-msgid "Token"
-msgstr ""
-
-msgid "no submissions"
-msgstr ""
-
-msgid "Played"
-msgstr ""
-
-msgid "Play!"
-msgstr ""
-
-msgid "No tokens"
+msgid "Your request has been discarded because you already used a token on that submission."
 msgstr ""
 
 msgid "Invalid file"

--- a/cms/locale/cs/LC_MESSAGES/cms.po
+++ b/cms/locale/cs/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: cs\n"
+"Language-Team: cs TEAM <EMAIL@ADDRESS>\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "N/A"
 
-msgid "Correct"
-msgstr "Správně"
-
 msgid "Not correct"
 msgstr "Nesprávně"
+
+msgid "Correct"
+msgstr "Správně"
 
 msgid "Partially correct"
 msgstr "Částečně správně"
 
-msgid "Outcome"
-msgstr "Výsledek"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "Výsledek"
 
 msgid "Details"
 msgstr "Podrobnosti"
@@ -107,11 +110,20 @@ msgstr "Program vyčerpal časový limit (překročený limit na reálný čas)"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "Odevzdané řešení využilo příliš mnoho celkového času. To může být např. způsobeno kódem s nedefinovaným chováním nebo přetečením bufferu. Uvědomte si, že v tomto případě může být procesorový čas zobrazený v detailech odevzdaného řešení mnohem menší než časový limit."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "Program byl ukončen (to mohlo být způsobeno překročením paměťových limitů)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Paměťový limit"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "Vyhodnocování bylo ukončeno signálem. To může být způsobeno překročením paměťového limitu. Uvědomte si, že je-li to způsobeno tím, použitá paměť zobrazená v detailech odevzdaného řešení je použitá paměť před alokací, která způsobila poslání signálu."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Odevzdané řešení spotřebovalo příliš mnoho procesorového času."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Program vyčerpal časový limit"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "Program selhal kvůli nenulové návratové hodnotě"
@@ -153,13 +165,24 @@ msgstr "token"
 msgid "tokens"
 msgstr "tokeny"
 
+#, fuzzy, python-format
+msgid "You don't have %(type_pl)s available for this task."
+msgstr "Právě teď nemáte pro tuto úlohu k dispozici žádný token."
+
+#, fuzzy, python-format
+msgid "You have an infinite number of %(type_pl)s for this task."
+msgstr "Máte neomezený počet tokenů."
+
+#, fuzzy, python-format
+msgid "You start with no %(type_pl)s."
+msgstr "%(type_pl)s k dispozici na začátku: %(gen_initial)d"
+
 #, python-format
 msgid "You start with one %(type_s)s."
 msgid_plural "You start with %(gen_initial)d %(type_pl)s."
 msgstr[0] "%(type_pl)s k dispozici na začátku: %(gen_initial)d"
 msgstr[1] "%(type_pl)s k dispozici na začátku: %(gen_initial)d"
 msgstr[2] "%(type_pl)s k dispozici na začátku: %(gen_initial)d"
-msgstr[3] ""
 
 #, python-format
 msgid "Every minute "
@@ -167,7 +190,6 @@ msgid_plural "Every %(gen_interval)g minutes "
 msgstr[0] "Každou %(gen_interval)g minutu "
 msgstr[1] "Každé %(gen_interval)g minuty "
 msgstr[2] "Každých %(gen_interval)g minut "
-msgstr[3] ""
 
 #, python-format
 msgid "you get another %(type_s)s, "
@@ -175,7 +197,6 @@ msgid_plural "you get %(gen_number)d other %(type_pl)s, "
 msgstr[0] "dostanete další %(type_s), "
 msgstr[1] "dostanete další %(gen_number)d %(type_pl), "
 msgstr[2] "dostanete dalších %(gen_number) %(type_pl), "
-msgstr[3] ""
 
 #, python-format
 msgid "up to a maximum of one %(type_s)s."
@@ -183,7 +204,6 @@ msgid_plural "up to a maximum of %(gen_max)d %(type_pl)s."
 msgstr[0] " až do maximálního počtu 1 %(type_pl)s."
 msgstr[1] " až do maximálního počtu %(gen_max)d %(type_pl)s."
 msgstr[2] " až do maximálního počtu %(gen_max)d %(type_pl)s."
-msgstr[3] ""
 
 #, python-format
 msgid "you get another %(type_s)s."
@@ -191,7 +211,10 @@ msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] " dostanete další %(type_s)s."
 msgstr[1] " dostanete další %(type_s)s v počtu %(gen_number)d."
 msgstr[2] " dostanete další %(type_s)s v počtu %(gen_number)d."
-msgstr[3] ""
+
+#, fuzzy, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr " dostanete další %(type_s)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -199,7 +222,6 @@ msgid_plural "You can use a %(type_s)s every %(min_interval)g seconds "
 msgstr[0] "Můžete použít %(type_s) každou vteřinu "
 msgstr[1] "Můžete použít %(type_s) každé %(min_interval)g vteřiny "
 msgstr[2] "Můžete použít %(type_s) každých %(min_interval)g vteřin "
-msgstr[3] ""
 
 #, python-format
 msgid "and no more than one %(type_s)s in total."
@@ -207,7 +229,6 @@ msgid_plural "and no more than %(max_number)d %(type_pl)s in total."
 msgstr[0] " a maximálně 1 %(type_s) celkem."
 msgstr[1] " a maximálně %(max_number)d %(type_pl)s celkem."
 msgstr[2] " a maximálně %(max_number)d %(type_pl)s celkem."
-msgstr[3] ""
 
 #, python-format
 msgid "You can use a %(type_s)s every second."
@@ -215,7 +236,6 @@ msgid_plural "You can use a %(type_s)s every %(min_interval)g seconds."
 msgstr[0] "Smíte použít %(type_s) každou vteřinu."
 msgstr[1] "Smíte použít %(type_s) každé %(min_interval)g vteřiny."
 msgstr[2] "Smíte použít %(type_s) každých %(min_interval)g vteřin."
-msgstr[3] ""
 
 #, python-format
 msgid "You can use no more than one %(type_s)s in total."
@@ -223,45 +243,9 @@ msgid_plural "You can use no more than %(max_number)d %(type_pl)s in total."
 msgstr[0] "Počet použití %(type_s)s máte omezený na 1."
 msgstr[1] "Počet použití %(type_s)s máte omezený na %(max_number)d."
 msgstr[2] "Počet použití %(type_s)s máte omezený na %(max_number)d."
-msgstr[3] ""
 
 msgid "You have no limitations on how you use them."
 msgstr "Nemáte žádná omezení na to, jak je použijete."
-
-msgid "Too many print jobs!"
-msgstr "Příliš mnoho tiskových úloh!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Byl dosažený limit maximálně %d tiskoových úloh."
-
-msgid "Invalid format!"
-msgstr "Neplatný formát!"
-
-msgid "Please select the correct files."
-msgstr "Prosím vyberte správné soubory."
-
-msgid "File too big!"
-msgstr "Příliš velký soubor!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Každý soubor smí být velký maximálně %d bytů."
-
-msgid "Print job storage failed!"
-msgstr "Nepodařilo se uložit tiskovou úlohu."
-
-msgid "Please try again."
-msgstr "Prosím zkuste to znovu."
-
-msgid "Token request discarded"
-msgstr "Požadavek na token nesplněn."
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Požadavek nebyl splněn, protože nemáte k dispozici žádné tokeny."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Požadavek nebyl splněn, protože pro toto odevzdané řešení jste už token použili."
 
 msgid "Question received"
 msgstr "Otázka přijata"
@@ -296,11 +280,11 @@ msgstr "Vyhodnoceno"
 msgid "status"
 msgstr "stav"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Váš požadavek byl použit na odevzdané řešení."
-
 msgid "Token request received"
 msgstr "Obdržen požadavek o token"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Váš požadavek byl použit na odevzdané řešení."
 
 msgid "Test received"
 msgstr "Test přijat"
@@ -316,6 +300,32 @@ msgstr "Provádění..."
 
 msgid "Executed"
 msgstr "Provedeno"
+
+msgid "Too many print jobs!"
+msgstr "Příliš mnoho tiskových úloh!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Byl dosažený limit maximálně %d tiskoových úloh."
+
+msgid "Invalid format!"
+msgstr "Neplatný formát!"
+
+msgid "Please select the correct files."
+msgstr "Prosím vyberte správné soubory."
+
+msgid "File too big!"
+msgstr "Příliš velký soubor!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Každý soubor smí být velký maximálně %d bytů."
+
+msgid "Print job storage failed!"
+msgstr "Nepodařilo se uložit tiskovou úlohu."
+
+msgid "Please try again."
+msgstr "Prosím zkuste to znovu."
 
 msgid "Too many submissions!"
 msgstr "Příliš mnoho odevzdaných řešení!"
@@ -339,6 +349,17 @@ msgstr "Řešení libovolné úlohy můžete znovu odevzdat po %d vteřinách od
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Řešení této úlohy můžete znovu odevzdat po %d vteřinách od posledního odevzdání."
 
+msgid "Submission too big!"
+msgstr "Příliš velké odevzdané řešení!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Každý zdrojový soubor smí být maximálně %d bytů velký."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Neplatný formát archivu!"
 
@@ -347,13 +368,6 @@ msgstr "Odevzdaný archiv nemohl být otevřen."
 
 msgid "Invalid submission format!"
 msgstr "Neplatný formát odevzdaného řešení!"
-
-msgid "Submission too big!"
-msgstr "Příliš velké odevzdané řešení!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Každý zdrojový soubor smí být maximálně %d bytů velký."
 
 msgid "Submission storage failed!"
 msgstr "Nepodařilo se uložit odevzdané řešení!"
@@ -477,11 +491,11 @@ msgstr "%d nepřečteno"
 msgid "Until contest starts:"
 msgstr "Do začátku soutěže:"
 
-msgid "Until analysis starts:"
-msgstr "Do začátku analýzy:"
-
 msgid "Until contest ends:"
 msgstr "Do konce soutěže:"
+
+msgid "Until analysis starts:"
+msgstr "Do začátku analýzy:"
 
 msgid "Until analysis ends:"
 msgstr "Do konce analýzy:"
@@ -525,9 +539,6 @@ msgstr "Vyberte si soutěž"
 msgid "Programming languages and libraries"
 msgstr "Programovací jazyky a knihovny"
 
-msgid "Standard Template Library"
-msgstr "Standard Template Library (STL)"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "Hlavní třída programu v Javě se musí jmenovat stejně jako úloha."
 
@@ -555,6 +566,30 @@ msgstr "Vezměte na vědomí, že pokusy zasahovat do soutěžního systému (ja
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Pokud potkáte tuto chybu během běžného použití, dejte prosím vědět organizátorům soutěže."
+
+msgid "Public score"
+msgstr "Veřejné skóre"
+
+msgid "Total score"
+msgstr "Celkové skóre"
+
+msgid "Score"
+msgstr "Skóre"
+
+msgid "Token"
+msgstr "Token"
+
+msgid "no submissions"
+msgstr "žádná odevzdaná řešení"
+
+msgid "Played"
+msgstr "Zahráno"
+
+msgid "Play!"
+msgstr "Zahrát!"
+
+msgid "No tokens"
+msgstr "Žádné tokeny"
 
 msgid "General information"
 msgstr "Obecné informace"
@@ -747,11 +782,30 @@ msgstr "Hesla se neshodují!"
 msgid "This username is already taken, please choose a different one."
 msgstr "Toto uživatelské jméno je již zabrané, prosíme vyberte jiné."
 
+#, fuzzy
+msgid "This user is already registered in the contest."
+msgstr "Toto uživatelské jméno je již zabrané, prosíme vyberte jiné."
+
+msgid "No such user."
+msgstr ""
+
+#, fuzzy
+msgid "The password is not correct."
+msgstr "Hesla se neshodují!"
+
+#, fuzzy
+msgid "Registration"
+msgstr "Registrovat"
+
 msgid "Please fill in the fields to register"
 msgstr "Prosíme vyplňte tato pole k registraci"
 
 msgid "New user"
 msgstr "Nový uživatel"
+
+#, fuzzy
+msgid "Join contest"
+msgstr "Vyberte si soutěž"
 
 msgid "First name"
 msgstr "Křestní jméno"
@@ -771,13 +825,18 @@ msgid_plural "Must be %(min_length)s characters or more."
 msgstr[0] "Musí mít alespoň %(min_length)s znak."
 msgstr[1] "Musí mít alespoň %(min_length)s znaky."
 msgstr[2] "Musí mít alespoň %(min_length)s znaků."
-msgstr[3] ""
 
 msgid "Confirm password"
 msgstr "Zopakujte heslo"
 
+msgid "Registered in the contest successfully!"
+msgstr ""
+
 msgid "Your username is:"
 msgstr "Vaše uživatelské jméno je:"
+
+msgid "Your password is stored securely."
+msgstr ""
 
 msgid "Back to login"
 msgstr "Zpět na přihlášení"
@@ -840,6 +899,10 @@ msgstr "Bližší informace"
 
 msgid "Compilation commands"
 msgstr "Příkazy ke kompilaci"
+
+#, fuzzy, python-format
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
+msgstr "Pravidla pro %(type_pl)s můžete najít u popisu každé úlohy."
 
 msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
 msgstr "Pamatujte, že k zobrazení detailních výsledků odevzdaného řešení musíte použít jak soutěžní token, tak úlohový token."
@@ -965,29 +1028,14 @@ msgstr "Počkejte..."
 msgid "None"
 msgstr "Žádné"
 
-msgid "Public score"
-msgstr "Veřejné skóre"
+msgid "Token request discarded"
+msgstr "Požadavek na token nesplněn."
 
-msgid "Total score"
-msgstr "Celkové skóre"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Požadavek nebyl splněn, protože nemáte k dispozici žádné tokeny."
 
-msgid "Score"
-msgstr "Skóre"
-
-msgid "Token"
-msgstr "Token"
-
-msgid "no submissions"
-msgstr "žádná odevzdaná řešení"
-
-msgid "Played"
-msgstr "Zahráno"
-
-msgid "Play!"
-msgstr "Zahrát!"
-
-msgid "No tokens"
-msgstr "Žádné tokeny"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Požadavek nebyl splněn, protože pro toto odevzdané řešení jste už token použili."
 
 msgid "Invalid file"
 msgstr "Neplatný soubor"
@@ -997,4 +1045,13 @@ msgstr "Tisková úloha má moc stránek"
 
 msgid "Sent to printer"
 msgstr "Odeslat do tiskárny"
+
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "Program byl ukončen (to mohlo být způsobeno překročením paměťových limitů)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "Vyhodnocování bylo ukončeno signálem. To může být způsobeno překročením paměťového limitu. Uvědomte si, že je-li to způsobeno tím, použitá paměť zobrazená v detailech odevzdaného řešení je použitá paměť před alokací, která způsobila poslání signálu."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Standard Template Library (STL)"
 

--- a/cms/locale/de/LC_MESSAGES/cms.po
+++ b/cms/locale/de/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: de_DE\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: de_DE TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "N/A"
 
-msgid "Correct"
-msgstr "Korrekt"
-
 msgid "Not correct"
 msgstr "Nicht korrekt"
+
+msgid "Correct"
+msgstr "Korrekt"
 
 msgid "Partially correct"
 msgstr "Teilweise korrekt"
 
-msgid "Outcome"
-msgstr "Ergebnis"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "Ergebnis"
 
 msgid "Details"
 msgstr "Details"
@@ -107,11 +110,20 @@ msgstr "Zeitüberschreitung bei Ausführung (Echtzeit-Limit überschritten)"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "Deine Einsendung hat zu viel Gesamtzeit benötigt. Dies könnte durch Undefined-Behavior oder einem Buffer-Overflow verursacht worden sein. Beachte, dass in diesem Fall die in den Einsendungsdetails sichtbare Ausführungszeit trotzdem deutlich kleiner als das Zeitlimit sein kann."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "Ausführung terminiert (könnte durch Überschreiten der Speicherbegrenzung ausgelöst worden sein)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Speicherlimit"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "Die Ausführung deiner Einsendung wurde durch ein Signal terminiert. Dies kann unter anderem durch ein Überschreiten der Speicherbegrenzung ausgelöst worden sein. Beachte in diesem Fall, dass die in den Einsendungsdetails angezeigte Speichernutzung sich auf den Wert vor der Allokation von weiterem Speicher bezieht."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Deine Einsendung hat zu viel CPU-Zeit benötigt."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Zeitüberschreitung bei Ausführung"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "Ausführung wegen Rückgabewert ungleich 0 fehlgeschlagen"
@@ -130,6 +142,10 @@ msgstr "Datei nicht eingesendet"
 
 msgid "Question too long!"
 msgstr "Frage zu lang!"
+
+#, python-format
+msgid "Subject must be at most %(max_subject_length)d characters, content at most %(max_text_length)d."
+msgstr ""
 
 msgid "contest-token"
 msgstr "Wettbewerbstoken"
@@ -186,14 +202,14 @@ msgstr[0] "bis zu einem Maximum von einem %(type_s)s."
 msgstr[1] "bis zu einem Maximum von %(gen_max)d %(type_pl)s."
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Du erhältst keine weiteren %(type_pl)s."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "erhältst du einen weiteren %(type_s)s."
 msgstr[1] "erhältst du %(gen_number)d weitere %(type_pl)s."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Du erhältst keine weiteren %(type_pl)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -221,41 +237,6 @@ msgstr[1] "Du kannst insgesamt maximal %(max_number)d %(type_pl)s nutzen."
 
 msgid "You have no limitations on how you use them."
 msgstr "Du hast keine Beschränkungen darin, wie du sie verwendest."
-
-msgid "Too many print jobs!"
-msgstr "Zu viele Druckaufträge!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Du hast die Begrenzung für maximal %d Druckaufträge erreicht."
-
-msgid "Invalid format!"
-msgstr "Ungültiges Format!"
-
-msgid "Please select the correct files."
-msgstr "Bitte wähle die korrekten Dateien aus."
-
-msgid "File too big!"
-msgstr "Datei zu groß!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Jede Datei darf maximal %d Bytes groß sein."
-
-msgid "Print job storage failed!"
-msgstr "Speichern des Druckauftrags fehlgeschlagen!"
-
-msgid "Please try again."
-msgstr "Bitte erneut versuchen."
-
-msgid "Token request discarded"
-msgstr "Token-Anfrage verworfen"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Deine Anfrage wurde verworfen, weil du über keine Tokens verfügst."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Deine Anfrage wurde verworfen, weil du für diese Einsendung bereits einen Token verwendet hast."
 
 msgid "Question received"
 msgstr "Frage erhalten"
@@ -290,11 +271,11 @@ msgstr "Ausgewertet"
 msgid "status"
 msgstr "Status"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Deine Anfrage wurde erhalten und wurde auf die Einsendung angewandt."
-
 msgid "Token request received"
 msgstr "Token-Anfrage erhalten"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Deine Anfrage wurde erhalten und wurde auf die Einsendung angewandt."
 
 msgid "Test received"
 msgstr "Test erhalten"
@@ -310,6 +291,32 @@ msgstr "Ausführung..."
 
 msgid "Executed"
 msgstr "Ausgeführt"
+
+msgid "Too many print jobs!"
+msgstr "Zu viele Druckaufträge!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Du hast die Begrenzung für maximal %d Druckaufträge erreicht."
+
+msgid "Invalid format!"
+msgstr "Ungültiges Format!"
+
+msgid "Please select the correct files."
+msgstr "Bitte wähle die korrekten Dateien aus."
+
+msgid "File too big!"
+msgstr "Datei zu groß!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Jede Datei darf maximal %d Bytes groß sein."
+
+msgid "Print job storage failed!"
+msgstr "Speichern des Druckauftrags fehlgeschlagen!"
+
+msgid "Please try again."
+msgstr "Bitte erneut versuchen."
 
 msgid "Too many submissions!"
 msgstr "Zu viele Einsendungen!"
@@ -333,6 +340,17 @@ msgstr "Du kannst Lösungen %d Sekunden nach vorherigen Einsendungen für irgend
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Du kannst Lösungen %d Sekunden nach vorherigen Einsendungen für diese Aufgabe einreichen."
 
+msgid "Submission too big!"
+msgstr "Einsendung zu groß!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Jede Quelltextdatei darf maximal %d Bytes groß sein."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Ungültiges Archivformat!"
 
@@ -341,13 +359,6 @@ msgstr "Das eingesendete Archiv konnte nicht geöffnet werden."
 
 msgid "Invalid submission format!"
 msgstr "Ungültiges Einsendungsformat!"
-
-msgid "Submission too big!"
-msgstr "Einsendung zu groß!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Jede Quelltextdatei darf maximal %d Bytes groß sein."
 
 msgid "Submission storage failed!"
 msgstr "Speichern der Einsendung fehlgeschlagen!"
@@ -449,6 +460,13 @@ msgstr "Passwort"
 msgid "Login"
 msgstr "Anmelden"
 
+msgid "Don't have an account?"
+msgstr ""
+
+#, fuzzy
+msgid "Register"
+msgstr "Zurücksetzen"
+
 msgid "New message"
 msgstr "Neue Nachricht"
 
@@ -465,11 +483,11 @@ msgstr "%d ungelesen"
 msgid "Until contest starts:"
 msgstr "Bis Wettbewerb beginnt:"
 
-msgid "Until analysis starts:"
-msgstr "Bis Analysephase beginnt:"
-
 msgid "Until contest ends:"
 msgstr "Bis Wettbewerb endet:"
+
+msgid "Until analysis starts:"
+msgstr "Bis Analysephase beginnt:"
 
 msgid "Until analysis ends:"
 msgstr "Bis Analysephase endet:"
@@ -513,9 +531,6 @@ msgstr "Wähle einen Wettbewerb"
 msgid "Programming languages and libraries"
 msgstr "Programmiersprachen und Bibliotheken"
 
-msgid "Standard Template Library"
-msgstr "Standardbibliothek (STL)"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "Der Name der Java-Hauptklasse sollte identisch zum Namen der Aufgabe sein."
 
@@ -543,6 +558,31 @@ msgstr "Beachte, dass jegliche Versuche, das Contest Management System in irgend
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Bitte kontaktiere die Wettbewerbsleitung, falls dieser Fehler bei normaler Nutzung aufgetreten ist."
+
+msgid "Public score"
+msgstr "Öffentliche Punktzahl"
+
+msgid "Total score"
+msgstr "Gesamte Punktzahl"
+
+msgid "Score"
+msgstr "Punktzahl"
+
+msgid "Token"
+msgstr "Token"
+
+#, fuzzy
+msgid "no submissions"
+msgstr "Einsendungen"
+
+msgid "Played"
+msgstr "Verwendet"
+
+msgid "Play!"
+msgstr "Verwenden!"
+
+msgid "No tokens"
+msgstr "Keine Tokens"
 
 msgid "General information"
 msgstr "Allgemeine Informationen"
@@ -729,6 +769,75 @@ msgstr "Vorbereitung..."
 msgid "no print jobs yet"
 msgstr "noch keine Druckaufträge"
 
+msgid "The passwords do not match!"
+msgstr ""
+
+msgid "This username is already taken, please choose a different one."
+msgstr ""
+
+msgid "This user is already registered in the contest."
+msgstr ""
+
+msgid "No such user."
+msgstr ""
+
+msgid "The password is not correct."
+msgstr ""
+
+msgid "Registration"
+msgstr ""
+
+msgid "Please fill in the fields to register"
+msgstr ""
+
+#, fuzzy
+msgid "New user"
+msgstr "Neue Antwort"
+
+#, fuzzy
+msgid "Join contest"
+msgstr "Wähle einen Wettbewerb"
+
+#, fuzzy
+msgid "First name"
+msgstr "Dateiname"
+
+#, fuzzy
+msgid "Last name"
+msgstr "Dateiname"
+
+#, fuzzy
+msgid "E-mail"
+msgstr "Details"
+
+#, fuzzy
+msgid "Representing"
+msgstr "Drucken"
+
+#, python-format
+msgid "Must be one character or more."
+msgid_plural "Must be %(min_length)s characters or more."
+msgstr[0] ""
+msgstr[1] ""
+
+#, fuzzy
+msgid "Confirm password"
+msgstr "Passwort"
+
+msgid "Registered in the contest successfully!"
+msgstr ""
+
+#, fuzzy
+msgid "Your username is:"
+msgstr "Benutzername"
+
+msgid "Your password is stored securely."
+msgstr ""
+
+#, fuzzy
+msgid "Back to login"
+msgstr "Anmeldung fehlgeschlagen."
+
 msgid "Compilation output"
 msgstr "Kompilierungsausgabe"
 
@@ -867,6 +976,14 @@ msgstr "Aktuell hast du keine Tokens für diese Aufgabe zur Verfügung."
 msgid "But you will have to wait until %(expiration_time)s to use it."
 msgstr "Du musst jedoch bis %(expiration_time)s warten, um ihn nutzen zu können."
 
+#, fuzzy
+msgid "Unofficial submissions"
+msgstr "Einsendungen"
+
+#, fuzzy
+msgid "Official submissions"
+msgstr "Einsendungen"
+
 msgid "Submission details"
 msgstr "Einsendungsdetails"
 
@@ -910,24 +1027,32 @@ msgstr "Einen Moment..."
 msgid "None"
 msgstr "Keine"
 
-msgid "Public score"
-msgstr "Öffentliche Punktzahl"
+msgid "Token request discarded"
+msgstr "Token-Anfrage verworfen"
 
-msgid "Total score"
-msgstr "Gesamte Punktzahl"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Deine Anfrage wurde verworfen, weil du über keine Tokens verfügst."
 
-msgid "Score"
-msgstr "Punktzahl"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Deine Anfrage wurde verworfen, weil du für diese Einsendung bereits einen Token verwendet hast."
 
-msgid "Token"
-msgstr "Token"
+#, fuzzy
+msgid "Invalid file"
+msgstr "Ungültiges Format!"
 
-msgid "Played"
-msgstr "Verwendet"
+#, fuzzy
+msgid "Print job has too many pages"
+msgstr "Speichern des Druckauftrags fehlgeschlagen!"
 
-msgid "Play!"
-msgstr "Verwenden!"
+msgid "Sent to printer"
+msgstr ""
 
-msgid "No tokens"
-msgstr "Keine Tokens"
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "Ausführung terminiert (könnte durch Überschreiten der Speicherbegrenzung ausgelöst worden sein)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "Die Ausführung deiner Einsendung wurde durch ein Signal terminiert. Dies kann unter anderem durch ein Überschreiten der Speicherbegrenzung ausgelöst worden sein. Beachte in diesem Fall, dass die in den Einsendungsdetails angezeigte Speichernutzung sich auf den Wert vor der Allokation von weiterem Speicher bezieht."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Standardbibliothek (STL)"
 

--- a/cms/locale/es/LC_MESSAGES/cms.po
+++ b/cms/locale/es/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: es_ES\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: es_ES TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "N/A"
 
-msgid "Correct"
-msgstr "Correcto"
-
 msgid "Not correct"
 msgstr "Incorrecto"
+
+msgid "Correct"
+msgstr "Correcto"
 
 msgid "Partially correct"
 msgstr "Parcialmente correcto"
 
-msgid "Outcome"
-msgstr "Resultado"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "Resultado"
 
 msgid "Details"
 msgstr "Detalles"
@@ -107,11 +110,20 @@ msgstr "Tiempo límite excedido (tiempo físico total)"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "El envío utilizó demasiado tiempo en total. Esto podría ser el resultado de código con comportamiento indefinido o desbordamientos (buffer overflow). Notar que en este caso, el tiempo de CPU que se muestra en los detalles podría ser muy inferior al tiempo máximo permitido."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "La ejecución fue terminada abruptamente (podría deberse a un exceso en el uso de memoria)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Límite de memoria"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "La evaluación fue terminada mediante una señal del sistema operativo. Entre otras cosas, esto podría deberse a un exceso en el uso de memoria. Notar que si esta fuera la razón, la memoria utilizada mostrada en los detalles de envío sería la memoria utilizada antes de la reserva de memoria que generó la señal."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "El envío utilizó demasiado tiempo de CPU."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Tiempo límite excedido"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "Ejecución fallida por código de retorno distinto de cero"
@@ -190,14 +202,14 @@ msgstr[0] "hasta un máximo de un %(type_s)s."
 msgstr[1] "hasta un máximo de %(gen_max)d %(type_pl)s."
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "No recibe %(type_pl)s adicionales."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "recibe otro %(type_s)s."
 msgstr[1] "recibe %(gen_number)d %(type_pl)s adicionales."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "No recibe %(type_pl)s adicionales."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -225,41 +237,6 @@ msgstr[1] "No puede utilizar más de %(max_number)d %(type_pl)s en total."
 
 msgid "You have no limitations on how you use them."
 msgstr "No hay limitaciones en cuanto a su utilización."
-
-msgid "Too many print jobs!"
-msgstr "¡Demasiados trabajos de impresión!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Ha alcanzado el límite máximo de %d trabajos de impresión."
-
-msgid "Invalid format!"
-msgstr "¡Formato inválido!"
-
-msgid "Please select the correct files."
-msgstr "Por favor seleccione los archivos correctos."
-
-msgid "File too big!"
-msgstr "¡El archivo es demasiado grande!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Cada archivo debe tener un tamaño de a lo sumo %d bytes."
-
-msgid "Print job storage failed!"
-msgstr "¡No se pudo almacenar el trabajo de impresión!"
-
-msgid "Please try again."
-msgstr "Por favor, intente nuevamente."
-
-msgid "Token request discarded"
-msgstr "Pedido de token descartado"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Su pedido ha sido descartado porque no posee tokens disponibles."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Su pedido ha sido descartado porque ya ha utilizado un token sobre ese envío."
 
 msgid "Question received"
 msgstr "Pregunta recibida"
@@ -294,11 +271,11 @@ msgstr "Evaluado"
 msgid "status"
 msgstr "estado"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Su pedido ha sido recibido y aplicado al envío."
-
 msgid "Token request received"
 msgstr "Pedido de token recibido"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Su pedido ha sido recibido y aplicado al envío."
 
 msgid "Test received"
 msgstr "Test recibido"
@@ -314,6 +291,32 @@ msgstr "Ejecutando..."
 
 msgid "Executed"
 msgstr "Ejecutado"
+
+msgid "Too many print jobs!"
+msgstr "¡Demasiados trabajos de impresión!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Ha alcanzado el límite máximo de %d trabajos de impresión."
+
+msgid "Invalid format!"
+msgstr "¡Formato inválido!"
+
+msgid "Please select the correct files."
+msgstr "Por favor seleccione los archivos correctos."
+
+msgid "File too big!"
+msgstr "¡El archivo es demasiado grande!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Cada archivo debe tener un tamaño de a lo sumo %d bytes."
+
+msgid "Print job storage failed!"
+msgstr "¡No se pudo almacenar el trabajo de impresión!"
+
+msgid "Please try again."
+msgstr "Por favor, intente nuevamente."
 
 msgid "Too many submissions!"
 msgstr "¡Demasiados envíos!"
@@ -337,6 +340,17 @@ msgstr "Entre todos los problemas, puede realizar un envío nuevamente pasados %
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "En este problema, puede realizar un envío nuevamente pasados %d segundos desde último envío."
 
+msgid "Submission too big!"
+msgstr "¡Envío demasiado grande!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Cada archivo de código fuente debe tener un tamaño de a lo sumo %d bytes."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "¡El formato del archivo comprimido es inválido!"
 
@@ -345,13 +359,6 @@ msgstr "No se pudo abrir el archivo comprimido enviado."
 
 msgid "Invalid submission format!"
 msgstr "¡El formato del envío es inválido!"
-
-msgid "Submission too big!"
-msgstr "¡Envío demasiado grande!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Cada archivo de código fuente debe tener un tamaño de a lo sumo %d bytes."
 
 msgid "Submission storage failed!"
 msgstr "¡No se pudo almacenar el envío!"
@@ -475,11 +482,11 @@ msgstr "%d sin leer"
 msgid "Until contest starts:"
 msgstr "Tiempo restante hasta el comienzo del certamen:"
 
-msgid "Until analysis starts:"
-msgstr "Tiempo restante hasta el comienzo de la fase de análisis:"
-
 msgid "Until contest ends:"
 msgstr "Tiempo restante hasta el final el certamen:"
+
+msgid "Until analysis starts:"
+msgstr "Tiempo restante hasta el comienzo de la fase de análisis:"
 
 msgid "Until analysis ends:"
 msgstr "Tiempo restante hasta el final de la fase de análisis:"
@@ -523,9 +530,6 @@ msgstr "Seleccione un certamen"
 msgid "Programming languages and libraries"
 msgstr "Lenguajes de programación y librerías"
 
-msgid "Standard Template Library"
-msgstr "Standard Template Library"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "La clase principal de la solución en Java debe tener exactamente el mismo nombre que el problema."
 
@@ -553,6 +557,30 @@ msgstr "Notar que cualquier intento de afectar el funcionamiento del sistema (co
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Si encuentra este error durante el uso normal del sistema, por favor contacte a un administrador."
+
+msgid "Public score"
+msgstr "Puntaje público"
+
+msgid "Total score"
+msgstr "Puntaje total"
+
+msgid "Score"
+msgstr "Puntaje"
+
+msgid "Token"
+msgstr "Token"
+
+msgid "no submissions"
+msgstr "no hay envíos"
+
+msgid "Played"
+msgstr "Token utilizado"
+
+msgid "Play!"
+msgstr "¡Usar token!"
+
+msgid "No tokens"
+msgstr "Sin tokens"
 
 msgid "General information"
 msgstr "Información general"
@@ -986,29 +1014,14 @@ msgstr "Espere..."
 msgid "None"
 msgstr "Ninguno"
 
-msgid "Public score"
-msgstr "Puntaje público"
+msgid "Token request discarded"
+msgstr "Pedido de token descartado"
 
-msgid "Total score"
-msgstr "Puntaje total"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Su pedido ha sido descartado porque no posee tokens disponibles."
 
-msgid "Score"
-msgstr "Puntaje"
-
-msgid "Token"
-msgstr "Token"
-
-msgid "no submissions"
-msgstr "no hay envíos"
-
-msgid "Played"
-msgstr "Token utilizado"
-
-msgid "Play!"
-msgstr "¡Usar token!"
-
-msgid "No tokens"
-msgstr "Sin tokens"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Su pedido ha sido descartado porque ya ha utilizado un token sobre ese envío."
 
 msgid "Invalid file"
 msgstr "Archivo inválido"
@@ -1018,4 +1031,13 @@ msgstr "El trabajo de impresión tiene demasiadas páginas"
 
 msgid "Sent to printer"
 msgstr "Enviado a la impresora"
+
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "La ejecución fue terminada abruptamente (podría deberse a un exceso en el uso de memoria)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "La evaluación fue terminada mediante una señal del sistema operativo. Entre otras cosas, esto podría deberse a un exceso en el uso de memoria. Notar que si esta fuera la razón, la memoria utilizada mostrada en los detalles de envío sería la memoria utilizada antes de la reserva de memoria que generó la señal."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Standard Template Library"
 

--- a/cms/locale/es_CL/LC_MESSAGES/cms.po
+++ b/cms/locale/es_CL/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: es_CL\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: es_CL TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "N/A"
 
-msgid "Correct"
-msgstr "Correcto"
-
 msgid "Not correct"
 msgstr "Incorrecto"
+
+msgid "Correct"
+msgstr "Correcto"
 
 msgid "Partially correct"
 msgstr "Parcialmente correcto"
 
-msgid "Outcome"
-msgstr "Resultado"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "Resultado"
 
 msgid "Details"
 msgstr "Detalles"
@@ -107,11 +110,20 @@ msgstr "Tiempo límite excedido (tiempo físico total)"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "El envío utilizó demasiado tiempo en total. Esto podría ser el resultado de código con comportamiento indefinido o desbordamientos (buffer overflow). Notar que en este caso, el tiempo de CPU que se muestra en los detalles podría ser muy inferior al tiempo máximo permitido."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "La ejecución fue terminada abruptamente (podría deberse a un exceso en el uso de memoria)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Límite de memoria"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "La evaluación fue terminada mediante una señal del sistema operativo. Entre otras cosas, esto podría deberse a un exceso en el uso de memoria. Notar que si esta fuera la razón, la memoria utilizada mostrada en los detalles de envío sería la memoria utilizada antes de la reserva de memoria que generó la señal."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "El envío utilizó demasiado tiempo de CPU."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Tiempo límite excedido"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "Ejecución fallida por código de retorno distinto de cero"
@@ -190,14 +202,14 @@ msgstr[0] "hasta un máximo de un %(type_s)s."
 msgstr[1] "hasta un máximo de %(gen_max)d %(type_pl)s."
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "No recibes %(type_pl)s adicionales."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "recibes otro %(type_s)s."
 msgstr[1] "recibes %(gen_number)d %(type_pl)s adicionales."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "No recibes %(type_pl)s adicionales."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -225,41 +237,6 @@ msgstr[1] "No puedes utilizar más de %(max_number)d %(type_pl)s en total."
 
 msgid "You have no limitations on how you use them."
 msgstr "No hay limitaciones en cuanto a su utilización."
-
-msgid "Too many print jobs!"
-msgstr "¡Demasiados trabajos de impresión!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Ha alcanzado el límite máximo de %d trabajos de impresión."
-
-msgid "Invalid format!"
-msgstr "¡Formato inválido!"
-
-msgid "Please select the correct files."
-msgstr "Por favor seleccione los archivos correctos."
-
-msgid "File too big!"
-msgstr "¡El archivo es demasiado grande!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Cada archivo debe tener un tamaño de a lo sumo %d bytes."
-
-msgid "Print job storage failed!"
-msgstr "¡No se pudo almacenar el trabajo de impresión!"
-
-msgid "Please try again."
-msgstr "Por favor, intente nuevamente."
-
-msgid "Token request discarded"
-msgstr "Pedido de token descartado"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Su pedido ha sido descartado porque no posee tokens disponibles."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Su pedido ha sido descartado porque ya ha utilizado un token sobre ese envío."
 
 msgid "Question received"
 msgstr "Pregunta recibida"
@@ -294,11 +271,11 @@ msgstr "Evaluado"
 msgid "status"
 msgstr "estado"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Su pedido ha sido recibido y aplicado al envío."
-
 msgid "Token request received"
 msgstr "Pedido de token recibido"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Su pedido ha sido recibido y aplicado al envío."
 
 msgid "Test received"
 msgstr "Test recibido"
@@ -314,6 +291,32 @@ msgstr "Ejecutando..."
 
 msgid "Executed"
 msgstr "Ejecutado"
+
+msgid "Too many print jobs!"
+msgstr "¡Demasiados trabajos de impresión!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Ha alcanzado el límite máximo de %d trabajos de impresión."
+
+msgid "Invalid format!"
+msgstr "¡Formato inválido!"
+
+msgid "Please select the correct files."
+msgstr "Por favor seleccione los archivos correctos."
+
+msgid "File too big!"
+msgstr "¡El archivo es demasiado grande!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Cada archivo debe tener un tamaño de a lo sumo %d bytes."
+
+msgid "Print job storage failed!"
+msgstr "¡No se pudo almacenar el trabajo de impresión!"
+
+msgid "Please try again."
+msgstr "Por favor, intente nuevamente."
 
 msgid "Too many submissions!"
 msgstr "¡Demasiados envíos!"
@@ -337,6 +340,17 @@ msgstr "Entre todos los problemas, puede realizar un envío nuevamente pasados %
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "En este problema, puede realizar un envío nuevamente pasados %d segundos desde último envío."
 
+msgid "Submission too big!"
+msgstr "¡Envío demasiado grande!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Cada archivo de código fuente debe tener un tamaño de a lo sumo %d bytes."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "¡El formato del archivo comprimido es inválido!"
 
@@ -345,13 +359,6 @@ msgstr "No se pudo abrir el archivo comprimido enviado."
 
 msgid "Invalid submission format!"
 msgstr "¡El formato del envío es inválido!"
-
-msgid "Submission too big!"
-msgstr "¡Envío demasiado grande!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Cada archivo de código fuente debe tener un tamaño de a lo sumo %d bytes."
 
 msgid "Submission storage failed!"
 msgstr "¡No se pudo almacenar el envío!"
@@ -475,11 +482,11 @@ msgstr "%d sin leer"
 msgid "Until contest starts:"
 msgstr "Tiempo restante hasta el comienzo de la competencia:"
 
-msgid "Until analysis starts:"
-msgstr "Tiempo restante hasta el inicio de la fase de análisis:"
-
 msgid "Until contest ends:"
 msgstr "Tiempo restante hasta el final de la competencia:"
+
+msgid "Until analysis starts:"
+msgstr "Tiempo restante hasta el inicio de la fase de análisis:"
 
 msgid "Until analysis ends:"
 msgstr "Tiempo restante el final de la fase de análisis:"
@@ -523,9 +530,6 @@ msgstr "Seleccionar una competencia"
 msgid "Programming languages and libraries"
 msgstr "Lenguajes de programación y librerías"
 
-msgid "Standard Template Library"
-msgstr "Standrad Template Library"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "La class principal en Java debe llamarse igual que el nombre del problema"
 
@@ -553,6 +557,30 @@ msgstr "Notar que cualquier intento de afectar el funcionamiento del sistema (co
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Si encuentra este error durante el uso normal del sistema, por favor contacte a un administrador."
+
+msgid "Public score"
+msgstr "Puntaje público"
+
+msgid "Total score"
+msgstr "Puntaje total"
+
+msgid "Score"
+msgstr "Puntaje"
+
+msgid "Token"
+msgstr "Token"
+
+msgid "no submissions"
+msgstr "no hay envíos"
+
+msgid "Played"
+msgstr "Token utilizado"
+
+msgid "Play!"
+msgstr "¡Usar token!"
+
+msgid "No tokens"
+msgstr "Sin tokens"
 
 msgid "General information"
 msgstr "Información general"
@@ -986,29 +1014,14 @@ msgstr "Espere..."
 msgid "None"
 msgstr "Ninguno"
 
-msgid "Public score"
-msgstr "Puntaje público"
+msgid "Token request discarded"
+msgstr "Pedido de token descartado"
 
-msgid "Total score"
-msgstr "Puntaje total"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Su pedido ha sido descartado porque no posee tokens disponibles."
 
-msgid "Score"
-msgstr "Puntaje"
-
-msgid "Token"
-msgstr "Token"
-
-msgid "no submissions"
-msgstr "no hay envíos"
-
-msgid "Played"
-msgstr "Token utilizado"
-
-msgid "Play!"
-msgstr "¡Usar token!"
-
-msgid "No tokens"
-msgstr "Sin tokens"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Su pedido ha sido descartado porque ya ha utilizado un token sobre ese envío."
 
 msgid "Invalid file"
 msgstr "Archivo inválido"
@@ -1018,4 +1031,13 @@ msgstr "El trabajo de impresión tiene demasiadas páginas"
 
 msgid "Sent to printer"
 msgstr "Enviado a la impresora"
+
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "La ejecución fue terminada abruptamente (podría deberse a un exceso en el uso de memoria)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "La evaluación fue terminada mediante una señal del sistema operativo. Entre otras cosas, esto podría deberse a un exceso en el uso de memoria. Notar que si esta fuera la razón, la memoria utilizada mostrada en los detalles de envío sería la memoria utilizada antes de la reserva de memoria que generó la señal."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Standrad Template Library"
 

--- a/cms/locale/et/LC_MESSAGES/cms.po
+++ b/cms/locale/et/LC_MESSAGES/cms.po
@@ -1,27 +1,33 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: et_EE\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: et_EE TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "-"
 
-msgid "Correct"
-msgstr "Õige vastus"
-
 msgid "Not correct"
 msgstr "Vale vastus"
 
+msgid "Correct"
+msgstr "Õige vastus"
+
 msgid "Partially correct"
 msgstr "Osaliselt õige vastus"
+
+msgid "#"
+msgstr ""
 
 msgid "Outcome"
 msgstr "Tulemus"
@@ -104,11 +110,20 @@ msgstr "Programmi tööaja limiit ületatud"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "Programmi tööaeg ületas lubatud piiri. Selle kõige tõenäolisem põhjus on katse lugeda rohkem sisendit, kui seda on. Aga mõnikord võivad seda põhjustada ka mitmesugused määramatused programmis, sealhulgas ka massiivide piiridest väljumine. Kuna lahendus jääb ootele, võib selle kasutatud protsessoriaeg olla protsessori ajalimiidist märksa väiksem."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "Programmi täitmine katkes signaali tagajärjel (võib olla tingitud mälupiirangute ületamisest)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Mälulimiit"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "Lahenduse jooksmine katkes signaali tagajärjel. See võib olla tingitud muuhulgas mälupiirangu ületamisest. Pane tähele, et sellisel juhul näidatakse esituse mälukastutust vahetult enne piirangu ületamist."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Lahenduse jooksmiseks kulus liiga palju protsessori aega."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Programmi protsessori ajalimiit ületatud"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "Programmi täitmine ebaõnnestus, nullist erinev veakood"
@@ -187,14 +202,14 @@ msgstr[0] "kuni maksimaalselt ühe %(type_s)sini."
 msgstr[1] "kuni maksimaalselt %(gen_max)d %(type_pl)sini."
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Te ei saa rohkem %(type_pl)seid."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "saate Te veel ühe %(type_s)si."
 msgstr[1] "saate Te veel %(gen_number)d %(type_pl)sit."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Te ei saa rohkem %(type_pl)seid."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -222,41 +237,6 @@ msgstr[1] "Te võite kokku kasutada maksimaalselt %(max_number)d %(type_pl)sit."
 
 msgid "You have no limitations on how you use them."
 msgstr "Teil pole piiranguid nende kasutamise osas."
-
-msgid "Too many print jobs!"
-msgstr "Liiga palju printmistöid!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Teil ei ole lubatud rohkem kui %d printimistööd esitada."
-
-msgid "Invalid format!"
-msgstr "Vigane vorming!"
-
-msgid "Please select the correct files."
-msgstr "Palun valige õiged failid."
-
-msgid "File too big!"
-msgstr "Fail on liiga suur!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Iga fail võib olla ülimalt %d baiti pikk."
-
-msgid "Print job storage failed!"
-msgstr "Printimistöö salvestamine ebaõnnestus!"
-
-msgid "Please try again."
-msgstr "Palun proovige uuesti."
-
-msgid "Token request discarded"
-msgstr "Pileti päring tühistatud"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Päring on tühistatud, kuna Teil pole ühtegi piletit."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Päring on tühistatud, kuna selle jaoks on juba piletit kasutatud."
 
 msgid "Question received"
 msgstr "Küsimus on vastu võetud"
@@ -291,11 +271,11 @@ msgstr "Testitud"
 msgid "status"
 msgstr "Olek"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Teie päring on vastu võetud ning rakendatud lahendusele."
-
 msgid "Token request received"
 msgstr "Pileti päring vastu võetud"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Teie päring on vastu võetud ning rakendatud lahendusele."
 
 msgid "Test received"
 msgstr "Test vastu võetud"
@@ -311,6 +291,32 @@ msgstr "Testimine..."
 
 msgid "Executed"
 msgstr "Käivitatud"
+
+msgid "Too many print jobs!"
+msgstr "Liiga palju printmistöid!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Teil ei ole lubatud rohkem kui %d printimistööd esitada."
+
+msgid "Invalid format!"
+msgstr "Vigane vorming!"
+
+msgid "Please select the correct files."
+msgstr "Palun valige õiged failid."
+
+msgid "File too big!"
+msgstr "Fail on liiga suur!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Iga fail võib olla ülimalt %d baiti pikk."
+
+msgid "Print job storage failed!"
+msgstr "Printimistöö salvestamine ebaõnnestus!"
+
+msgid "Please try again."
+msgstr "Palun proovige uuesti."
 
 msgid "Too many submissions!"
 msgstr "Liiga palju esitatud lahendusi!"
@@ -334,6 +340,17 @@ msgstr "Saate jälle uue lahenduse esitada (suvalisele ülesandele) %d sekundit 
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Saate sellele ülesandele uue lahenduse esitada %d sekundit pärast viimase lahenduse esitamist."
 
+msgid "Submission too big!"
+msgstr "Esitatud lahendus on liiga suur!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Iga lähteteksti fail võib olla ülimalt %d baiti pikk."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Vigases vormingus arhiiv!"
 
@@ -342,13 +359,6 @@ msgstr "Esitatud arhiivi ei õnnestunud avada."
 
 msgid "Invalid submission format!"
 msgstr "Esitatud lahenduse vorming on vale!"
-
-msgid "Submission too big!"
-msgstr "Esitatud lahendus on liiga suur!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Iga lähteteksti fail võib olla ülimalt %d baiti pikk."
 
 msgid "Submission storage failed!"
 msgstr "Esitatud lahenduse salvestamine ebaõnnestus!"
@@ -472,11 +482,11 @@ msgstr "%d lugemata"
 msgid "Until contest starts:"
 msgstr "Võistluse alguseni:"
 
-msgid "Until analysis starts:"
-msgstr "Järellahendamise alguseni:"
-
 msgid "Until contest ends:"
 msgstr "Võisluse lõpuni:"
+
+msgid "Until analysis starts:"
+msgstr "Järellahendamise alguseni:"
 
 msgid "Until analysis ends:"
 msgstr "Järellahendamise lõpuni:"
@@ -520,9 +530,6 @@ msgstr "Vali võistlus"
 msgid "Programming languages and libraries"
 msgstr "Programmeerimiskeeled ja teegid"
 
-msgid "Standard Template Library"
-msgstr "Standard Template Library"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "Java lahenduse peaklass peaks olema sama nimega kui ülesanne."
 
@@ -550,6 +557,32 @@ msgstr "Pange tähele, et Contest Management System'i ebaotstarbeline kasutus (n
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Kui te avastasite selle vea normaalse kasutuse käigus, palun teavitage võistluse administraatoreid."
+
+msgid "Public score"
+msgstr "Avalikud punktid"
+
+msgid "Total score"
+msgstr "Punktid kokku"
+
+msgid "Score"
+msgstr "Punktid"
+
+msgid "Token"
+msgstr "Pilet"
+
+#, fuzzy
+msgid "no submissions"
+msgstr "Esitatud lahendused"
+
+msgid "Played"
+msgstr ""
+
+msgid "Play!"
+msgstr ""
+
+#, fuzzy
+msgid "No tokens"
+msgstr "Piletid"
 
 msgid "General information"
 msgstr "Üldinfo"
@@ -855,6 +888,10 @@ msgstr "Üksikasjad"
 msgid "Compilation commands"
 msgstr "Kompileerimise käsurida"
 
+#, fuzzy, python-format
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
+msgstr "Te saate iga ülesande kirjelduse lehel teada, milliste reeglite järgi %(type_pl)seid kasutada saab."
+
 msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
 msgstr "Pane tähele, et esitatud lahenduse tulemuste detailvaate nägemiseks pead kasutama nii ühe võistluspileti kui ka ühe ülesandepileti."
 
@@ -979,15 +1016,32 @@ msgstr "Oota..."
 msgid "None"
 msgstr "Puudub"
 
-msgid "Public score"
-msgstr "Avalikud punktid"
+msgid "Token request discarded"
+msgstr "Pileti päring tühistatud"
 
-msgid "Total score"
-msgstr "Punktid kokku"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Päring on tühistatud, kuna Teil pole ühtegi piletit."
 
-msgid "Score"
-msgstr "Punktid"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Päring on tühistatud, kuna selle jaoks on juba piletit kasutatud."
 
-msgid "Token"
-msgstr "Pilet"
+#, fuzzy
+msgid "Invalid file"
+msgstr "Vigane vorming!"
+
+#, fuzzy
+msgid "Print job has too many pages"
+msgstr "Printimistöö salvestamine ebaõnnestus!"
+
+msgid "Sent to printer"
+msgstr ""
+
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "Programmi täitmine katkes signaali tagajärjel (võib olla tingitud mälupiirangute ületamisest)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "Lahenduse jooksmine katkes signaali tagajärjel. See võib olla tingitud muuhulgas mälupiirangu ületamisest. Pane tähele, et sellisel juhul näidatakse esituse mälukastutust vahetult enne piirangu ületamist."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Standard Template Library"
 

--- a/cms/locale/fr/LC_MESSAGES/cms.po
+++ b/cms/locale/fr/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: fr_FR\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: fr_FR TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "N/A"
 
-msgid "Correct"
-msgstr "Correct"
-
 msgid "Not correct"
 msgstr "Incorrect"
+
+msgid "Correct"
+msgstr "Correct"
 
 msgid "Partially correct"
 msgstr "Partiellement correct"
 
-msgid "Outcome"
-msgstr "Résultat"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "Résultat"
 
 msgid "Details"
 msgstr "Détails"
@@ -107,11 +110,20 @@ msgstr "Temps d'exécution dépassé (durée maximale dépassée)"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "Votre soumission a pris trop de temps. Cela peut être causé, par exemple, par un code indéfini ou une écriture hors mémoire allouée. Notez que dans ce cas, le temps CPU (processeur) visible dans les détails de la soumission peut être bien plus petit que la limite de temps."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "Exécution tuée (peut être causé par un dépassement des limites mémoire)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Limite de mémoire"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "L'évaluation a été tuée par un signal. Cela peut être causé, mais pas uniquement, par un dépassement des limites mémoire. Notez que si cela est le cas, l'utilisation de la mémoire visible dans les détails de la soumission est l'utilisation avant l'allocation mémoire qui a causé le signal."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Votre soumission a utilisé trop de temps CPU (processeur)"
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Durée maximale d'exécution dépassée"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "Exécution échouée: code de retour différent de zéro"
@@ -190,14 +202,14 @@ msgstr[0] "jusqu'à un maximum d'un %(type_s)s."
 msgstr[1] "jusqu'à un maximum de %(gen_max)d %(type_pl)s."
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Vous ne recevez plus de %(type_pl)s."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "vous recevez un %(type_s)s supplémentaire."
 msgstr[1] "vous recevez %(gen_number)d %(type_pl)s supplémentaires."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Vous ne recevez plus de %(type_pl)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -225,41 +237,6 @@ msgstr[1] "Vous pouvez utiliser au maximum %(max_number)d %(type_pl)s."
 
 msgid "You have no limitations on how you use them."
 msgstr "Il n'y a pas de limitation sur leur utilisation."
-
-msgid "Too many print jobs!"
-msgstr "Trop d'impressions !"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Vous avez atteint le nombre maximal de %d impressions."
-
-msgid "Invalid format!"
-msgstr "Format invalide !"
-
-msgid "Please select the correct files."
-msgstr "Sélectionnez les fichiers corrects."
-
-msgid "File too big!"
-msgstr "Fichier trop gros !"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Chaque fichier source ne peut pas faire plus de %d octets."
-
-msgid "Print job storage failed!"
-msgstr "Impossible de stocker l'impression !"
-
-msgid "Please try again."
-msgstr "Veuillez réessayer."
-
-msgid "Token request discarded"
-msgstr "Demande de token refusée"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Votre requête a été annulée car vous n'avez plus de jetons disponibles."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Votre requête a été annulée car vous avez déjà utilisé un jeton sur cette soumission."
 
 msgid "Question received"
 msgstr "Question envoyée"
@@ -294,11 +271,11 @@ msgstr "Évalué"
 msgid "status"
 msgstr "état"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Votre requête a été reçue et appliquée à la soumission."
-
 msgid "Token request received"
 msgstr "Demande de jeton reçue"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Votre requête a été reçue et appliquée à la soumission."
 
 msgid "Test received"
 msgstr "Test reçu"
@@ -314,6 +291,32 @@ msgstr "En cours d'exécution..."
 
 msgid "Executed"
 msgstr "Exécuté"
+
+msgid "Too many print jobs!"
+msgstr "Trop d'impressions !"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Vous avez atteint le nombre maximal de %d impressions."
+
+msgid "Invalid format!"
+msgstr "Format invalide !"
+
+msgid "Please select the correct files."
+msgstr "Sélectionnez les fichiers corrects."
+
+msgid "File too big!"
+msgstr "Fichier trop gros !"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Chaque fichier source ne peut pas faire plus de %d octets."
+
+msgid "Print job storage failed!"
+msgstr "Impossible de stocker l'impression !"
+
+msgid "Please try again."
+msgstr "Veuillez réessayer."
 
 msgid "Too many submissions!"
 msgstr "Trop de soumissions !"
@@ -337,6 +340,17 @@ msgstr "Toutes tâches confondues, vous ne pouvez resoumettre que %d secondes ap
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Pour cette tâche, vous ne pouvez resoumettre que %d secondes après votre précédente soumission."
 
+msgid "Submission too big!"
+msgstr "Fichier soumis trop gros !"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Chaque fichier source ne peut pas faire plus de %d octets."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Format d'archive invalide !"
 
@@ -345,13 +359,6 @@ msgstr "Impossible d'ouvrir l'archive soumise."
 
 msgid "Invalid submission format!"
 msgstr "Format de soumission invalide !"
-
-msgid "Submission too big!"
-msgstr "Fichier soumis trop gros !"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Chaque fichier source ne peut pas faire plus de %d octets."
 
 msgid "Submission storage failed!"
 msgstr "Erreur d'enregistrement de votre soumission !"
@@ -475,11 +482,11 @@ msgstr "%d non lu(s)"
 msgid "Until contest starts:"
 msgstr "L'épreuve commence dans :"
 
-msgid "Until analysis starts:"
-msgstr "La session d'analyse commence dans :"
-
 msgid "Until contest ends:"
 msgstr "Temps d'épreuve restant :"
+
+msgid "Until analysis starts:"
+msgstr "La session d'analyse commence dans :"
 
 msgid "Until analysis ends:"
 msgstr "Temps restant dans la session d'analyse :"
@@ -523,9 +530,6 @@ msgstr "Choisissez un concours"
 msgid "Programming languages and libraries"
 msgstr "Langages et librairies de programmation"
 
-msgid "Standard Template Library"
-msgstr "Librairie Standard C++ (STL)"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "La classe Java principale de la solution doit avoir exactement le même nom que la tâche."
 
@@ -553,6 +557,30 @@ msgstr "Toute tentative de manipulation frauduleuse du serveur de soumission (te
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Si vous recontrer cette erreur alors que vous utilisez le service normalement, veuillez en notifier les administrateurs du concours."
+
+msgid "Public score"
+msgstr "Score public"
+
+msgid "Total score"
+msgstr "Score total"
+
+msgid "Score"
+msgstr "Score"
+
+msgid "Token"
+msgstr "Jeton"
+
+msgid "no submissions"
+msgstr "aucune soumission"
+
+msgid "Played"
+msgstr "Utilisé"
+
+msgid "Play!"
+msgstr "Utiliser !"
+
+msgid "No tokens"
+msgstr "Aucun jeton"
 
 msgid "General information"
 msgstr "Information générale"
@@ -986,29 +1014,14 @@ msgstr "Patientez ..."
 msgid "None"
 msgstr "Aucun(e)"
 
-msgid "Public score"
-msgstr "Score public"
+msgid "Token request discarded"
+msgstr "Demande de token refusée"
 
-msgid "Total score"
-msgstr "Score total"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Votre requête a été annulée car vous n'avez plus de jetons disponibles."
 
-msgid "Score"
-msgstr "Score"
-
-msgid "Token"
-msgstr "Jeton"
-
-msgid "no submissions"
-msgstr "aucune soumission"
-
-msgid "Played"
-msgstr "Utilisé"
-
-msgid "Play!"
-msgstr "Utiliser !"
-
-msgid "No tokens"
-msgstr "Aucun jeton"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Votre requête a été annulée car vous avez déjà utilisé un jeton sur cette soumission."
 
 msgid "Invalid file"
 msgstr "Fichier invalide"
@@ -1018,4 +1031,13 @@ msgstr "Le document à imprimer est trop long."
 
 msgid "Sent to printer"
 msgstr "Envoyer à l'imprimante"
+
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "Exécution tuée (peut être causé par un dépassement des limites mémoire)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "L'évaluation a été tuée par un signal. Cela peut être causé, mais pas uniquement, par un dépassement des limites mémoire. Notez que si cela est le cas, l'utilisation de la mémoire visible dans les détails de la soumission est l'utilisation avant l'allocation mémoire qui a causé le signal."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Librairie Standard C++ (STL)"
 

--- a/cms/locale/hu/LC_MESSAGES/cms.po
+++ b/cms/locale/hu/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: hu\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: hu TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "nem elérhető"
 
-msgid "Correct"
-msgstr "Helyes"
-
 msgid "Not correct"
 msgstr "Helytelen"
+
+msgid "Correct"
+msgstr "Helyes"
 
 msgid "Partially correct"
 msgstr "Részlegesen helyes"
 
-msgid "Outcome"
-msgstr "Eredmény"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "Eredmény"
 
 msgid "Details"
 msgstr "Részletek"
@@ -107,11 +110,20 @@ msgstr "Időlimit túllépés (valós idő)"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "A megoldásod túl sok ideig futott valós időben mérve. Ezt például érvénytelen/hibás programkód, puffer túlcsordulás is okozhatja. Fontos, hogy ebben az esetben a beküldés részletes megtekintésekor mutatott processzoridő jóval kisebb lehet a feladatban megadott időlimitnél."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "Kilőve futás közben (memóriatúllépés is okozhatja)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Memórialimit"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "A kiértékelés hibakóddal fejeződött be. Többek között ezt a túlzott memóriahasználat okozhatja. Fontos, ha valóban ez okozta a hibát, akkor a beküldés részletes megtekintésekor mutatott memóriahasználat a hibát kiváltó memóriafoglalás előtti állapotot mutatja."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "A beküldött megoldásod túl sok processzoridőt használt."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Időlimit túllépés"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "A végrehajtás sikertelen, mert a kilépési kód nem nulla"
@@ -190,14 +202,14 @@ msgstr[0] "amíg nem lesz összesen egy %(type_s)sod."
 msgstr[1] "amíg nem lesz összesen %(gen_max)d %(type_s)sod."
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Nem kapsz további %(type_pl)sokat."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "kapsz egy %(type_s)st."
 msgstr[1] "kapsz %(gen_number)d %(type_s)st."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Nem kapsz további %(type_pl)sokat."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -226,36 +238,18 @@ msgstr[1] "Maximum %(max_number)d %(type_s)st használhatsz fel."
 msgid "You have no limitations on how you use them."
 msgstr "Nincsenek korlátozások a zsetonok felhasználására vonatkozóan."
 
-msgid "Invalid format!"
-msgstr "Érvénytelen formátum!"
-
-msgid "Please select the correct files."
-msgstr "Kérlek válaszd ki a megfelelő fájlokat."
-
-msgid "File too big!"
-msgstr "Túl nagy fájl!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Minden fájl maximum %d bájt méretű lehet."
-
-msgid "Please try again."
-msgstr "Kérlek próbáld újra."
-
-msgid "Token request discarded"
-msgstr "Zseton kérelem elutasítva"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "A kérelmed el lett utasítva, mert nincsenek zsetonjaid."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "A kérelmed el lett utasítva, mert már felhasználtál egy zseton erre a beküldésre."
-
 msgid "Question received"
 msgstr "Kérdés elküldve"
 
 msgid "Your question has been received, you will be notified when it is answered."
 msgstr "A kérdésed el lett küldve, értesítve leszel amint megválaszolásra kerül."
+
+#, fuzzy
+msgid "Print job received"
+msgstr "Teszt elküldve"
+
+msgid "Your print job has been received."
+msgstr ""
 
 msgid "Submission received"
 msgstr "Beküldés elküldve"
@@ -278,6 +272,14 @@ msgstr "Kiértékelve"
 msgid "status"
 msgstr "állapot"
 
+#, fuzzy
+msgid "Token request received"
+msgstr "Zseton kérelem elutasítva"
+
+#, fuzzy
+msgid "Your request has been received and applied to the submission."
+msgstr "A kérelmed el lett utasítva, mert már felhasználtál egy zseton erre a beküldésre."
+
 msgid "Test received"
 msgstr "Teszt elküldve"
 
@@ -292,6 +294,34 @@ msgstr "Végrehajtás..."
 
 msgid "Executed"
 msgstr "Végrehajtva"
+
+#, fuzzy
+msgid "Too many print jobs!"
+msgstr "nincsenek nyomtatások"
+
+#, fuzzy, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Elérted az erre a feladatra engedélyezett beküldések maximális számát (%d)."
+
+msgid "Invalid format!"
+msgstr "Érvénytelen formátum!"
+
+msgid "Please select the correct files."
+msgstr "Kérlek válaszd ki a megfelelő fájlokat."
+
+msgid "File too big!"
+msgstr "Túl nagy fájl!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Minden fájl maximum %d bájt méretű lehet."
+
+#, fuzzy
+msgid "Print job storage failed!"
+msgstr "A beküldés mentése nem sikerült!"
+
+msgid "Please try again."
+msgstr "Kérlek próbáld újra."
 
 msgid "Too many submissions!"
 msgstr "Túl sok beküldés!"
@@ -315,9 +345,6 @@ msgstr "Az összes feladatra vonatkoztatva az utolsó beküldésed után %d más
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Ennél a feladatnál az utolsó beküldésed után %d másodperccel tudsz újra beküldeni."
 
-msgid "The submitted archive could not be opened."
-msgstr "A beküldött tömörített állományt nem sikerült megnyitni."
-
 msgid "Submission too big!"
 msgstr "Túl nagy beküldés!"
 
@@ -325,8 +352,35 @@ msgstr "Túl nagy beküldés!"
 msgid "Each source file must be at most %d bytes long."
 msgstr "Minden forrásfájl maximum %d bájt méretű lehet."
 
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
+#, fuzzy
+msgid "Invalid archive format!"
+msgstr "Érvénytelen teszt formátum!"
+
+msgid "The submitted archive could not be opened."
+msgstr "A beküldött tömörített állományt nem sikerült megnyitni."
+
+#, fuzzy
+msgid "Invalid submission format!"
+msgstr "Érvénytelen teszt formátum!"
+
 msgid "Submission storage failed!"
 msgstr "A beküldés mentése nem sikerült!"
+
+#, fuzzy
+msgid "Too many tests!"
+msgstr "Túl sok beküldés!"
+
+#, fuzzy, python-format
+msgid "You have reached the maximum limit of at most %d tests among all tasks."
+msgstr "Elérted az összes feladatra engedélyezett beküldések maximális számát (%d)."
+
+#, fuzzy, python-format
+msgid "You have reached the maximum limit of at most %d tests on this task."
+msgstr "Elérted az erre a feladatra engedélyezett beküldések maximális számát (%d)."
 
 msgid "Tests too frequent!"
 msgstr "Túl gyakori tesztelés!"
@@ -351,6 +405,10 @@ msgstr "Túl nagy bemenet!"
 #, python-format
 msgid "The input file must be at most %d bytes long."
 msgstr "A bemeneti fájl maximum %d bájt méretű lehet."
+
+#, fuzzy
+msgid "Test storage failed!"
+msgstr "A beküldés mentése nem sikerült!"
 
 msgid "Communication"
 msgstr "Kommunikáció"
@@ -433,11 +491,11 @@ msgstr "%d olvasatlan"
 msgid "Until contest starts:"
 msgstr "A verseny kezdetéig:"
 
-msgid "Until analysis starts:"
-msgstr "Az analízis kezdetéig:"
-
 msgid "Until contest ends:"
 msgstr "A verseny végéig:"
+
+msgid "Until analysis starts:"
+msgstr "Az analízis kezdetéig:"
 
 msgid "Until analysis ends:"
 msgstr "Az analízis végéig:"
@@ -481,9 +539,6 @@ msgstr "Válassz egy versenyt"
 msgid "Programming languages and libraries"
 msgstr "Programozási nyelvek és könyvtárak"
 
-msgid "Standard Template Library"
-msgstr "Standard Template Library"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "A megoldásod fő Java osztályának neve meg kell, hogy egyezzen a feladat nevével."
 
@@ -511,6 +566,30 @@ msgstr "Megjegyezzük, hogy a Contest Management System (CMS) nem rendeltetéssz
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Ha ezt a hibát látod, akkor értesítsd a versenyszervezőket."
+
+msgid "Public score"
+msgstr "Nyilvános pontszám"
+
+msgid "Total score"
+msgstr "Teljes pontszám"
+
+msgid "Score"
+msgstr "Pontszám"
+
+msgid "Token"
+msgstr "Zseton"
+
+msgid "no submissions"
+msgstr "nincsenek beküldések"
+
+msgid "Played"
+msgstr "Felhasználva"
+
+msgid "Play!"
+msgstr "Felhasznál"
+
+msgid "No tokens"
+msgstr "Nincs zseton"
 
 msgid "General information"
 msgstr "Általános információk"
@@ -563,6 +642,10 @@ msgstr "Végtelen zsetonod van."
 msgid "You can see the detailed result of a submission by using a token on it."
 msgstr "Zsetonok felhasználásával megtekintheted egy beküldés részleteit."
 
+#, fuzzy
+msgid "Your score for each task will be the maximum among the tokened submissions and the last one."
+msgstr "Elérted az erre a feladatra engedélyezett beküldések maximális számát (%d)."
+
 msgid "You have a distinct set of tokens for each task."
 msgstr "Vannak zsetonjaid, amin nem osztoznak a feladatok."
 
@@ -581,6 +664,10 @@ msgstr "Egy beküldés részletes eredményét megtekintheted, ha mindkétféle 
 
 #, python-format
 msgid "You can submit at most %(submissions)s solutions during this contest."
+msgstr "Maximum %(submissions)s alkalommal küldhetsz be megoldást a verseny ideje alatt."
+
+#, fuzzy, python-format
+msgid "You can submit at most %(user_tests)s user tests during this contest."
 msgstr "Maximum %(submissions)s alkalommal küldhetsz be megoldást a verseny ideje alatt."
 
 #, python-format
@@ -649,6 +736,14 @@ msgstr "Nem"
 msgid "Print"
 msgstr "Nyomtatás"
 
+#, python-format
+msgid "You can print %(remaining_jobs)s more text or PDF files of up to %(max_pages)s pages each."
+msgstr ""
+
+#, python-format
+msgid "You can print %(remaining_jobs)s more text files of up to %(max_pages)s pages each."
+msgstr ""
+
 msgid "File (text or PDF)"
 msgstr "Fájl (szöveg vagy PDF)"
 
@@ -705,6 +800,10 @@ msgstr "Kérlek töltsd ki a mezőket a regisztrációhoz"
 
 msgid "New user"
 msgstr "Új felhasználó"
+
+#, fuzzy
+msgid "Join contest"
+msgstr "Válassz egy versenyt"
 
 msgid "First name"
 msgstr "Keresztnév"
@@ -833,6 +932,9 @@ msgstr "Teljes pontszám:"
 msgid "Submit a solution"
 msgstr "Megoldás beküldése"
 
+msgid "You may submit any subset of outputs in a single submission."
+msgstr ""
+
 #, python-format
 msgid "You can submit %(submissions_left)s more solution(s)."
 msgstr "Még %(submissions_left)s alkalommal küldhetsz be megoldást."
@@ -923,29 +1025,14 @@ msgstr "Várj..."
 msgid "None"
 msgstr "Egyik sem"
 
-msgid "Public score"
-msgstr "Nyilvános pontszám"
+msgid "Token request discarded"
+msgstr "Zseton kérelem elutasítva"
 
-msgid "Total score"
-msgstr "Teljes pontszám"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "A kérelmed el lett utasítva, mert nincsenek zsetonjaid."
 
-msgid "Score"
-msgstr "Pontszám"
-
-msgid "Token"
-msgstr "Zseton"
-
-msgid "no submissions"
-msgstr "nincsenek beküldések"
-
-msgid "Played"
-msgstr "Felhasználva"
-
-msgid "Play!"
-msgstr "Felhasznál"
-
-msgid "No tokens"
-msgstr "Nincs zseton"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "A kérelmed el lett utasítva, mert már felhasználtál egy zseton erre a beküldésre."
 
 msgid "Invalid file"
 msgstr "Érvénytelen fájl"
@@ -955,4 +1042,13 @@ msgstr "A nyomtatandó dokumentum túl sok oldalt tartalmaz"
 
 msgid "Sent to printer"
 msgstr "Elküldve a nyomtatónak"
+
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "Kilőve futás közben (memóriatúllépés is okozhatja)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "A kiértékelés hibakóddal fejeződött be. Többek között ezt a túlzott memóriahasználat okozhatja. Fontos, ha valóban ez okozta a hibát, akkor a beküldés részletes megtekintésekor mutatott memóriahasználat a hibát kiváltó memóriafoglalás előtti állapotot mutatja."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Standard Template Library"
 

--- a/cms/locale/it/LC_MESSAGES/cms.po
+++ b/cms/locale/it/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: it_IT\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: it_IT TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "N/A"
 
-msgid "Correct"
-msgstr "Corretto"
-
 msgid "Not correct"
 msgstr "Non corretto"
+
+msgid "Correct"
+msgstr "Corretto"
 
 msgid "Partially correct"
 msgstr "Parzialmente corretto"
 
-msgid "Outcome"
-msgstr "Esito"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "Esito"
 
 msgid "Details"
 msgstr "Dettagli"
@@ -107,11 +110,20 @@ msgstr "Esecuzione terminata perché fuori tempo massimo (superamento del limite
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "La tua sottoposizione ha usato troppo tempo totale. Questo può essere causato da codice con comportamento non definito, per esempio da un buffer overflow. In questo caso, i dettagli della sottoposizione possono mostrare un tempo CPU anche molto inferiore al limite."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "Esecuzione terminata forzatamente (potrebbe essere causato da una violazione dei limiti di memoria)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Limite di memoria"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "La valutazione è stata interrotta da un segnale. Tra le altre cose, questo potrebbe essere causato dal superamento del limite di memoria. Nota che se questo è il motivo, l'utilizzo della memoria visibile nei dettagli di invio è l'utilizzo appena prima dell'allocazione che ha causato il segnale."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "La tua sottoposizione ha usato troppo tempo CPU."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Esecuzione terminata perché fuori tempo massimo"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "Esecuzione fallita a causa di codice di ritorno diverso da zero"
@@ -190,14 +202,14 @@ msgstr[0] "fino ad un massimo di un %(type_s)s."
 msgstr[1] "fino ad un massimo di %(gen_max)d %(type_pl)s."
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Non riceverai altri %(type_pl)s."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "riceverai un altro %(type_s)s."
 msgstr[1] "riceverai altri %(gen_number)d %(type_pl)s."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Non riceverai altri %(type_pl)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -225,41 +237,6 @@ msgstr[1] "Non puoi usare più di %(max_number)d %(type_pl)s in totale."
 
 msgid "You have no limitations on how you use them."
 msgstr "Non hai limitazioni sul loro utilizzo."
-
-msgid "Too many print jobs!"
-msgstr "Troppe stampe!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Hai raggiunto il limite massimo di %d stampe."
-
-msgid "Invalid format!"
-msgstr "Formato invalido!"
-
-msgid "Please select the correct files."
-msgstr "Seleziona i file corretti."
-
-msgid "File too big!"
-msgstr "File troppo grande!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Ogni file deve essere grande al massimo %d byte."
-
-msgid "Print job storage failed!"
-msgstr "Errore nel salvataggio della stampa!"
-
-msgid "Please try again."
-msgstr "Riprova."
-
-msgid "Token request discarded"
-msgstr "Richiesta del token rifiutata"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "La tua richiesta è stata rifiutata perché non hai token disponibili."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "La tua richiesta è stata rifiutata perché hai già usato un token su questa sottoposizione."
 
 msgid "Question received"
 msgstr "Domanda ricevuta"
@@ -294,11 +271,11 @@ msgstr "Valutato"
 msgid "status"
 msgstr "stato"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "La tua richiesta è stata ricevuta e applicata alla sottoposizione."
-
 msgid "Token request received"
 msgstr "Richiesta del token ricevuta"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "La tua richiesta è stata ricevuta e applicata alla sottoposizione."
 
 msgid "Test received"
 msgstr "Test ricevuto"
@@ -314,6 +291,32 @@ msgstr "Esecuzione in corso..."
 
 msgid "Executed"
 msgstr "Eseguito"
+
+msgid "Too many print jobs!"
+msgstr "Troppe stampe!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Hai raggiunto il limite massimo di %d stampe."
+
+msgid "Invalid format!"
+msgstr "Formato invalido!"
+
+msgid "Please select the correct files."
+msgstr "Seleziona i file corretti."
+
+msgid "File too big!"
+msgstr "File troppo grande!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Ogni file deve essere grande al massimo %d byte."
+
+msgid "Print job storage failed!"
+msgstr "Errore nel salvataggio della stampa!"
+
+msgid "Please try again."
+msgstr "Riprova."
 
 msgid "Too many submissions!"
 msgstr "Troppe sottoposizioni!"
@@ -337,6 +340,17 @@ msgstr "Tra tutti i problemi, devi aspettare almeno %d secondi tra due sottoposi
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Su questo problema, devi aspettare almeno %d secondi tra due sottoposizioni."
 
+msgid "Submission too big!"
+msgstr "Sottoposizione troppo grande!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Ogni file sorgente deve essere grande al massimo %d byte."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Formato archivio invalido!"
 
@@ -345,13 +359,6 @@ msgstr "Impossibile aprire l'archivio sottoposto."
 
 msgid "Invalid submission format!"
 msgstr "Formato sottoposizione invalido!"
-
-msgid "Submission too big!"
-msgstr "Sottoposizione troppo grande!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Ogni file sorgente deve essere grande al massimo %d byte."
 
 msgid "Submission storage failed!"
 msgstr "Errore nel salvataggio della sottoposizione!"
@@ -475,11 +482,11 @@ msgstr "%d nuovi"
 msgid "Until contest starts:"
 msgstr "Fino a inizio gara:"
 
-msgid "Until analysis starts:"
-msgstr "Fino a inizio gara:"
-
 msgid "Until contest ends:"
 msgstr "Fino a fine gara:"
+
+msgid "Until analysis starts:"
+msgstr "Fino a inizio gara:"
 
 msgid "Until analysis ends:"
 msgstr "Fino a fine gara:"
@@ -523,9 +530,6 @@ msgstr "Scegli un contest"
 msgid "Programming languages and libraries"
 msgstr "Linguaggi di programmazione e librerie"
 
-msgid "Standard Template Library"
-msgstr "Standard Template Library"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "In Java, la classe principale della soluzione deve avere lo stesso nome del problema."
 
@@ -553,6 +557,30 @@ msgstr "Ricorda che tentativi di compromissione di Contest Management System (co
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Se questo errore si è verificato durante un uso normale sei pregato di notificare lo staff di gara."
+
+msgid "Public score"
+msgstr "Punteggio pubblico"
+
+msgid "Total score"
+msgstr "Punteggio totale"
+
+msgid "Score"
+msgstr "Punteggio"
+
+msgid "Token"
+msgstr "Token"
+
+msgid "no submissions"
+msgstr "nessuna sottoposizione"
+
+msgid "Played"
+msgstr "Usato"
+
+msgid "Play!"
+msgstr "Usa!"
+
+msgid "No tokens"
+msgstr "Nessun token"
 
 msgid "General information"
 msgstr "Informazioni generali"
@@ -986,29 +1014,14 @@ msgstr "Aspetta..."
 msgid "None"
 msgstr "Nessuno"
 
-msgid "Public score"
-msgstr "Punteggio pubblico"
+msgid "Token request discarded"
+msgstr "Richiesta del token rifiutata"
 
-msgid "Total score"
-msgstr "Punteggio totale"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "La tua richiesta è stata rifiutata perché non hai token disponibili."
 
-msgid "Score"
-msgstr "Punteggio"
-
-msgid "Token"
-msgstr "Token"
-
-msgid "no submissions"
-msgstr "nessuna sottoposizione"
-
-msgid "Played"
-msgstr "Usato"
-
-msgid "Play!"
-msgstr "Usa!"
-
-msgid "No tokens"
-msgstr "Nessun token"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "La tua richiesta è stata rifiutata perché hai già usato un token su questa sottoposizione."
 
 msgid "Invalid file"
 msgstr "File non valido"
@@ -1018,4 +1031,13 @@ msgstr "Il job di stampa ha troppe pagine"
 
 msgid "Sent to printer"
 msgstr "Inviato alla stampante"
+
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "Esecuzione terminata forzatamente (potrebbe essere causato da una violazione dei limiti di memoria)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "La valutazione è stata interrotta da un segnale. Tra le altre cose, questo potrebbe essere causato dal superamento del limite di memoria. Nota che se questo è il motivo, l'utilizzo della memoria visibile nei dettagli di invio è l'utilizzo appena prima dell'allocazione che ha causato il segnale."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Standard Template Library"
 

--- a/cms/locale/ja/LC_MESSAGES/cms.po
+++ b/cms/locale/ja/LC_MESSAGES/cms.po
@@ -1,27 +1,33 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: ja\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: ja TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "N/A"
 
-msgid "Correct"
-msgstr "正解"
-
 msgid "Not correct"
 msgstr "不正解"
 
+msgid "Correct"
+msgstr "正解"
+
 msgid "Partially correct"
 msgstr "部分的に正解"
+
+msgid "#"
+msgstr ""
 
 msgid "Outcome"
 msgstr "結果"
@@ -34,6 +40,9 @@ msgstr "実行時間"
 
 msgid "Memory used"
 msgstr "メモリ使用量"
+
+msgid "Score details temporarily unavailable."
+msgstr ""
 
 #, python-format
 msgid "Subtask %(index)s"
@@ -101,6 +110,21 @@ msgstr "実行時間超過 (実時間)"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "提出されたプログラムの実行が実時間の制限を超えました。原因として、ソースコード中の未定義動作やバッファオーバーフローなどが考えられます。詳細ページに表示される実行時間は実時間ではなく CPU 時間であるため、時間制限より小さくなりうることに注意してください。"
 
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "メモリ制限"
+
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "提出されたプログラムの実行が CPU 時間の制限を超えました。"
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "実行時間超過"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
+
 msgid "Execution failed because the return code was nonzero"
 msgstr "戻り値がゼロでなかったことによる異常終了"
 
@@ -115,6 +139,14 @@ msgstr "コンパイル不要"
 
 msgid "File not submitted"
 msgstr "ファイル未提出"
+
+#, fuzzy
+msgid "Question too long!"
+msgstr "テストが大きすぎます!"
+
+#, python-format
+msgid "Subject must be at most %(max_subject_length)d characters, content at most %(max_text_length)d."
+msgstr ""
 
 msgid "contest-token"
 msgstr "コンテストトークン"
@@ -167,13 +199,13 @@ msgid_plural "up to a maximum of %(gen_max)d %(type_pl)s."
 msgstr[0] "ただし、同時に %(gen_max)d 個までしか保有できず、持ちきれなくなった%(type_pl)sは破棄されます。"
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "これ以上%(type_pl)sが追加されることはありません。"
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "新たに %(gen_number)d 個の%(type_pl)sが追加されます。"
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "これ以上%(type_pl)sが追加されることはありません。"
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -197,41 +229,6 @@ msgstr[0] "あなたは%(type_pl)sを合計で %(max_number)d 個までしか使
 
 msgid "You have no limitations on how you use them."
 msgstr "%(type_pl)sを使う間隔や回数に制限はありません。"
-
-msgid "Too many print jobs!"
-msgstr "印刷が多すぎます!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "印刷はひとりあたり最大 %d 回までです。"
-
-msgid "Invalid format!"
-msgstr "無効な形式です!"
-
-msgid "Please select the correct files."
-msgstr "正しいファイルを選択してください。"
-
-msgid "File too big!"
-msgstr "ファイルが大きすぎます!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "各ファイルは %d バイト以下である必要があります。"
-
-msgid "Print job storage failed!"
-msgstr "印刷ジョブの保存に失敗しました!"
-
-msgid "Please try again."
-msgstr "もう一度試してください。"
-
-msgid "Token request discarded"
-msgstr "トークン使用要求は却下されました"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "使用可能なトークンがないので、あなたの要求は却下されました。"
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "この提出には既にトークンが使用されているため、あなたの要求は却下されました。"
 
 msgid "Question received"
 msgstr "質問を受理しました"
@@ -263,11 +260,15 @@ msgstr "得点を計算しています…"
 msgid "Evaluated"
 msgstr "実行・評価完了"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "あなたの要求は受理され、トークンが提出に適用されました。"
+#, fuzzy
+msgid "status"
+msgstr "状態"
 
 msgid "Token request received"
 msgstr "トークン使用要求は受理されました"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "あなたの要求は受理され、トークンが提出に適用されました。"
 
 msgid "Test received"
 msgstr "テスト要求を受理しました"
@@ -283,6 +284,32 @@ msgstr "実行中…"
 
 msgid "Executed"
 msgstr "実行完了"
+
+msgid "Too many print jobs!"
+msgstr "印刷が多すぎます!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "印刷はひとりあたり最大 %d 回までです。"
+
+msgid "Invalid format!"
+msgstr "無効な形式です!"
+
+msgid "Please select the correct files."
+msgstr "正しいファイルを選択してください。"
+
+msgid "File too big!"
+msgstr "ファイルが大きすぎます!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "各ファイルは %d バイト以下である必要があります。"
+
+msgid "Print job storage failed!"
+msgstr "印刷ジョブの保存に失敗しました!"
+
+msgid "Please try again."
+msgstr "もう一度試してください。"
 
 msgid "Too many submissions!"
 msgstr "提出が多すぎます!"
@@ -306,6 +333,17 @@ msgstr "全課題を通して、最後の提出から %d 秒間は解答を提�
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "この課題に関して、最後の提出から %d 秒間は解答を提出することができません。"
 
+msgid "Submission too big!"
+msgstr "提出ファイルが大きすぎます!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "各ソースファイルは %d バイト以下である必要があります。"
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "無効なアーカイブ形式です!"
 
@@ -314,13 +352,6 @@ msgstr "提出されたアーカイブを開くことができませんでした
 
 msgid "Invalid submission format!"
 msgstr "無効な提出形式です!"
-
-msgid "Submission too big!"
-msgstr "提出ファイルが大きすぎます!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "各ソースファイルは %d バイト以下である必要があります。"
 
 msgid "Submission storage failed!"
 msgstr "提出ファイルの保存に失敗しました!"
@@ -422,6 +453,13 @@ msgstr "パスワード"
 msgid "Login"
 msgstr "ログイン"
 
+msgid "Don't have an account?"
+msgstr ""
+
+#, fuzzy
+msgid "Register"
+msgstr "リセット"
+
 msgid "New message"
 msgstr "新着メッセージ"
 
@@ -439,6 +477,14 @@ msgid "Until contest starts:"
 msgstr "コンテスト開始まで:"
 
 msgid "Until contest ends:"
+msgstr "コンテスト終了まで:"
+
+#, fuzzy
+msgid "Until analysis starts:"
+msgstr "コンテスト開始まで:"
+
+#, fuzzy
+msgid "Until analysis ends:"
 msgstr "コンテスト終了まで:"
 
 msgid "Time left:"
@@ -474,11 +520,11 @@ msgstr "は以下のライセンスのもとでリリースされています:"
 msgid "GNU Affero General Public License"
 msgstr "GNU Affero General Public License"
 
+msgid "Choose a contest"
+msgstr ""
+
 msgid "Programming languages and libraries"
 msgstr "プログラミング言語およびライブラリの仕様"
-
-msgid "Standard Template Library"
-msgstr "Standard Template Library"
 
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "Java 言語で解答する場合のメインクラスの名前は、課題名と完全に一致させる必要があります。"
@@ -508,6 +554,31 @@ msgstr "コンテスト管理システム (CMS) の内部に干渉したり、�
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "通常の利用においてこのエラーに遭遇した場合は、コンテストの管理者に知らせてください。"
 
+msgid "Public score"
+msgstr "公開得点"
+
+msgid "Total score"
+msgstr "合計得点"
+
+msgid "Score"
+msgstr "得点"
+
+msgid "Token"
+msgstr "トークン"
+
+#, fuzzy
+msgid "no submissions"
+msgstr "提出"
+
+msgid "Played"
+msgstr "解禁済"
+
+msgid "Play!"
+msgstr "解禁!"
+
+msgid "No tokens"
+msgstr "トークン無し"
+
 msgid "General information"
 msgstr "全般的な情報"
 
@@ -530,6 +601,30 @@ msgstr "コンテストは終了しました。"
 
 #, python-format
 msgid "The contest started at %(start_time)s and ended at %(stop_time)s."
+msgstr "コンテストは %(start_time)s に始まり、%(stop_time)s に終わりました。"
+
+#, fuzzy
+msgid "The analysis mode hasn't started yet."
+msgstr "コンテストはまだ始まっていません。"
+
+#, fuzzy, python-format
+msgid "The analysis mode will start at %(start_time)s and will end at %(stop_time)s."
+msgstr "コンテストは %(start_time)s に始まり、 %(stop_time)s に終わる予定です。"
+
+#, fuzzy
+msgid "The analysis mode is currently running."
+msgstr "コンテストは現在実施中です。"
+
+#, fuzzy, python-format
+msgid "The analysis mode started at %(start_time)s and will end at %(stop_time)s."
+msgstr "コンテストは %(start_time)s に始まりました。%(stop_time)s に終わる予定です。"
+
+#, fuzzy
+msgid "The analysis mode has already ended."
+msgstr "コンテストは終了しました。"
+
+#, fuzzy, python-format
+msgid "The analysis mode started at %(start_time)s and ended at %(stop_time)s."
 msgstr "コンテストは %(start_time)s に始まり、%(stop_time)s に終わりました。"
 
 msgid "You have an infinite number of tokens."
@@ -672,6 +767,73 @@ msgstr "準備中…"
 msgid "no print jobs yet"
 msgstr "まだ印刷ジョブはありません"
 
+msgid "The passwords do not match!"
+msgstr ""
+
+msgid "This username is already taken, please choose a different one."
+msgstr ""
+
+msgid "This user is already registered in the contest."
+msgstr ""
+
+msgid "No such user."
+msgstr ""
+
+msgid "The password is not correct."
+msgstr ""
+
+msgid "Registration"
+msgstr ""
+
+msgid "Please fill in the fields to register"
+msgstr ""
+
+#, fuzzy
+msgid "New user"
+msgstr "新着回答"
+
+msgid "Join contest"
+msgstr ""
+
+#, fuzzy
+msgid "First name"
+msgstr "ファイル名"
+
+#, fuzzy
+msgid "Last name"
+msgstr "ファイル名"
+
+#, fuzzy
+msgid "E-mail"
+msgstr "詳細"
+
+#, fuzzy
+msgid "Representing"
+msgstr "印刷"
+
+#, python-format
+msgid "Must be one character or more."
+msgid_plural "Must be %(min_length)s characters or more."
+msgstr[0] ""
+
+#, fuzzy
+msgid "Confirm password"
+msgstr "パスワード"
+
+msgid "Registered in the contest successfully!"
+msgstr ""
+
+#, fuzzy
+msgid "Your username is:"
+msgstr "ユーザ名"
+
+msgid "Your password is stored securely."
+msgstr ""
+
+#, fuzzy
+msgid "Back to login"
+msgstr "ログインに失敗しました。"
+
 msgid "Compilation output"
 msgstr "コンパイル出力"
 
@@ -731,6 +893,10 @@ msgstr "詳細"
 msgid "Compilation commands"
 msgstr "コンパイル時のコマンド"
 
+#, fuzzy, python-format
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
+msgstr "%(type_pl)sの使用に関する規則は、各課題の説明ページを参照してください。"
+
 msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
 msgstr "提出に対する詳細な結果を見るためには、コンテストトークンと課題トークンの両方を使用する必要があることに注意してください。"
 
@@ -747,8 +913,27 @@ msgstr "読み込み中…"
 msgid "%(name)s (%(short_name)s) <small>submissions</small>"
 msgstr "%(name)s (%(short_name)s) <small>提出</small>"
 
+#, fuzzy
+msgid "Score:"
+msgstr "得点"
+
+#, fuzzy
+msgid "Public score:"
+msgstr "公開得点"
+
+#, fuzzy
+msgid "Score of tokened submissions:"
+msgstr "以前の提出"
+
+#, fuzzy
+msgid "Total score:"
+msgstr "合計得点"
+
 msgid "Submit a solution"
 msgstr "解答を提出する"
+
+msgid "You may submit any subset of outputs in a single submission."
+msgstr ""
 
 #, python-format
 msgid "You can submit %(submissions_left)s more solution(s)."
@@ -759,6 +944,9 @@ msgstr "submission.zip"
 
 msgid "Previous submissions"
 msgstr "以前の提出"
+
+msgid "Tokens are not allowed on this task."
+msgstr ""
 
 msgid "Right now, you have infinite tokens available on this task."
 msgstr "現在、この課題ではトークンを無制限に使用できます。"
@@ -787,6 +975,14 @@ msgstr "現在、この課題で使用可能なトークンはありません。
 #, python-format
 msgid "But you will have to wait until %(expiration_time)s to use it."
 msgstr "しかし、そのトークンを使用するためには %(expiration_time)s 待つ必要があります。"
+
+#, fuzzy
+msgid "Unofficial submissions"
+msgstr "提出"
+
+#, fuzzy
+msgid "Official submissions"
+msgstr "提出"
 
 msgid "Submission details"
 msgstr "提出の詳細"
@@ -831,24 +1027,26 @@ msgstr "お待ちください…"
 msgid "None"
 msgstr "なし"
 
-msgid "Public score"
-msgstr "公開得点"
+msgid "Token request discarded"
+msgstr "トークン使用要求は却下されました"
 
-msgid "Total score"
-msgstr "合計得点"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "使用可能なトークンがないので、あなたの要求は却下されました。"
 
-msgid "Score"
-msgstr "得点"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "この提出には既にトークンが使用されているため、あなたの要求は却下されました。"
 
-msgid "Token"
-msgstr "トークン"
+#, fuzzy
+msgid "Invalid file"
+msgstr "無効な形式です!"
 
-msgid "Played"
-msgstr "解禁済"
+#, fuzzy
+msgid "Print job has too many pages"
+msgstr "印刷ジョブの保存に失敗しました!"
 
-msgid "Play!"
-msgstr "解禁!"
+msgid "Sent to printer"
+msgstr ""
 
-msgid "No tokens"
-msgstr "トークン無し"
+#~ msgid "Standard Template Library"
+#~ msgstr "Standard Template Library"
 

--- a/cms/locale/ko/LC_MESSAGES/cms.po
+++ b/cms/locale/ko/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: ko\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: ko TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "없음"
 
-msgid "Correct"
-msgstr "맞았습니다"
-
 msgid "Not correct"
 msgstr "틀렸습니다"
+
+msgid "Correct"
+msgstr "맞았습니다"
 
 msgid "Partially correct"
 msgstr "일부 맞았습니다"
 
-msgid "Outcome"
-msgstr "출력결과"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "출력결과"
 
 msgid "Details"
 msgstr "세부사항"
@@ -61,14 +64,18 @@ msgid "Compilation timed out"
 msgstr "컴파일 제한 시간 초과"
 
 msgid "Your submission exceeded the time limit while compiling. This might be caused by an excessive use of C++ templates, for example."
-msgstr "제출한 파일을 컴파일하는 과정에서 제한 시간을 초과하였습니다.\n C++ 템플릿을 너무 많이 사용했을 수도 있습니다."
+msgstr ""
+"제출한 파일을 컴파일하는 과정에서 제한 시간을 초과하였습니다.\n"
+" C++ 템플릿을 너무 많이 사용했을 수도 있습니다."
 
 #, python-format
 msgid "Compilation killed with signal %s (could be triggered by violating memory limits)"
 msgstr "%s 오류로 컴파일 취소 (메모리제한 초과 등)"
 
 msgid "Your submission was killed with the specified signal. Among other things, this might be caused by exceeding the memory limit for the compilation, and in turn by an excessive use of C++ templates, for example."
-msgstr "오류가 발생하여 채점이 취소되었습니다.\n 컴파일 과정에서 메모리제한을 초과했거나, C++ 템플릿을 너무 많이 사용한 경우에 주로 발생합니다."
+msgstr ""
+"오류가 발생하여 채점이 취소되었습니다.\n"
+" 컴파일 과정에서 메모리제한을 초과했거나, C++ 템플릿을 너무 많이 사용한 경우에 주로 발생합니다."
 
 msgid "Output is correct"
 msgstr "맞았습니다"
@@ -105,13 +112,25 @@ msgid "Execution timed out (wall clock limit exceeded)"
 msgstr "실행 시간 초과 (CPU 클록 제한 초과 등)"
 
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
-msgstr "제출한 프로그램이 너무 많은 시간을 사용했습니다.\n 정의되지 않은 코드, 버퍼 오버플로 등에 의해 발생할 수 있습니다.\n 그렇지만, 채점 세부사항에 나타나는 CPU 시간은 프로그램 실행 제한시간보다 작게 나타날 수 있습니다."
+msgstr ""
+"제출한 프로그램이 너무 많은 시간을 사용했습니다.\n"
+" 정의되지 않은 코드, 버퍼 오버플로 등에 의해 발생할 수 있습니다.\n"
+" 그렇지만, 채점 세부사항에 나타나는 CPU 시간은 프로그램 실행 제한시간보다 작게 나타날 수 있습니다."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "프로그램 실행 중단 (메모리제한 초과 등)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "메모리 제한"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "오류가 발생하여 채점이 중단되었습니다.\n 주로 메모리사용 제한 초과로 발생합니다.\n 메모리제한 초과로 오류가 발생한 경우, 채점 세부사항에 나타나는 메모리사용량은 메모리사용 제한 초과가 발생하기 전의 사용량입니다."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "제출한 프로그램이 너무 많은 CPU 시간을 사용했습니다."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "시간 초과"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "실행 파일이 0을 return하지 않았습니다."
@@ -155,15 +174,24 @@ msgstr "토큰"
 
 #, python-format
 msgid "You don't have %(type_pl)s available for this task."
-msgstr "이 문제는 %(type_pl)s을 더 이상 사용할 수 없습니다.\n\n "
+msgstr ""
+"이 문제는 %(type_pl)s을 더 이상 사용할 수 없습니다.\n"
+"\n"
+" "
 
 #, python-format
 msgid "You have an infinite number of %(type_pl)s for this task."
-msgstr "이 문제는 %(type_pl)s을 무한히 사용할 수 있습니다.\n\n "
+msgstr ""
+"이 문제는 %(type_pl)s을 무한히 사용할 수 있습니다.\n"
+"\n"
+" "
 
 #, python-format
 msgid "You start with no %(type_pl)s."
-msgstr "0 개의 %(type_pl)s을 가지고 시작합니다.\n\n "
+msgstr ""
+"0 개의 %(type_pl)s을 가지고 시작합니다.\n"
+"\n"
+" "
 
 #, python-format
 msgid "You start with one %(type_s)s."
@@ -186,13 +214,13 @@ msgid_plural "up to a maximum of %(gen_max)d %(type_pl)s."
 msgstr[0] ""
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "%(type_pl)s을 더 받을 수 없습니다."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] ""
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "%(type_pl)s을 더 받을 수 없습니다."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -215,42 +243,10 @@ msgid_plural "You can use no more than %(max_number)d %(type_pl)s in total."
 msgstr[0] ""
 
 msgid "You have no limitations on how you use them."
-msgstr "무제한으로 사용할 수 있습니다.\n\n "
-
-msgid "Too many print jobs!"
-msgstr "프린트 불가능!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "최대 프린트 횟수(%d)를 모두 사용했습니다."
-
-msgid "Invalid format!"
-msgstr "파일 오류!"
-
-msgid "Please select the correct files."
-msgstr "정확한 파일들을 선택하세요."
-
-msgid "File too big!"
-msgstr "파일 크기 초과!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "각 파일의 최대 크기는 %d bytes 입니다."
-
-msgid "Print job storage failed!"
-msgstr "프린트 작업 전송 실패!"
-
-msgid "Please try again."
-msgstr "다시 시도해보세요."
-
-msgid "Token request discarded"
-msgstr "토큰 제출 실패"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "토큰이 없기 때문에, 제출할 수 없습니다."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "해당 채점에 대해서 이미 토큰을 사용했기 때문에, 제출할 수 없습니다."
+msgstr ""
+"무제한으로 사용할 수 있습니다.\n"
+"\n"
+" "
 
 msgid "Question received"
 msgstr "질문 전송 완료"
@@ -285,11 +281,11 @@ msgstr "채점 완료"
 msgid "status"
 msgstr "결과"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "토큰을 사용해서 채점을 제출했습니다."
-
 msgid "Token request received"
 msgstr "토큰 제출 완료"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "토큰을 사용해서 채점을 제출했습니다."
 
 msgid "Test received"
 msgstr "테스트 제출 완료"
@@ -305,6 +301,32 @@ msgstr "실행 중..."
 
 msgid "Executed"
 msgstr "실행 완료"
+
+msgid "Too many print jobs!"
+msgstr "프린트 불가능!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "최대 프린트 횟수(%d)를 모두 사용했습니다."
+
+msgid "Invalid format!"
+msgstr "파일 오류!"
+
+msgid "Please select the correct files."
+msgstr "정확한 파일들을 선택하세요."
+
+msgid "File too big!"
+msgstr "파일 크기 초과!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "각 파일의 최대 크기는 %d bytes 입니다."
+
+msgid "Print job storage failed!"
+msgstr "프린트 작업 전송 실패!"
+
+msgid "Please try again."
+msgstr "다시 시도해보세요."
 
 msgid "Too many submissions!"
 msgstr "더 이상 제출할 수 없습니다!"
@@ -328,6 +350,17 @@ msgstr "누적 마지막 제출 시각을 기준으로 %d 초 이후에 다시 �
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "이 문제에 대해서, 마지막 제출 시각을 기준으로 %d 초 이후에 다시 제출할 수 있습니다."
 
+msgid "Submission too big!"
+msgstr "제출 파일 용량 초과 "
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "제출 파일의 최대 크기는 %d bytes 입니다."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "압축 파일 오류!"
 
@@ -336,13 +369,6 @@ msgstr "압축 파일을 열 수 없습니다."
 
 msgid "Invalid submission format!"
 msgstr "제출 파일 오류!"
-
-msgid "Submission too big!"
-msgstr "제출 파일 용량 초과 "
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "제출 파일의 최대 크기는 %d bytes 입니다."
 
 msgid "Submission storage failed!"
 msgstr "제출 파일 저장 실패!"
@@ -466,11 +492,11 @@ msgstr "미확인 메시지 %d 개"
 msgid "Until contest starts:"
 msgstr "대회 시작까지 남은 시간:"
 
-msgid "Until analysis starts:"
-msgstr "리뷰 시작까지 남은 시간:"
-
 msgid "Until contest ends:"
 msgstr "대회 종료까지 남은 시간:"
+
+msgid "Until analysis starts:"
+msgstr "리뷰 시작까지 남은 시간:"
 
 msgid "Until analysis ends:"
 msgstr "리뷰 종료까지 남은 시간:"
@@ -514,9 +540,6 @@ msgstr "대회 선택"
 msgid "Programming languages and libraries"
 msgstr "프로그래밍 언어 및 라이브러리"
 
-msgid "Standard Template Library"
-msgstr "STL(Standard Template Library)"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "답안 제출시 Java main class 의 이름은 해당 문제와 일치해야 합니다."
 
@@ -545,6 +568,30 @@ msgstr "(접속 URL 주소를 바꿔가며 대회 운영과 관련된 페이지�
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "정상적인 사용 과정에서 이 메시지를 받는 경우에는 반드시 대회 운영진에게 알려주세요."
 
+msgid "Public score"
+msgstr "공식 점수"
+
+msgid "Total score"
+msgstr "총점"
+
+msgid "Score"
+msgstr "점수"
+
+msgid "Token"
+msgstr "토큰"
+
+msgid "no submissions"
+msgstr "채점 기록 없음"
+
+msgid "Played"
+msgstr "확인함"
+
+msgid "Play!"
+msgstr "확인하기!"
+
+msgid "No tokens"
+msgstr "토큰 없음"
+
 msgid "General information"
 msgstr "일반 사항"
 
@@ -553,48 +600,63 @@ msgstr "대회 시작전입니다."
 
 #, python-format
 msgid "The contest will start at %(start_time)s and will end at %(stop_time)s."
-msgstr "대회는 %(start_time)s 에 시작되어\n %(stop_time)s 에 종료될 예정입니다."
+msgstr ""
+"대회는 %(start_time)s 에 시작되어\n"
+" %(stop_time)s 에 종료될 예정입니다."
 
 msgid "The contest is currently running."
 msgstr "대회가 진행중입니다."
 
 #, python-format
 msgid "The contest started at %(start_time)s and will end at %(stop_time)s."
-msgstr "대회가 %(start_time)s 에 시작되었으며\n %(stop_time)s 에 종료될 예정입니다."
+msgstr ""
+"대회가 %(start_time)s 에 시작되었으며\n"
+" %(stop_time)s 에 종료될 예정입니다."
 
 msgid "The contest has already ended."
 msgstr "대회가 종료되었습니다."
 
 #, python-format
 msgid "The contest started at %(start_time)s and ended at %(stop_time)s."
-msgstr "대회가 %(start_time)s 에 시작되었으며\n %(stop_time)s 에 종료되었습니다."
+msgstr ""
+"대회가 %(start_time)s 에 시작되었으며\n"
+" %(stop_time)s 에 종료되었습니다."
 
 msgid "The analysis mode hasn't started yet."
 msgstr "대회 리뷰 시작전입니다."
 
 #, python-format
 msgid "The analysis mode will start at %(start_time)s and will end at %(stop_time)s."
-msgstr "대회 리뷰는 %(start_time)s 에 시작되어\n %(stop_time)s 에 종료될 예정입니다."
+msgstr ""
+"대회 리뷰는 %(start_time)s 에 시작되어\n"
+" %(stop_time)s 에 종료될 예정입니다."
 
 msgid "The analysis mode is currently running."
 msgstr "대회 리뷰가 진행중입니다."
 
 #, python-format
 msgid "The analysis mode started at %(start_time)s and will end at %(stop_time)s."
-msgstr "대회 리뷰가 %(start_time)s 에 시작되었으며\n %(stop_time)s 에 종료될 예정입니다."
+msgstr ""
+"대회 리뷰가 %(start_time)s 에 시작되었으며\n"
+" %(stop_time)s 에 종료될 예정입니다."
 
 msgid "The analysis mode has already ended."
 msgstr "대회 리뷰가 종료되었습니다."
 
 #, python-format
 msgid "The analysis mode started at %(start_time)s and ended at %(stop_time)s."
-msgstr "대회 리뷰가 %(start_time)s 에 시작되었으며\n %(stop_time)s 에 종료되었습니다."
+msgstr ""
+"대회 리뷰가 %(start_time)s 에 시작되었으며\n"
+" %(stop_time)s 에 종료되었습니다."
 
 msgid "You have an infinite number of tokens."
 msgstr "토큰을 무한히 가지고 있습니다."
 
 msgid "You can see the detailed result of a submission by using a token on it."
-msgstr "토큰을 1개 사용해서, 채점 결과에 대한 세부사항을 자세히 살펴볼 수 있습니다.\n\n "
+msgstr ""
+"토큰을 1개 사용해서, 채점 결과에 대한 세부사항을 자세히 살펴볼 수 있습니다.\n"
+"\n"
+" "
 
 msgid "Your score for each task will be the maximum among the tokened submissions and the last one."
 msgstr "각 문제에 대한 득점은, 토큰을 사용해서 제출한 채점 결과 중에서 가장 높은 점수로서 가장 마지막에 채점된 점수로 계산됩니다."
@@ -607,13 +669,22 @@ msgid "You can find the rules for the %(type_pl)s on each task's description pag
 msgstr "%(type_pl)s에 대한 규칙들은 각 문제의 설명 페이지에서 찾아볼 수 있습니다."
 
 msgid "You have a set of tokens shared among all tasks."
-msgstr "모든 문제에 같은 토큰을 사용합니다.\n\n "
+msgstr ""
+"모든 문제에 같은 토큰을 사용합니다.\n"
+"\n"
+" "
 
 msgid "You have two types of tokens: a set of <em>contest-tokens</em> shared among all tasks and a distinct set of <em>task-tokens</em> for each task."
-msgstr "2 종류의 토큰을 사용합니다.: <em>대회-토큰</em>은 모든 문제들에 대해 공통으로 사용하고, <em>문제-토큰</em>은 각 문제별로 따로 사용합니다.\n\n "
+msgstr ""
+"2 종류의 토큰을 사용합니다.: <em>대회-토큰</em>은 모든 문제들에 대해 공통으로 사용하고, <em>문제-토큰</em>은 각 문제별로 따로 사용합니다.\n"
+"\n"
+" "
 
 msgid "You can see the detailed result of a submission by using two tokens on it, one of each type."
-msgstr "2 종류의 토큰을 각각 1개씩 사용해서, 채점 결과에 대한 세부사항을 자세히 살펴볼 수 있습니다.\n\n "
+msgstr ""
+"2 종류의 토큰을 각각 1개씩 사용해서, 채점 결과에 대한 세부사항을 자세히 살펴볼 수 있습니다.\n"
+"\n"
+" "
 
 #, python-format
 msgid "You can submit at most %(submissions)s solutions during this contest."
@@ -634,11 +705,17 @@ msgid "Once you start, you can submit solutions until the end of the time frame 
 msgstr "자신의 타임 프레임을 시작해야만 채점을 제출할 수 있습니다. 하지만, 자신의 타임 프레임이 남아있다고 하더라도 대회 종료전까지만 채점을 제출할 수 있습니다."
 
 msgid "By clicking on the button below you can start your time frame."
-msgstr "아래의 대회 참가 버튼을 누르면 자신의 타임 프레임이 시작됩니다.\n\n "
+msgstr ""
+"아래의 대회 참가 버튼을 누르면 자신의 타임 프레임이 시작됩니다.\n"
+"\n"
+" "
 
 #, python-format
 msgid "You started your time frame at %(start_time)s."
-msgstr "타임 프레임을 %(start_time)s 에 시작시켰습니다.\n\n "
+msgstr ""
+"타임 프레임을 %(start_time)s 에 시작시켰습니다.\n"
+"\n"
+" "
 
 msgid "You can submit solutions until the end of the time frame or until the end of the contest, whatever comes first."
 msgstr "자신에게 주어진 타임 프레임 이내에서만 채점을 제출할 수 있습니다. 하지만, 자신의 타임 프레임이 남아있다고 하더라도 대회 종료전까지만 채점을 제출할 수 있습니다."
@@ -976,29 +1053,14 @@ msgstr "대기..."
 msgid "None"
 msgstr "없음"
 
-msgid "Public score"
-msgstr "공식 점수"
+msgid "Token request discarded"
+msgstr "토큰 제출 실패"
 
-msgid "Total score"
-msgstr "총점"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "토큰이 없기 때문에, 제출할 수 없습니다."
 
-msgid "Score"
-msgstr "점수"
-
-msgid "Token"
-msgstr "토큰"
-
-msgid "no submissions"
-msgstr "채점 기록 없음"
-
-msgid "Played"
-msgstr "확인함"
-
-msgid "Play!"
-msgstr "확인하기!"
-
-msgid "No tokens"
-msgstr "토큰 없음"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "해당 채점에 대해서 이미 토큰을 사용했기 때문에, 제출할 수 없습니다."
 
 msgid "Invalid file"
 msgstr "파일 오류"
@@ -1008,4 +1070,16 @@ msgstr "프린트 할 페이지가 너무 많습니다."
 
 msgid "Sent to printer"
 msgstr "프린터 전송 완료"
+
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "프로그램 실행 중단 (메모리제한 초과 등)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr ""
+#~ "오류가 발생하여 채점이 중단되었습니다.\n"
+#~ " 주로 메모리사용 제한 초과로 발생합니다.\n"
+#~ " 메모리제한 초과로 오류가 발생한 경우, 채점 세부사항에 나타나는 메모리사용량은 메모리사용 제한 초과가 발생하기 전의 사용량입니다."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "STL(Standard Template Library)"
 

--- a/cms/locale/lt/LC_MESSAGES/cms.po
+++ b/cms/locale/lt/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: lt_LT\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: lt_LT TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "Nėra"
 
-msgid "Correct"
-msgstr "Teisingai"
-
 msgid "Not correct"
 msgstr "Neteisingai"
+
+msgid "Correct"
+msgstr "Teisingai"
 
 msgid "Partially correct"
 msgstr "Dalinai teisingai"
 
-msgid "Outcome"
-msgstr "Rezultatas"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "Rezultatas"
 
 msgid "Details"
 msgstr "Detalės"
@@ -107,11 +110,20 @@ msgstr "Vykdymas užtruko per ilgai (viršytas sieninio laikrodžio ribojimas)"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "Tavo sprendimo vykdymas užtruko per ilgai neišnaudodamas procesoriaus laiko. Tai galėjo įvykti, pavyzdžiui, dėl neapibrėžto kodo ar buferio perpildymo. Įvykus šiai klaidai, sprendimo informacijos lange rodomas panaudoto procesoriaus laiko kiekis gali būti gerokai mažesnis už laiko ribojimą."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "Vykdymas nutrauktas (tai galėjo įvykti viršijus atminties ribojimus)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Atminties limitas"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "Tavo sprendimo vykdymas buvo nutrauktas signalu. Viena iš galimų priežasčių yra atminties ribojimo viršijimas. Sprendimo informacijos lange rodomas panaudotos atminties kiekis yra toks, koks jis buvo prieš signalą sukėlusį veiksmą."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Tavo sprendimo vykdymas panaudojo per daug procesoriaus laiko."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Vykdymas viršijo laiko ribojimą"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "Vykdymas nesėkmingas, nes grąžintas kodas buvo ne nulis"
@@ -171,7 +183,6 @@ msgid_plural "You start with %(gen_initial)d %(type_pl)s."
 msgstr[0] "Pradžioje turi vieną %(type_s)s."
 msgstr[1] "Pradžioje turi %(gen_initial)d %(type_pl)s."
 msgstr[2] "Pradžioje turi %(gen_initial)d %(type_pl)s."
-msgstr[3] ""
 
 #, python-format
 msgid "Every minute "
@@ -179,7 +190,6 @@ msgid_plural "Every %(gen_interval)g minutes "
 msgstr[0] "Kas minutę "
 msgstr[1] "Kas %(gen_interval)g minutes "
 msgstr[2] "Kas %(gen_interval)g minučių "
-msgstr[3] ""
 
 #, python-format
 msgid "you get another %(type_s)s, "
@@ -187,7 +197,6 @@ msgid_plural "you get %(gen_number)d other %(type_pl)s, "
 msgstr[0] "gausi po vieną %(type_s)s, "
 msgstr[1] "gausi po %(gen_number)d %(type_pl)s, "
 msgstr[2] "gausi po %(gen_number)d %(type_pl)s, "
-msgstr[3] ""
 
 #, python-format
 msgid "up to a maximum of one %(type_s)s."
@@ -195,11 +204,6 @@ msgid_plural "up to a maximum of %(gen_max)d %(type_pl)s."
 msgstr[0] "kol pasieksi vieną %(type_s)s."
 msgstr[1] "kol pasieksi %(gen_max)d %(type_pl)s."
 msgstr[2] "kol pasieksi %(gen_max)d %(type_pl)s."
-msgstr[3] ""
-
-#, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Daugiau %(type_pl)s negausi."
 
 #, python-format
 msgid "you get another %(type_s)s."
@@ -207,7 +211,10 @@ msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "gausi po vieną %(type_s)s."
 msgstr[1] "gausi po %(gen_number)d %(type_pl)s."
 msgstr[2] "gausi po %(gen_number)d %(type_pl)s."
-msgstr[3] ""
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Daugiau %(type_pl)s negausi."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -215,7 +222,6 @@ msgid_plural "You can use a %(type_s)s every %(min_interval)g seconds "
 msgstr[0] "Gali naudoti %(type_s)s kartą per sekundę "
 msgstr[1] "Gali naudoti %(type_s)s kartą per %(min_interval)g sekundes "
 msgstr[2] "Gali naudoti %(type_s)s kartą per %(min_interval)g sekundžių "
-msgstr[3] ""
 
 #, python-format
 msgid "and no more than one %(type_s)s in total."
@@ -223,7 +229,6 @@ msgid_plural "and no more than %(max_number)d %(type_pl)s in total."
 msgstr[0] "ir ne daugiau nei vieną %(type_s)s iš viso."
 msgstr[1] "ir ne daugiau nei %(max_number)d %(type_pl)s iš viso."
 msgstr[2] "ir ne daugiau nei %(max_number)d %(type_pl)s iš viso."
-msgstr[3] ""
 
 #, python-format
 msgid "You can use a %(type_s)s every second."
@@ -231,7 +236,6 @@ msgid_plural "You can use a %(type_s)s every %(min_interval)g seconds."
 msgstr[0] "Gali naudoti %(type_s)s kartą per sekundę."
 msgstr[1] "Gali naudoti %(type_s)s kartą per %(min_interval)g sekundes."
 msgstr[2] "Gali naudoti %(type_s)s kartą per %(min_interval)g sekundžių."
-msgstr[3] ""
 
 #, python-format
 msgid "You can use no more than one %(type_s)s in total."
@@ -239,45 +243,9 @@ msgid_plural "You can use no more than %(max_number)d %(type_pl)s in total."
 msgstr[0] "Iš viso gali naudoti ne daugiau nei vieną %(type_s)s."
 msgstr[1] "Iš viso gali naudoti ne daugiau nei %(max_number)d %(type_pl)s."
 msgstr[2] "Iš viso gali naudoti ne daugiau nei %(max_number)d %(type_pl)s."
-msgstr[3] ""
 
 msgid "You have no limitations on how you use them."
 msgstr "Neturi apribojimų jų naudojimui."
-
-msgid "Too many print jobs!"
-msgstr "Per daug spausdinimo darbų!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Pasiekei %d spausdinimo darbų limitą."
-
-msgid "Invalid format!"
-msgstr "Netinkamas formatas!"
-
-msgid "Please select the correct files."
-msgstr "Pasirink teisingus failus."
-
-msgid "File too big!"
-msgstr "Failas per didelis!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Kiekvienas failas turi būti ne didesnis nei %d baitų."
-
-msgid "Print job storage failed!"
-msgstr "Nepavyko išsaugoti spausdinimo darbo!"
-
-msgid "Please try again."
-msgstr "Bandyk dar kartą."
-
-msgid "Token request discarded"
-msgstr "Žetono užklausa atmesta"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Tavo užklausa atmesta, kadangi neturi žetonų."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Užklausa buvo atmesta, kadangi šiam sprendimui žetoną jau naudojai."
 
 msgid "Question received"
 msgstr "Klausimas gautas"
@@ -309,11 +277,15 @@ msgstr "Skaičiuojami taškai..."
 msgid "Evaluated"
 msgstr "Įvertinta"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Tavo užklausa gauta ir įvykdyta pateiktam sprendimui."
+#, fuzzy
+msgid "status"
+msgstr "Būsena"
 
 msgid "Token request received"
 msgstr "Žetono užklausa gauta"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Tavo užklausa gauta ir įvykdyta pateiktam sprendimui."
 
 msgid "Test received"
 msgstr "Testas gautas"
@@ -329,6 +301,32 @@ msgstr "Vykdoma..."
 
 msgid "Executed"
 msgstr "Įvykdyta"
+
+msgid "Too many print jobs!"
+msgstr "Per daug spausdinimo darbų!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Pasiekei %d spausdinimo darbų limitą."
+
+msgid "Invalid format!"
+msgstr "Netinkamas formatas!"
+
+msgid "Please select the correct files."
+msgstr "Pasirink teisingus failus."
+
+msgid "File too big!"
+msgstr "Failas per didelis!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Kiekvienas failas turi būti ne didesnis nei %d baitų."
+
+msgid "Print job storage failed!"
+msgstr "Nepavyko išsaugoti spausdinimo darbo!"
+
+msgid "Please try again."
+msgstr "Bandyk dar kartą."
 
 msgid "Too many submissions!"
 msgstr "Per daug pateiktų sprendimų!"
@@ -352,6 +350,17 @@ msgstr "Dar kartą pateikti sprendimą gali po %d sekundžių nuo paskutinio bet
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Dar kartą pateikti sprendimą gali po %d sekundžių nuo paskutinio šios užduoties sprendimo pateikimo."
 
+msgid "Submission too big!"
+msgstr "Pateiktas sprendimas per didelis!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Kiekvienas pirminio teksto failas turi būti nedidesnis nei %d baitų."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Netinkamas archyvo formatas!"
 
@@ -360,13 +369,6 @@ msgstr "Nepavyksta atverti pateikto archyvo."
 
 msgid "Invalid submission format!"
 msgstr "Netinkamas pateikimo formatas!"
-
-msgid "Submission too big!"
-msgstr "Pateiktas sprendimas per didelis!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Kiekvienas pirminio teksto failas turi būti nedidesnis nei %d baitų."
 
 msgid "Submission storage failed!"
 msgstr "Nepavyko išsaugoti pateikto sprendimo!"
@@ -468,6 +470,13 @@ msgstr "Slaptažodis"
 msgid "Login"
 msgstr "Prisijungti"
 
+msgid "Don't have an account?"
+msgstr ""
+
+#, fuzzy
+msgid "Register"
+msgstr "Atstatyti"
+
 msgid "New message"
 msgstr "Nauja žinutė"
 
@@ -484,11 +493,11 @@ msgstr "%d neskaityti"
 msgid "Until contest starts:"
 msgstr "Iki varžybų pradžios:"
 
-msgid "Until analysis starts:"
-msgstr "Iki analizės pradžios:"
-
 msgid "Until contest ends:"
 msgstr "Iki varžybų pabaigos:"
+
+msgid "Until analysis starts:"
+msgstr "Iki analizės pradžios:"
 
 msgid "Until analysis ends:"
 msgstr "Iki analizės pabaigos:"
@@ -532,9 +541,6 @@ msgstr "Pasirink varžybas"
 msgid "Programming languages and libraries"
 msgstr "Programavimo kalbos ir bibliotekos"
 
-msgid "Standard Template Library"
-msgstr "Standartinė šablonų biblioteka"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "Pagrindinė sprendimo klasė turi vadintis taip pat kaip užduotis."
 
@@ -562,6 +568,31 @@ msgstr "Atkreipkite dėmesį, jog bandymas gadinti Varžybų aptarnavimo sistem�
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Jeigu šią klaidą gavote normaliai naudodamiesi sistema, prašome pranešti varžybų administratoriams."
+
+msgid "Public score"
+msgstr "Vieši taškai"
+
+msgid "Total score"
+msgstr "Visi taškai"
+
+msgid "Score"
+msgstr "Taškai"
+
+msgid "Token"
+msgstr "Žetonas"
+
+#, fuzzy
+msgid "no submissions"
+msgstr "Pateikti sprendimai"
+
+msgid "Played"
+msgstr "Panaudotas"
+
+msgid "Play!"
+msgstr "Naudoti!"
+
+msgid "No tokens"
+msgstr "Žetonų nėra"
 
 msgid "General information"
 msgstr "Bendra informacija"
@@ -748,6 +779,76 @@ msgstr "Paruošiama..."
 msgid "no print jobs yet"
 msgstr "spausdinimo darbų dar nėra"
 
+msgid "The passwords do not match!"
+msgstr ""
+
+msgid "This username is already taken, please choose a different one."
+msgstr ""
+
+msgid "This user is already registered in the contest."
+msgstr ""
+
+msgid "No such user."
+msgstr ""
+
+msgid "The password is not correct."
+msgstr ""
+
+msgid "Registration"
+msgstr ""
+
+msgid "Please fill in the fields to register"
+msgstr ""
+
+#, fuzzy
+msgid "New user"
+msgstr "Naujas atsakymas"
+
+#, fuzzy
+msgid "Join contest"
+msgstr "Pasirink varžybas"
+
+#, fuzzy
+msgid "First name"
+msgstr "Failo vardas"
+
+#, fuzzy
+msgid "Last name"
+msgstr "Failo vardas"
+
+#, fuzzy
+msgid "E-mail"
+msgstr "išsamiai"
+
+#, fuzzy
+msgid "Representing"
+msgstr "Spausdinimas"
+
+#, python-format
+msgid "Must be one character or more."
+msgid_plural "Must be %(min_length)s characters or more."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, fuzzy
+msgid "Confirm password"
+msgstr "Slaptažodis"
+
+msgid "Registered in the contest successfully!"
+msgstr ""
+
+#, fuzzy
+msgid "Your username is:"
+msgstr "Vartotojo vardas"
+
+msgid "Your password is stored securely."
+msgstr ""
+
+#, fuzzy
+msgid "Back to login"
+msgstr "Prisijungti nepavyko."
+
 msgid "Compilation output"
 msgstr "Kompiliavimo išvestis"
 
@@ -886,6 +987,14 @@ msgstr "Šiuo metu neturi žetonų šiam uždaviniui."
 msgid "But you will have to wait until %(expiration_time)s to use it."
 msgstr "Tačiau turi palaukti iki %(expiration_time)s, kad galėtum jį naudoti."
 
+#, fuzzy
+msgid "Unofficial submissions"
+msgstr "Pateikti sprendimai"
+
+#, fuzzy
+msgid "Official submissions"
+msgstr "Pateikti sprendimai"
+
 msgid "Submission details"
 msgstr "Pateikto sprendimo detalės"
 
@@ -929,24 +1038,32 @@ msgstr "Laukite..."
 msgid "None"
 msgstr "Nėra"
 
-msgid "Public score"
-msgstr "Vieši taškai"
+msgid "Token request discarded"
+msgstr "Žetono užklausa atmesta"
 
-msgid "Total score"
-msgstr "Visi taškai"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Tavo užklausa atmesta, kadangi neturi žetonų."
 
-msgid "Score"
-msgstr "Taškai"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Užklausa buvo atmesta, kadangi šiam sprendimui žetoną jau naudojai."
 
-msgid "Token"
-msgstr "Žetonas"
+#, fuzzy
+msgid "Invalid file"
+msgstr "Netinkamas formatas!"
 
-msgid "Played"
-msgstr "Panaudotas"
+#, fuzzy
+msgid "Print job has too many pages"
+msgstr "Nepavyko išsaugoti spausdinimo darbo!"
 
-msgid "Play!"
-msgstr "Naudoti!"
+msgid "Sent to printer"
+msgstr ""
 
-msgid "No tokens"
-msgstr "Žetonų nėra"
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "Vykdymas nutrauktas (tai galėjo įvykti viršijus atminties ribojimus)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "Tavo sprendimo vykdymas buvo nutrauktas signalu. Viena iš galimų priežasčių yra atminties ribojimo viršijimas. Sprendimo informacijos lange rodomas panaudotos atminties kiekis yra toks, koks jis buvo prieš signalą sukėlusį veiksmą."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Standartinė šablonų biblioteka"
 

--- a/cms/locale/lv/LC_MESSAGES/cms.po
+++ b/cms/locale/lv/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: lv_LV\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: lv_LV TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "Nav pieejams"
 
-msgid "Correct"
-msgstr "Pareizs"
-
 msgid "Not correct"
 msgstr "Nepareizs"
+
+msgid "Correct"
+msgstr "Pareizs"
 
 msgid "Partially correct"
 msgstr "Daļēji pareizs"
 
-msgid "Outcome"
-msgstr "Iznākums"
-
 msgid "#"
 msgstr "Nr."
+
+msgid "Outcome"
+msgstr "Iznākums"
 
 msgid "Details"
 msgstr "Detaļas"
@@ -107,11 +110,20 @@ msgstr "Pārsniegts izpildes laiks (pārsniegts reālā laika ierobežojums)"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "Jūsu iesūtījums kopumā ir patērējis pārāk daudz laika. Tas var būt noticis, piemēram, nedefinētas koda uzvedības vai bufera pārpildīšanās dēļ. Šādos gadījumos iesūtījuma detaļās norādītais procesora laiks var būt ievērojami mazāks nekā izpildes laika ierobežojums."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "Izpilde pārtraukta (to var būt izraisījusi atmiņas ierobežojumu neievērošana)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Atmiņas ierobežojums"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "Izpilde tika pārtraukta ar signālu. Citu iemeslu starpā, to varētu būt izraisījusi atmiņas ierobežojuma pārsniegšana. Šajā gadījumā atmiņas patēriņš, kas ir redzams iesūtījuma detaļās, atbilst stāvoklim pirms signālu izraisījušās atmiņas iedalīšanas."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Jūsu iesūtījums izmantojis pārāk daudz procesora laika."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Pārsniegts izpildes laiks"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "Izpilde ir nesekmīga, jo atgriešanās kods nav nulle"
@@ -194,15 +206,15 @@ msgstr[1] "līdz ne vairāk kā %(gen_max)d %(type_pl)s."
 msgstr[2] "līdz ne vairāk kā %(gen_max)d %(type_pl)s."
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Jums netiek piešķirti citi %(type_pl)s."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "jums tiek piešķirts vēl %(gen_number)d %(type_s)s."
 msgstr[1] "jums tiek piešķirti vēl %(gen_number)d %(type_pl)s."
 msgstr[2] "jums tiek piešķirti vēl %(gen_number)d %(type_pl)s."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Jums netiek piešķirti citi %(type_pl)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -234,41 +246,6 @@ msgstr[2] "Kopumā jūs varat lietot ne vairāk kā %(max_number)d %(type_pl)s."
 
 msgid "You have no limitations on how you use them."
 msgstr "Jūs varat izmantot tos bez ierobežojumiem."
-
-msgid "Too many print jobs!"
-msgstr "Pārāk daudz drukas uzdevumu!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Jūs esat sasniedzis maksimāli pieļaujamo drukas uzdevumu ierobežojumu (%d)."
-
-msgid "Invalid format!"
-msgstr "Nepareizs formāts!"
-
-msgid "Please select the correct files."
-msgstr "Lūdzu, izvēlieties pareizās datnes."
-
-msgid "File too big!"
-msgstr "Datne pārāk liela!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Katras datnes lielums nedrīkst pārsniegt %d baitus."
-
-msgid "Print job storage failed!"
-msgstr "Drukas uzdevumu glabātuvē ir radusies kļūme!"
-
-msgid "Please try again."
-msgstr "Lūdzu, mēģiniet vēlreiz."
-
-msgid "Token request discarded"
-msgstr "Žetona pieprasījums noraidīts"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Jūsu pieprasījums ir noraidīts, jo jums nav žetonu."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Jūsu pieprasījums ir noraidīts, jo jūs jau izmantojāt žetonu šim iesūtījumam."
 
 msgid "Question received"
 msgstr "Jautājums saņemts"
@@ -303,11 +280,11 @@ msgstr "Izpildīts"
 msgid "status"
 msgstr "statuss"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Jūsu pieprasījums ir saņemts un pielietots iesūtījumam."
-
 msgid "Token request received"
 msgstr "Žetona pieprasījums saņemts"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Jūsu pieprasījums ir saņemts un pielietots iesūtījumam."
 
 msgid "Test received"
 msgstr "Tests saņemts"
@@ -323,6 +300,32 @@ msgstr "Izpilda…"
 
 msgid "Executed"
 msgstr "Izpildīts"
+
+msgid "Too many print jobs!"
+msgstr "Pārāk daudz drukas uzdevumu!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Jūs esat sasniedzis maksimāli pieļaujamo drukas uzdevumu ierobežojumu (%d)."
+
+msgid "Invalid format!"
+msgstr "Nepareizs formāts!"
+
+msgid "Please select the correct files."
+msgstr "Lūdzu, izvēlieties pareizās datnes."
+
+msgid "File too big!"
+msgstr "Datne pārāk liela!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Katras datnes lielums nedrīkst pārsniegt %d baitus."
+
+msgid "Print job storage failed!"
+msgstr "Drukas uzdevumu glabātuvē ir radusies kļūme!"
+
+msgid "Please try again."
+msgstr "Lūdzu, mēģiniet vēlreiz."
 
 msgid "Too many submissions!"
 msgstr "Pārāk daudz iesūtījumu!"
@@ -346,6 +349,17 @@ msgstr "Jebkura uzdevuma risinājumu jūs drīkstat iesūtīt %d sekundes pēc i
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Šī uzdevuma risinājumu jūs drīkstat iesūtīt %d sekundes pēc iepriekšējā iesūtījuma."
 
+msgid "Submission too big!"
+msgstr "Iesūtījums pārāk liels!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Katra pirmkoda datne drīkst būt ne vairāk kā %d baitus liela."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Nepareizs arhīva formāts!"
 
@@ -354,13 +368,6 @@ msgstr "Iesūtīto arhīvu nav iespējams atvērt."
 
 msgid "Invalid submission format!"
 msgstr "Nepareizs iesūtījuma formāts!"
-
-msgid "Submission too big!"
-msgstr "Iesūtījums pārāk liels!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Katra pirmkoda datne drīkst būt ne vairāk kā %d baitus liela."
 
 msgid "Submission storage failed!"
 msgstr "Iesūtījumu glabātuvē ir radusies kļūme!"
@@ -484,11 +491,11 @@ msgstr "%d nelasītas"
 msgid "Until contest starts:"
 msgstr "Līdz sacensību sākumam:"
 
-msgid "Until analysis starts:"
-msgstr "Līdz analīzes režīma sākumam:"
-
 msgid "Until contest ends:"
 msgstr "Līdz sacensību beigām:"
+
+msgid "Until analysis starts:"
+msgstr "Līdz analīzes režīma sākumam:"
 
 msgid "Until analysis ends:"
 msgstr "Līdz analīzes režīma beigām:"
@@ -532,9 +539,6 @@ msgstr "Izvēlieties sacensības"
 msgid "Programming languages and libraries"
 msgstr "Programmēšanas valodas un bibliotēkas"
 
-msgid "Standard Template Library"
-msgstr "Standarta šablonu bibliotēka (STL)"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "Risinājuma galvenās Java klases nosaukumam ir jāsakrīt ar uzdevuma nosaukumu."
 
@@ -562,6 +566,30 @@ msgstr "Iedarbošanās uz testēšanas sistēmu neatļautā veidā (piemēram, m
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Ja jūs saskārāties ar šo kļūdu parastā situācijā, lūdzu, informējiet sacensību administratorus."
+
+msgid "Public score"
+msgstr "Publiski redzamais rezultāts"
+
+msgid "Total score"
+msgstr "Kopējais rezultāts"
+
+msgid "Score"
+msgstr "Rezultāts"
+
+msgid "Token"
+msgstr "Žetons"
+
+msgid "no submissions"
+msgstr "nav iesūtījumu"
+
+msgid "Played"
+msgstr "Izmantots"
+
+msgid "Play!"
+msgstr "Izmantot!"
+
+msgid "No tokens"
+msgstr "Nav žetonu"
 
 msgid "General information"
 msgstr "Vispārīga informācija"
@@ -996,29 +1024,14 @@ msgstr "Gaidiet…"
 msgid "None"
 msgstr "Nav"
 
-msgid "Public score"
-msgstr "Publiski redzamais rezultāts"
+msgid "Token request discarded"
+msgstr "Žetona pieprasījums noraidīts"
 
-msgid "Total score"
-msgstr "Kopējais rezultāts"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Jūsu pieprasījums ir noraidīts, jo jums nav žetonu."
 
-msgid "Score"
-msgstr "Rezultāts"
-
-msgid "Token"
-msgstr "Žetons"
-
-msgid "no submissions"
-msgstr "nav iesūtījumu"
-
-msgid "Played"
-msgstr "Izmantots"
-
-msgid "Play!"
-msgstr "Izmantot!"
-
-msgid "No tokens"
-msgstr "Nav žetonu"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Jūsu pieprasījums ir noraidīts, jo jūs jau izmantojāt žetonu šim iesūtījumam."
 
 msgid "Invalid file"
 msgstr "Nepareiza datne"
@@ -1028,4 +1041,13 @@ msgstr "Drukas uzdevumam ir pārāk daudz lappušu"
 
 msgid "Sent to printer"
 msgstr "Nosūtīts drukāšanai"
+
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "Izpilde pārtraukta (to var būt izraisījusi atmiņas ierobežojumu neievērošana)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "Izpilde tika pārtraukta ar signālu. Citu iemeslu starpā, to varētu būt izraisījusi atmiņas ierobežojuma pārsniegšana. Šajā gadījumā atmiņas patēriņš, kas ir redzams iesūtījuma detaļās, atbilst stāvoklim pirms signālu izraisījušās atmiņas iedalīšanas."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Standarta šablonu bibliotēka (STL)"
 

--- a/cms/locale/nl/LC_MESSAGES/cms.po
+++ b/cms/locale/nl/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: nl_NL\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: nl_NL TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "Niet beschikbaar"
 
-msgid "Correct"
-msgstr "Correct"
-
 msgid "Not correct"
 msgstr "Niet correct"
+
+msgid "Correct"
+msgstr "Correct"
 
 msgid "Partially correct"
 msgstr "Deels correct"
 
-msgid "Outcome"
-msgstr "Uitkomst"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "Uitkomst"
 
 msgid "Details"
 msgstr "Details"
@@ -107,11 +110,20 @@ msgstr "Time-out bij uitvoering (harde tijdslimiet overschreden)"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "Je inzending gebruikte teveel tijd in totaal. Dit kan het gevolg zijn van, bijvoorbeeld, ongedefinieerde code of buffer overflow. Merk op dat in dit geval de CPU-tijd die zichtbaar is bij de details van de inzending veel kleiner kan zijn dan de tijdslimiet."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "Uitvoering beëindigt (kan veroorzaakt woorden voor geheugenlimieten te overschrijden)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Geheugenlimiet"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "De uitvoering werd beëindigd door een signaal. Dit kan onder andere veroorzaakt worden door het overschrijden van de geheugenlimiet. Als dit de reden is, is het geheugengebruik, voor de allocatie die het signaal veroorzaakte, zichtbaar in de details van de inzending."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Je inzending gebruikte teveel CPU tijd."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Time-out bij uitvoering"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "Uitvoering mislukt omdat de return code niet nul was"
@@ -190,14 +202,14 @@ msgstr[0] "tot een maximum van een %(type_s)s."
 msgstr[1] "tot een maximum van %(gen_max)d %(type_pl)s."
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Je krijgt geen andere %(type_pl)s."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "krijg je nog een %(type_s)s."
 msgstr[1] "krijg je %(gen_number)d %(type_pl)s erbij."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Je krijgt geen andere %(type_pl)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -225,41 +237,6 @@ msgstr[1] "Je kan niet meer dan %(max_number)d %(type_pl)s in totaal gebruiken."
 
 msgid "You have no limitations on how you use them."
 msgstr "Er zijn geen beperkingen op hoe je ze gebruikt."
-
-msgid "Too many print jobs!"
-msgstr "Te veel printopdrachten!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Je hebt de maximumlimiet van %d printopdrachten bereikt."
-
-msgid "Invalid format!"
-msgstr "Ongeldig formaat!"
-
-msgid "Please select the correct files."
-msgstr "Selecteer de correcte bestanden aub."
-
-msgid "File too big!"
-msgstr "Bestand te groot!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Elk bestand mag maximaal %d bytes groot zijn."
-
-msgid "Print job storage failed!"
-msgstr "Kon de printopdracht niet registreren!"
-
-msgid "Please try again."
-msgstr "Probeer opnieuw aub."
-
-msgid "Token request discarded"
-msgstr "Aanvraag token afgewezen"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Je aanvraag werd afgewezen omdat je geen tokens beschikbaar hebt."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Je aanvraag werd afgewezen omdat je al een token gebruikte voor deze inzending."
 
 msgid "Question received"
 msgstr "Vraag ontvangen"
@@ -294,11 +271,11 @@ msgstr "Geëvalueerd"
 msgid "status"
 msgstr "status"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Je aanvraag werd ontvangen en toegepast op de inzending."
-
 msgid "Token request received"
 msgstr "Aanvraag token ontvangen"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Je aanvraag werd ontvangen en toegepast op de inzending."
 
 msgid "Test received"
 msgstr "Test ontvangen"
@@ -314,6 +291,32 @@ msgstr "Bezig met uitvoeren..."
 
 msgid "Executed"
 msgstr "Uitgevoerd"
+
+msgid "Too many print jobs!"
+msgstr "Te veel printopdrachten!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Je hebt de maximumlimiet van %d printopdrachten bereikt."
+
+msgid "Invalid format!"
+msgstr "Ongeldig formaat!"
+
+msgid "Please select the correct files."
+msgstr "Selecteer de correcte bestanden aub."
+
+msgid "File too big!"
+msgstr "Bestand te groot!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Elk bestand mag maximaal %d bytes groot zijn."
+
+msgid "Print job storage failed!"
+msgstr "Kon de printopdracht niet registreren!"
+
+msgid "Please try again."
+msgstr "Probeer opnieuw aub."
 
 msgid "Too many submissions!"
 msgstr "Te veel inzendingen!"
@@ -337,6 +340,17 @@ msgstr "Voor alle taken samen, kan je opnieuw indienen na %d seconden na je laat
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Voor deze taak kan je opnieuw indienen na %d seconden na je laatste inzending."
 
+msgid "Submission too big!"
+msgstr "Inzending te groot!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Elk bronbestand mag maximaal %d bytes lang zijn."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Ongeldig formaat voor archief!"
 
@@ -345,13 +359,6 @@ msgstr "Het ingediende archief kon niet worden geopend."
 
 msgid "Invalid submission format!"
 msgstr "Ongeldig formaat voor inzending!"
-
-msgid "Submission too big!"
-msgstr "Inzending te groot!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Elk bronbestand mag maximaal %d bytes lang zijn."
 
 msgid "Submission storage failed!"
 msgstr "Opslag van inzending mislukt!"
@@ -475,11 +482,11 @@ msgstr "%d ongelezen"
 msgid "Until contest starts:"
 msgstr "Totdat de wedstrijd start:"
 
-msgid "Until analysis starts:"
-msgstr "Totdat de analyse start:"
-
 msgid "Until contest ends:"
 msgstr "Totdat de wedstrijd eindigt:"
+
+msgid "Until analysis starts:"
+msgstr "Totdat de analyse start:"
 
 msgid "Until analysis ends:"
 msgstr "Totdat de analyse eindigt:"
@@ -523,9 +530,6 @@ msgstr "Kies een wedstrijd"
 msgid "Programming languages and libraries"
 msgstr "Programmeertalen en -libraries"
 
-msgid "Standard Template Library"
-msgstr "Standard Template Library"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "De main Java class van de oplossing moet exact dezelfde naam hebben als de opdracht."
 
@@ -553,6 +557,30 @@ msgstr "Elke poging om het Wedstrijdbeheersysteem te beïnvloeden (zoals het stu
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Als je deze fout tegenkomt bij normaal gebruik, verwittig dan de begeleiders van de wedstrijd."
+
+msgid "Public score"
+msgstr "Publieke score"
+
+msgid "Total score"
+msgstr "Totaalscore"
+
+msgid "Score"
+msgstr "Score"
+
+msgid "Token"
+msgstr "Token"
+
+msgid "no submissions"
+msgstr "geen inzendingen"
+
+msgid "Played"
+msgstr "Afgespeeld"
+
+msgid "Play!"
+msgstr "Afspelen!"
+
+msgid "No tokens"
+msgstr "Geen tokens"
 
 msgid "General information"
 msgstr "Algemene informatie"
@@ -986,29 +1014,14 @@ msgstr "Wachten..."
 msgid "None"
 msgstr "Geen"
 
-msgid "Public score"
-msgstr "Publieke score"
+msgid "Token request discarded"
+msgstr "Aanvraag token afgewezen"
 
-msgid "Total score"
-msgstr "Totaalscore"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Je aanvraag werd afgewezen omdat je geen tokens beschikbaar hebt."
 
-msgid "Score"
-msgstr "Score"
-
-msgid "Token"
-msgstr "Token"
-
-msgid "no submissions"
-msgstr "geen inzendingen"
-
-msgid "Played"
-msgstr "Afgespeeld"
-
-msgid "Play!"
-msgstr "Afspelen!"
-
-msgid "No tokens"
-msgstr "Geen tokens"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Je aanvraag werd afgewezen omdat je al een token gebruikte voor deze inzending."
 
 msgid "Invalid file"
 msgstr "Ongeldig bestand"
@@ -1018,4 +1031,13 @@ msgstr "Printopdracht heeft de veel paginas"
 
 msgid "Sent to printer"
 msgstr "Naar de printer verzonden"
+
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "Uitvoering beëindigt (kan veroorzaakt woorden voor geheugenlimieten te overschrijden)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "De uitvoering werd beëindigd door een signaal. Dit kan onder andere veroorzaakt worden door het overschrijden van de geheugenlimiet. Als dit de reden is, is het geheugengebruik, voor de allocatie die het signaal veroorzaakte, zichtbaar in de details van de inzending."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Standard Template Library"
 

--- a/cms/locale/ro/LC_MESSAGES/cms.po
+++ b/cms/locale/ro/LC_MESSAGES/cms.po
@@ -1,27 +1,33 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: ro_RO\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: ro_RO TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "N/A"
 
-msgid "Correct"
-msgstr "Corect"
-
 msgid "Not correct"
 msgstr "Gresit"
 
+msgid "Correct"
+msgstr "Corect"
+
 msgid "Partially correct"
 msgstr "Solutie partiala"
+
+msgid "#"
+msgstr ""
 
 msgid "Outcome"
 msgstr "Rezultatul"
@@ -34,6 +40,13 @@ msgstr "Timpul de executie"
 
 msgid "Memory used"
 msgstr "Memoria utilizata"
+
+msgid "Score details temporarily unavailable."
+msgstr ""
+
+#, python-format
+msgid "Subtask %(index)s"
+msgstr ""
 
 msgid "Compilation succeeded"
 msgstr "Compilare reusita"
@@ -52,6 +65,10 @@ msgstr "Depasirea timpului alocat pentru compilare"
 
 msgid "Your submission exceeded the time limit while compiling. This might be caused by an excessive use of C++ templates, for example."
 msgstr "Expedierea a depasit limita de timp la compilare.Aceasta ar putea ficauzata de utilizarea excesiva a template-urilor C++, de exemplu."
+
+#, python-format
+msgid "Compilation killed with signal %s (could be triggered by violating memory limits)"
+msgstr ""
 
 msgid "Your submission was killed with the specified signal. Among other things, this might be caused by exceeding the memory limit for the compilation, and in turn by an excessive use of C++ templates, for example."
 msgstr "Expedierea a fost intrerupta cu semnalul specificat. Printre altele, acest lucru ar putea fi cauzat de depasirea limitei de memorie pentru compilare si, la rindul sau, de utilizarea excesiva a template-urilor utilizate in C++, de exemplu."
@@ -90,6 +107,24 @@ msgstr "Programul expediat utilizeaza prea mult timp al procesorului."
 msgid "Execution timed out (wall clock limit exceeded)"
 msgstr "Depasirea timpului de executie (wall clock limit exceeded)"
 
+msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
+msgstr ""
+
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Restrictia de memorie"
+
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Programul expediat utilizeaza prea mult timp al procesorului."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Depasirea timpului de executie"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
+
 msgid "Execution failed because the return code was nonzero"
 msgstr "Executia a esuat, deoarece codur de retur a fost nonzero"
 
@@ -104,6 +139,36 @@ msgstr "Compilarea nu este necesara"
 
 msgid "File not submitted"
 msgstr "Fisierul nu a fost expediat"
+
+msgid "Question too long!"
+msgstr ""
+
+#, python-format
+msgid "Subject must be at most %(max_subject_length)d characters, content at most %(max_text_length)d."
+msgstr ""
+
+msgid "contest-token"
+msgstr ""
+
+#, fuzzy
+msgid "contest-tokens"
+msgstr "Nu sint token-e"
+
+#, fuzzy
+msgid "task-token"
+msgstr "Token-e"
+
+#, fuzzy
+msgid "task-tokens"
+msgstr "Token-e"
+
+#, fuzzy
+msgid "token"
+msgstr "Token-e"
+
+#, fuzzy
+msgid "tokens"
+msgstr "Token-e"
 
 #, python-format
 msgid "You don't have %(type_pl)s available for this task."
@@ -146,15 +211,15 @@ msgstr[1] "pina la maxim %(gen_max)d %(type_pl)s."
 msgstr[2] ""
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Nu puteti primi alte %(type_pl)s."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "obtineti inca %(type_s)s."
 msgstr[1] "obtineti inca %(gen_number)d din %(type_pl)s."
 msgstr[2] ""
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Nu puteti primi alte %(type_pl)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -187,11 +252,18 @@ msgstr[2] ""
 msgid "You have no limitations on how you use them."
 msgstr "Nu aveti limite de utilizare a acestora."
 
-msgid "Please try again."
-msgstr "Va rugam sa mai incercati"
-
 msgid "Question received"
 msgstr "Intrebarea a fost primita"
+
+msgid "Your question has been received, you will be notified when it is answered."
+msgstr ""
+
+#, fuzzy
+msgid "Print job received"
+msgstr "Intrebarea a fost primita"
+
+msgid "Your print job has been received."
+msgstr ""
 
 msgid "Submission received"
 msgstr "Expediere cu succes"
@@ -211,11 +283,76 @@ msgstr "Punctare..."
 msgid "Evaluated"
 msgstr "Evaluat"
 
+#, fuzzy
+msgid "status"
+msgstr "Statut"
+
+#, fuzzy
+msgid "Token request received"
+msgstr "Intrebarea a fost primita"
+
+msgid "Your request has been received and applied to the submission."
+msgstr ""
+
+#, fuzzy
+msgid "Test received"
+msgstr "Intrebarea a fost primita"
+
+#, fuzzy
+msgid "Your test has been received and is currently being executed."
+msgstr "Programul a fost receptionat si se evalueaza."
+
 msgid "details"
 msgstr "detalii"
 
+#, fuzzy
+msgid "Executing..."
+msgstr "Evaluare..."
+
+#, fuzzy
+msgid "Executed"
+msgstr "Timpul de executie"
+
+#, fuzzy
+msgid "Too many print jobs!"
+msgstr "Prea multe  teste!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr ""
+
+#, fuzzy
+msgid "Invalid format!"
+msgstr "Format nevalid pentru arhiva!"
+
+msgid "Please select the correct files."
+msgstr ""
+
+#, fuzzy
+msgid "File too big!"
+msgstr "Eroare de logare"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr ""
+
+#, fuzzy
+msgid "Print job storage failed!"
+msgstr "Gresala de stocare a fisierului!"
+
+msgid "Please try again."
+msgstr "Va rugam sa mai incercati"
+
 msgid "Too many submissions!"
 msgstr "Prea multe expedieri!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d submissions among all tasks."
+msgstr ""
+
+#, fuzzy, python-format
+msgid "You have reached the maximum limit of at most %d submissions on this task."
+msgstr "Puteti expedia nu mai mult de %(submissions)s solutii in acest concurs."
 
 msgid "Submissions too frequent!"
 msgstr "Expedieri prea dese!"
@@ -228,8 +365,23 @@ msgstr "Pentru toate sarcinile, puteti face trimiteri din nou dupa %d secunde de
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Pentru aceasta sarcina, puteti face trimitere din nou dupa %d secunde de la ultima expediere."
 
+#, fuzzy
+msgid "Submission too big!"
+msgstr "Expedieri prea dese!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr ""
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Format nevalid pentru arhiva!"
+
+msgid "The submitted archive could not be opened."
+msgstr ""
 
 msgid "Invalid submission format!"
 msgstr "Format nevalid al expedierii!"
@@ -239,6 +391,45 @@ msgstr "Gresala de stocare a fisierului!"
 
 msgid "Too many tests!"
 msgstr "Prea multe  teste!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d tests among all tasks."
+msgstr ""
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d tests on this task."
+msgstr ""
+
+#, fuzzy
+msgid "Tests too frequent!"
+msgstr "Expedieri prea dese!"
+
+#, fuzzy, python-format
+msgid "Among all tasks, you can test again after %d seconds from last test."
+msgstr "Pentru toate sarcinile, puteti face trimiteri din nou dupa %d secunde de la ultima expediere."
+
+#, fuzzy, python-format
+msgid "For this task, you can test again after %d seconds from last test."
+msgstr "Pentru aceasta sarcina, puteti face trimitere din nou dupa %d secunde de la ultima expediere."
+
+#, fuzzy
+msgid "Invalid test format!"
+msgstr "Format nevalid pentru arhiva!"
+
+#, fuzzy
+msgid "Test too big!"
+msgstr "Testare"
+
+msgid "Input too big!"
+msgstr ""
+
+#, python-format
+msgid "The input file must be at most %d bytes long."
+msgstr ""
+
+#, fuzzy
+msgid "Test storage failed!"
+msgstr "Gresala de stocare a fisierului!"
 
 msgid "Communication"
 msgstr "Comunicarea cu juriul"
@@ -269,6 +460,10 @@ msgstr "raspunsul inca nu este"
 
 msgid "Messages"
 msgstr "Mesaje"
+
+#, python-format
+msgid "Automatic (%(lang)s)"
+msgstr ""
 
 msgid "Logout"
 msgstr "Iesire"
@@ -320,6 +515,14 @@ msgstr "Pina la inceputul olimpiadei:"
 msgid "Until contest ends:"
 msgstr "Pina la sfirsitul olimpiadei:"
 
+#, fuzzy
+msgid "Until analysis starts:"
+msgstr "Pina la inceputul olimpiadei:"
+
+#, fuzzy
+msgid "Until analysis ends:"
+msgstr "Pina la sfirsitul olimpiadei:"
+
 msgid "Time left:"
 msgstr "Timpul ramas"
 
@@ -359,14 +562,22 @@ msgstr "Alege un concurs"
 msgid "Programming languages and libraries"
 msgstr "Limbaje de programare si biblioteci"
 
-msgid "Standard Template Library"
-msgstr "Standard Template Library"
+msgid "The main Java class of the solution should have exactly the same name as the task."
+msgstr ""
+
+#, fuzzy
+msgid "Submission details for compilation"
+msgstr "Detaliile expedierii"
 
 msgid "Message"
 msgstr "Mesaje"
 
 msgid "Explanation"
 msgstr "Explicatii"
+
+#, fuzzy
+msgid "Submission details for evaluation"
+msgstr "Detaliile expedierii"
 
 #, python-format
 msgid "Error %(status_code)s"
@@ -380,6 +591,32 @@ msgstr "Atentie, incercarile de a incalca/manipula sistemul (cum ar fi ondarea s
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Daca in timpul licrului ati intilnit o eroare de sistem, va rugam sa anuntati administratorul."
+
+msgid "Public score"
+msgstr "Scorul public"
+
+msgid "Total score"
+msgstr "Scorul total"
+
+msgid "Score"
+msgstr "Scorul"
+
+#, fuzzy
+msgid "Token"
+msgstr "Token-e"
+
+#, fuzzy
+msgid "no submissions"
+msgstr "Expedieri"
+
+msgid "Played"
+msgstr "Jucat"
+
+msgid "Play!"
+msgstr "Joaca!"
+
+msgid "No tokens"
+msgstr "Nu sint token-e"
 
 msgid "General information"
 msgstr "Informatie generala"
@@ -405,10 +642,55 @@ msgstr "Olimpiada s-a sfirsit."
 msgid "The contest started at %(start_time)s and ended at %(stop_time)s."
 msgstr "Olimpiada a inceput la  %(start_time)s si s-a sfirsit la %(stop_time)s."
 
+#, fuzzy
+msgid "The analysis mode hasn't started yet."
+msgstr "Olimpiada nu a inceput inca."
+
+#, fuzzy, python-format
+msgid "The analysis mode will start at %(start_time)s and will end at %(stop_time)s."
+msgstr "Olimpiada incepe la %(start_time)s si finiseaza la %(stop_time)s."
+
+#, fuzzy
+msgid "The analysis mode is currently running."
+msgstr "Olimpiada este in process de desfasurare."
+
+#, fuzzy, python-format
+msgid "The analysis mode started at %(start_time)s and will end at %(stop_time)s."
+msgstr "Olimpiada a incepul la  %(start_time)s si se sfirseste la %(stop_time)s."
+
+#, fuzzy
+msgid "The analysis mode has already ended."
+msgstr "Olimpiada s-a sfirsit."
+
+#, fuzzy, python-format
+msgid "The analysis mode started at %(start_time)s and ended at %(stop_time)s."
+msgstr "Olimpiada a inceput la  %(start_time)s si s-a sfirsit la %(stop_time)s."
+
 msgid "You have an infinite number of tokens."
 msgstr "Aveti un numar nelimitat de token-e."
 
 msgid "You can see the detailed result of a submission by using a token on it."
+msgstr "Puteti vizualiza rezultatele detaliate ale expedierilor, utilizint token-ul."
+
+msgid "Your score for each task will be the maximum among the tokened submissions and the last one."
+msgstr ""
+
+#, fuzzy
+msgid "You have a distinct set of tokens for each task."
+msgstr "Aveti un numar infinit de %(type_pl)s pentru aceasta sarcina."
+
+#, python-format
+msgid "You can find the rules for the %(type_pl)s on each task's description page."
+msgstr ""
+
+msgid "You have a set of tokens shared among all tasks."
+msgstr ""
+
+msgid "You have two types of tokens: a set of <em>contest-tokens</em> shared among all tasks and a distinct set of <em>task-tokens</em> for each task."
+msgstr ""
+
+#, fuzzy
+msgid "You can see the detailed result of a submission by using two tokens on it, one of each type."
 msgstr "Puteti vizualiza rezultatele detaliate ale expedierilor, utilizint token-ul."
 
 #, python-format
@@ -485,6 +767,14 @@ msgstr "Nu"
 msgid "Print"
 msgstr "Tipar"
 
+#, python-format
+msgid "You can print %(remaining_jobs)s more text or PDF files of up to %(max_pages)s pages each."
+msgstr ""
+
+#, python-format
+msgid "You can print %(remaining_jobs)s more text files of up to %(max_pages)s pages each."
+msgstr ""
+
 msgid "File (text or PDF)"
 msgstr "Fisier (text sau PDF)"
 
@@ -493,6 +783,13 @@ msgstr "Fisier (text)"
 
 msgid "Submit"
 msgstr "Expediaza"
+
+msgid "You cannot print anything any more as you have used up your printing quota."
+msgstr ""
+
+#, fuzzy
+msgid "Previous print jobs"
+msgstr "Teste precedente"
 
 msgid "Date and time"
 msgstr "Data si timpul"
@@ -508,6 +805,81 @@ msgstr "Statut"
 
 msgid "Preparing..."
 msgstr "Pregatire..."
+
+#, fuzzy
+msgid "no print jobs yet"
+msgstr "nu sunt teste"
+
+msgid "The passwords do not match!"
+msgstr ""
+
+msgid "This username is already taken, please choose a different one."
+msgstr ""
+
+msgid "This user is already registered in the contest."
+msgstr ""
+
+msgid "No such user."
+msgstr ""
+
+msgid "The password is not correct."
+msgstr ""
+
+#, fuzzy
+msgid "Registration"
+msgstr "Înregistrează-te"
+
+msgid "Please fill in the fields to register"
+msgstr ""
+
+#, fuzzy
+msgid "New user"
+msgstr "Raspuns nou"
+
+#, fuzzy
+msgid "Join contest"
+msgstr "Alege un concurs"
+
+#, fuzzy
+msgid "First name"
+msgstr "Denumire fisier"
+
+#, fuzzy
+msgid "Last name"
+msgstr "Denumire fisier"
+
+#, fuzzy
+msgid "E-mail"
+msgstr "detalii"
+
+#, fuzzy
+msgid "Representing"
+msgstr "Tiparire"
+
+#, python-format
+msgid "Must be one character or more."
+msgid_plural "Must be %(min_length)s characters or more."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, fuzzy
+msgid "Confirm password"
+msgstr "Parola"
+
+msgid "Registered in the contest successfully!"
+msgstr ""
+
+#, fuzzy
+msgid "Your username is:"
+msgstr "Nume utilizator"
+
+msgid "Your password is stored securely."
+msgstr ""
+
+#, fuzzy
+msgid "Back to login"
+msgstr "Eroare de logare"
 
 msgid "Compilation output"
 msgstr "Iesire de compilare"
@@ -554,14 +926,33 @@ msgstr "Enunt in <b>%(lang)s</b>"
 msgid "Statement in %(lang)s"
 msgstr "Enunt in %(lang)s"
 
+#, fuzzy, python-format
+msgid "<b>%(lang)s</b>"
+msgstr "Enunt in <b>%(lang)s</b>"
+
+#, python-format
+msgid "%(lang)s"
+msgstr ""
+
 msgid "Some details"
 msgstr "Detalii"
 
 msgid "Compilation commands"
 msgstr "Comenzile compilarii"
 
+#, python-format
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
+msgstr ""
+
+#, fuzzy
+msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
+msgstr "Puteti vizualiza rezultatele detaliate ale expedierilor, utilizint token-ul."
+
 msgid "Attachments"
 msgstr "Atasari"
+
+msgid "unknown"
+msgstr ""
 
 msgid "loading..."
 msgstr "se incarca..."
@@ -570,15 +961,41 @@ msgstr "se incarca..."
 msgid "%(name)s (%(short_name)s) <small>submissions</small>"
 msgstr "%(name)s (%(short_name)s) <small>expedieri</small>"
 
+#, fuzzy
+msgid "Score:"
+msgstr "Scorul"
+
+#, fuzzy
+msgid "Public score:"
+msgstr "Scorul public"
+
+#, fuzzy
+msgid "Score of tokened submissions:"
+msgstr "Expedierile anterioare"
+
+#, fuzzy
+msgid "Total score:"
+msgstr "Scorul total"
+
 msgid "Submit a solution"
 msgstr "Expedierea solutiei"
+
+msgid "You may submit any subset of outputs in a single submission."
+msgstr ""
 
 #, python-format
 msgid "You can submit %(submissions_left)s more solution(s)."
 msgstr "Mai puteti trimite %(submissions_left)s solutii."
 
+#, fuzzy
+msgid "submission.zip"
+msgstr "Expedieri"
+
 msgid "Previous submissions"
 msgstr "Expedierile anterioare"
+
+msgid "Tokens are not allowed on this task."
+msgstr ""
 
 msgid "Right now, you have infinite tokens available on this task."
 msgstr "Acum pentru aceasta sarcina aveti un numar nelimitat de token-e"
@@ -600,6 +1017,22 @@ msgstr "Veti primi un token nou in %(gen_time)s."
 
 msgid "In the current situation, no more tokens will be generated."
 msgstr "In situatia actuala, nu vor mai fi generate alte token-e."
+
+#, fuzzy
+msgid "Right now, you do not have tokens available for this task."
+msgstr "Acum pentru aceasta sarcina aveti un token."
+
+#, fuzzy, python-format
+msgid "But you will have to wait until %(expiration_time)s to use it."
+msgstr "Dar le veti putea utiliza doar dupa  %(expiration_time)s."
+
+#, fuzzy
+msgid "Unofficial submissions"
+msgstr "Expedieri"
+
+#, fuzzy
+msgid "Official submissions"
+msgstr "Expedieri"
 
 msgid "Submission details"
 msgstr "Detaliile expedierii"
@@ -644,21 +1077,24 @@ msgstr "Asteptati..."
 msgid "None"
 msgstr "Lipsa"
 
-msgid "Public score"
-msgstr "Scorul public"
+msgid "Token request discarded"
+msgstr ""
 
-msgid "Total score"
-msgstr "Scorul total"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr ""
 
-msgid "Score"
-msgstr "Scorul"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr ""
 
-msgid "Played"
-msgstr "Jucat"
+msgid "Invalid file"
+msgstr ""
 
-msgid "Play!"
-msgstr "Joaca!"
+msgid "Print job has too many pages"
+msgstr ""
 
-msgid "No tokens"
-msgstr "Nu sint token-e"
+msgid "Sent to printer"
+msgstr ""
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Standard Template Library"
 

--- a/cms/locale/ru/LC_MESSAGES/cms.po
+++ b/cms/locale/ru/LC_MESSAGES/cms.po
@@ -1,27 +1,33 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: ru_RU\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: ru_RU TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "Н/Д"
 
-msgid "Correct"
-msgstr "Правильно"
-
 msgid "Not correct"
 msgstr "Неправильно"
 
+msgid "Correct"
+msgstr "Правильно"
+
 msgid "Partially correct"
 msgstr "Частичное решение"
+
+msgid "#"
+msgstr ""
 
 msgid "Outcome"
 msgstr "Результат"
@@ -104,6 +110,21 @@ msgstr "Превышено реальное время выполнения"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "Ваша посылка выполнялась слишком долго. Это могло быть вызвано переполнением буфера или неопределенным кодом. Обратите внимание, что в этом случае процессорное время в подробностях посылки может быть гораздо меньше ограничения по времени на задачу."
 
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Ограничение по памяти"
+
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Ваша посылка использовала слишком много процессорного времени."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Превышено процессорное время выполнения"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
+
 msgid "Execution failed because the return code was nonzero"
 msgstr "Ошибка во время выполнения программы"
 
@@ -118,6 +139,14 @@ msgstr "Нет необходимости компилировать"
 
 msgid "File not submitted"
 msgstr "Файл не отправлен"
+
+#, fuzzy
+msgid "Question too long!"
+msgstr "Тест слишком большой!"
+
+#, python-format
+msgid "Subject must be at most %(max_subject_length)d characters, content at most %(max_text_length)d."
+msgstr ""
 
 msgid "contest-token"
 msgstr "contest-token"
@@ -178,15 +207,15 @@ msgstr[1] "до максимально двух %(type_s)s"
 msgstr[2] "до максимально %(gen_max)d %(type_s)s"
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "У вас нет %(type_pl)s."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "вы получаете %(type_s)s."
 msgstr[1] "вы получаете 2 %(type_s)s."
 msgstr[2] "вы получаете %(gen_number)d %(type_s)s."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "У вас нет %(type_pl)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -219,41 +248,6 @@ msgstr[2] "Вы можете использовать не более %(max_numb
 msgid "You have no limitations on how you use them."
 msgstr "У вас нет ограничений по тому, как использовать их."
 
-msgid "Too many print jobs!"
-msgstr "Слишком много запросов на печать!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Вы достигли лимита запросов на печать по этой задаче, равного %d запросов."
-
-msgid "Invalid format!"
-msgstr "Неправильный формат!"
-
-msgid "Please select the correct files."
-msgstr "Пожалуйста, выберите правильные файлы."
-
-msgid "File too big!"
-msgstr "Файл слишком большой!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Размер каждого файла не должен превышать %d байт."
-
-msgid "Print job storage failed!"
-msgstr "Не удалось сохранить запрос на печать!"
-
-msgid "Please try again."
-msgstr "Пожалуйста, попробуйте еще раз."
-
-msgid "Token request discarded"
-msgstr "Запрос токена отклонен"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Ваш запрос отклонен, потому что у вас нет доступных токенов."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Ваш запрос был отклонен, потому что вы уже использовали токен на этой посылке."
-
 msgid "Question received"
 msgstr "Вопрос получен"
 
@@ -284,11 +278,15 @@ msgstr "Оценивание..."
 msgid "Evaluated"
 msgstr "Проверено"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Ваш запрос был получен и применен к посылке."
+#, fuzzy
+msgid "status"
+msgstr "Статус"
 
 msgid "Token request received"
 msgstr "Запрос токена получен"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Ваш запрос был получен и применен к посылке."
 
 msgid "Test received"
 msgstr "Тест принят"
@@ -304,6 +302,32 @@ msgstr "Выполнение..."
 
 msgid "Executed"
 msgstr "Выполнено"
+
+msgid "Too many print jobs!"
+msgstr "Слишком много запросов на печать!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Вы достигли лимита запросов на печать по этой задаче, равного %d запросов."
+
+msgid "Invalid format!"
+msgstr "Неправильный формат!"
+
+msgid "Please select the correct files."
+msgstr "Пожалуйста, выберите правильные файлы."
+
+msgid "File too big!"
+msgstr "Файл слишком большой!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Размер каждого файла не должен превышать %d байт."
+
+msgid "Print job storage failed!"
+msgstr "Не удалось сохранить запрос на печать!"
+
+msgid "Please try again."
+msgstr "Пожалуйста, попробуйте еще раз."
 
 msgid "Too many submissions!"
 msgstr "Слишком много посылок!"
@@ -327,6 +351,17 @@ msgstr "Вы можете отправлять решения по любой з
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Вы можете отправлять решения этой задачи спустя %d секунд после последней посылки."
 
+msgid "Submission too big!"
+msgstr "Размер посылки слишком большой!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Размер каждого файла не должен превышать %d байт."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Недопустимый формат архива!"
 
@@ -335,13 +370,6 @@ msgstr "Отправленный архив не открывается."
 
 msgid "Invalid submission format!"
 msgstr "Неправильный формат посылки!"
-
-msgid "Submission too big!"
-msgstr "Размер посылки слишком большой!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Размер каждого файла не должен превышать %d байт."
 
 msgid "Submission storage failed!"
 msgstr "Не удалось сохранить посылку!"
@@ -443,6 +471,13 @@ msgstr "Пароль"
 msgid "Login"
 msgstr "Войти в систему"
 
+msgid "Don't have an account?"
+msgstr ""
+
+#, fuzzy
+msgid "Register"
+msgstr "Очистить"
+
 msgid "New message"
 msgstr "Новое сообщение"
 
@@ -459,11 +494,11 @@ msgstr "%d непрочитанных"
 msgid "Until contest starts:"
 msgstr "До начала соревнования:"
 
-msgid "Until analysis starts:"
-msgstr "До начала дорешивания:"
-
 msgid "Until contest ends:"
 msgstr "До конца соревнования:"
+
+msgid "Until analysis starts:"
+msgstr "До начала дорешивания:"
 
 msgid "Until analysis ends:"
 msgstr "До конца дорешивания:"
@@ -501,11 +536,11 @@ msgstr "выпущена по лицензии"
 msgid "GNU Affero General Public License"
 msgstr "GNU Affero General Public License"
 
+msgid "Choose a contest"
+msgstr ""
+
 msgid "Programming languages and libraries"
 msgstr "Языки программирования и библиотеки"
-
-msgid "Standard Template Library"
-msgstr "Standard Template Library"
 
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "Главный класс решений на Java должен называться так же, как и задача."
@@ -534,6 +569,31 @@ msgstr "Обратите внимание, что попытки нарушит�
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Если вы столкнулись с этой ошибкой системы во время нормального использования, просьба обратиться к системным администраторам."
+
+msgid "Public score"
+msgstr "Открытый результат"
+
+msgid "Total score"
+msgstr "Результат"
+
+msgid "Score"
+msgstr "Очки"
+
+msgid "Token"
+msgstr "Токен"
+
+#, fuzzy
+msgid "no submissions"
+msgstr "Посылки"
+
+msgid "Played"
+msgstr "Сыграно"
+
+msgid "Play!"
+msgstr "Играть!"
+
+msgid "No tokens"
+msgstr "Нет токенов"
 
 msgid "General information"
 msgstr "Общая информация"
@@ -679,6 +739,14 @@ msgstr "Нет"
 msgid "Print"
 msgstr "Печать"
 
+#, python-format
+msgid "You can print %(remaining_jobs)s more text or PDF files of up to %(max_pages)s pages each."
+msgstr ""
+
+#, python-format
+msgid "You can print %(remaining_jobs)s more text files of up to %(max_pages)s pages each."
+msgstr ""
+
 msgid "File (text or PDF)"
 msgstr "Файл (текстовый или PDF)"
 
@@ -711,6 +779,75 @@ msgstr "Подготовка..."
 
 msgid "no print jobs yet"
 msgstr "нет запросов на печать"
+
+msgid "The passwords do not match!"
+msgstr ""
+
+msgid "This username is already taken, please choose a different one."
+msgstr ""
+
+msgid "This user is already registered in the contest."
+msgstr ""
+
+msgid "No such user."
+msgstr ""
+
+msgid "The password is not correct."
+msgstr ""
+
+msgid "Registration"
+msgstr ""
+
+msgid "Please fill in the fields to register"
+msgstr ""
+
+#, fuzzy
+msgid "New user"
+msgstr "Новый ответ"
+
+msgid "Join contest"
+msgstr ""
+
+#, fuzzy
+msgid "First name"
+msgstr "Имя файла"
+
+#, fuzzy
+msgid "Last name"
+msgstr "Имя файла"
+
+#, fuzzy
+msgid "E-mail"
+msgstr "подробности"
+
+#, fuzzy
+msgid "Representing"
+msgstr "Печать"
+
+#, python-format
+msgid "Must be one character or more."
+msgid_plural "Must be %(min_length)s characters or more."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, fuzzy
+msgid "Confirm password"
+msgstr "Пароль"
+
+msgid "Registered in the contest successfully!"
+msgstr ""
+
+#, fuzzy
+msgid "Your username is:"
+msgstr "Имя пользователя"
+
+msgid "Your password is stored securely."
+msgstr ""
+
+#, fuzzy
+msgid "Back to login"
+msgstr "Неудачный вход."
 
 msgid "Compilation output"
 msgstr "Вывод компилятора"
@@ -771,6 +908,10 @@ msgstr "Некоторые подробности"
 msgid "Compilation commands"
 msgstr "Команды компиляции"
 
+#, fuzzy, python-format
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
+msgstr "Вы можете найти правила для %(type_pl)s на странице каждого задания."
+
 msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
 msgstr "Помните, что для того, чтобы увидеть детальный результат посылки, вам необходимо использовать как contest-token, так и task-token для этой задачи."
 
@@ -787,8 +928,27 @@ msgstr "загрузка..."
 msgid "%(name)s (%(short_name)s) <small>submissions</small>"
 msgstr "%(name)s (%(short_name)s) <small>посылки</small>"
 
+#, fuzzy
+msgid "Score:"
+msgstr "Очки"
+
+#, fuzzy
+msgid "Public score:"
+msgstr "Открытый результат"
+
+#, fuzzy
+msgid "Score of tokened submissions:"
+msgstr "Предыдущие посылки"
+
+#, fuzzy
+msgid "Total score:"
+msgstr "Результат"
+
 msgid "Submit a solution"
 msgstr "Отправить решение"
+
+msgid "You may submit any subset of outputs in a single submission."
+msgstr ""
 
 #, python-format
 msgid "You can submit %(submissions_left)s more solution(s)."
@@ -799,6 +959,9 @@ msgstr "submission.zip"
 
 msgid "Previous submissions"
 msgstr "Предыдущие посылки"
+
+msgid "Tokens are not allowed on this task."
+msgstr ""
 
 msgid "Right now, you have infinite tokens available on this task."
 msgstr "Сейчас у вас неограниченное количество токенов для этой задачи."
@@ -827,6 +990,14 @@ msgstr "Сейчас у вас нет доступных токенов для �
 #, python-format
 msgid "But you will have to wait until %(expiration_time)s to use it."
 msgstr "Но вы сможете использовать его только после %(expiration_time)s."
+
+#, fuzzy
+msgid "Unofficial submissions"
+msgstr "Посылки"
+
+#, fuzzy
+msgid "Official submissions"
+msgstr "Посылки"
 
 msgid "Submission details"
 msgstr "Подробности посылки"
@@ -871,24 +1042,26 @@ msgstr "Подождите..."
 msgid "None"
 msgstr "Отсутсвует"
 
-msgid "Public score"
-msgstr "Открытый результат"
+msgid "Token request discarded"
+msgstr "Запрос токена отклонен"
 
-msgid "Total score"
-msgstr "Результат"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Ваш запрос отклонен, потому что у вас нет доступных токенов."
 
-msgid "Score"
-msgstr "Очки"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Ваш запрос был отклонен, потому что вы уже использовали токен на этой посылке."
 
-msgid "Token"
-msgstr "Токен"
+#, fuzzy
+msgid "Invalid file"
+msgstr "Неправильный формат!"
 
-msgid "Played"
-msgstr "Сыграно"
+#, fuzzy
+msgid "Print job has too many pages"
+msgstr "Не удалось сохранить запрос на печать!"
 
-msgid "Play!"
-msgstr "Играть!"
+msgid "Sent to printer"
+msgstr ""
 
-msgid "No tokens"
-msgstr "Нет токенов"
+#~ msgid "Standard Template Library"
+#~ msgstr "Standard Template Library"
 

--- a/cms/locale/sl/LC_MESSAGES/cms.po
+++ b/cms/locale/sl/LC_MESSAGES/cms.po
@@ -1,27 +1,33 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: sl_SI\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: sl_SI TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "Ni odgovora"
 
-msgid "Correct"
-msgstr "Pravilno"
-
 msgid "Not correct"
 msgstr "Napačno"
 
+msgid "Correct"
+msgstr "Pravilno"
+
 msgid "Partially correct"
 msgstr "Delno pravilno"
+
+msgid "#"
+msgstr ""
 
 msgid "Outcome"
 msgstr "Rezultat"
@@ -34,6 +40,9 @@ msgstr "Čas izvajanja"
 
 msgid "Memory used"
 msgstr "Porabljen spomin"
+
+msgid "Score details temporarily unavailable."
+msgstr ""
 
 #, python-format
 msgid "Subtask %(index)s"
@@ -101,6 +110,21 @@ msgstr "Čas izvajanja je potekel (dejanjska časovna omejitev je bila presežen
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "Tvoja oddaja je porabila preveč skupnega časa. To je lahko posledica nedefinirane kode ali preseženega medpomnilnika. V tem primeru je lahko procesorski čas, ki je viden pri podrobnostih o oddaji, precej manjši od dejanjske časovne omejitve."
 
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Omejitev spomina"
+
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Tvoja oddaja je porabila preveč procesorskega časa."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Čas izvajanja je potekel"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
+
 msgid "Execution failed because the return code was nonzero"
 msgstr "Izvajanje je spodletelo, ker se je končala z neničelno kodo"
 
@@ -115,6 +139,14 @@ msgstr "Prevajanje ni potrebno"
 
 msgid "File not submitted"
 msgstr "Datoteka ni bila oddana"
+
+#, fuzzy
+msgid "Question too long!"
+msgstr "Prevelik preizkus!"
+
+#, python-format
+msgid "Subject must be at most %(max_subject_length)d characters, content at most %(max_text_length)d."
+msgstr ""
 
 msgid "contest-token"
 msgstr "tekmovalni-žeton"
@@ -179,16 +211,16 @@ msgstr[2] "največ %(gen_max)d %(type_pl)s."
 msgstr[3] "največ %(gen_max)d %(type_pl)s."
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Ne dobiš več novih %(type_pl)s."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "dobiš dodaten %(type_s)s."
 msgstr[1] "dobiš dodatna %(gen_number)d %(type_ps)s."
 msgstr[2] "dobiš dodatne %(gen_number)d %(type_ps)s."
 msgstr[3] "dobiš dodatnih %(gen_number)d %(type_ps)s."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Ne dobiš več novih %(type_pl)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -225,41 +257,6 @@ msgstr[3] "Uporabiš lahko največ %(max_number)d %(type_s)sov."
 msgid "You have no limitations on how you use them."
 msgstr "Ni omejitev za uporabo."
 
-msgid "Too many print jobs!"
-msgstr "Preveč tiskalniških opravil!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Dosegel(la) si največje število %d tiskanj."
-
-msgid "Invalid format!"
-msgstr "Napačen format!"
-
-msgid "Please select the correct files."
-msgstr "Prosim izberi pravilne datoteke."
-
-msgid "File too big!"
-msgstr "Datoteka je prevelika!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Vsaka datoteka je lahko velika največ %d bajtov."
-
-msgid "Print job storage failed!"
-msgstr "Shranjevanje tiska ni uspelo!"
-
-msgid "Please try again."
-msgstr "Prosim poizkusi znova."
-
-msgid "Token request discarded"
-msgstr "Žeton je opuščen"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Tvoja zahteva je bila zavžena, ker nimaš na voljo žetonov."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Tvoja zahteva je bila zavržena, ker si pri tej oddaji že uporabil žeton."
-
 msgid "Question received"
 msgstr "Vprašanje je bilo prejeto"
 
@@ -290,11 +287,15 @@ msgstr "Točkujem..."
 msgid "Evaluated"
 msgstr "Ovrednoteno"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Tvoja zahteva je bila sprejeta in je dodana k oddaji."
+#, fuzzy
+msgid "status"
+msgstr "Stanje"
 
 msgid "Token request received"
 msgstr "Zahteva žetona je sprejeta"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Tvoja zahteva je bila sprejeta in je dodana k oddaji."
 
 msgid "Test received"
 msgstr "Preizkus sprejet"
@@ -310,6 +311,32 @@ msgstr "Izvajam..."
 
 msgid "Executed"
 msgstr "Izvedeno"
+
+msgid "Too many print jobs!"
+msgstr "Preveč tiskalniških opravil!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Dosegel(la) si največje število %d tiskanj."
+
+msgid "Invalid format!"
+msgstr "Napačen format!"
+
+msgid "Please select the correct files."
+msgstr "Prosim izberi pravilne datoteke."
+
+msgid "File too big!"
+msgstr "Datoteka je prevelika!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Vsaka datoteka je lahko velika največ %d bajtov."
+
+msgid "Print job storage failed!"
+msgstr "Shranjevanje tiska ni uspelo!"
+
+msgid "Please try again."
+msgstr "Prosim poizkusi znova."
 
 msgid "Too many submissions!"
 msgstr "Preveč oddaj!"
@@ -333,6 +360,17 @@ msgstr "Nasednjo oddajo lahko opraviš %d sekund po zadnji oddaji."
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Nasednjo oddajo za to nalogo lahko opraviš %d sekund po zadnji oddaji."
 
+msgid "Submission too big!"
+msgstr "Prevelika oddaja!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Vsaka izvorna datoteka je lahko velika največ %d bajtov."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Napačna oblika arhiva!"
 
@@ -341,13 +379,6 @@ msgstr "Ne morem odpreti oddanega arhiva."
 
 msgid "Invalid submission format!"
 msgstr "Napačna oblika oddaje!"
-
-msgid "Submission too big!"
-msgstr "Prevelika oddaja!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Vsaka izvorna datoteka je lahko velika največ %d bajtov."
 
 msgid "Submission storage failed!"
 msgstr "Shranjevanje oddaje neuspešno!"
@@ -449,6 +480,13 @@ msgstr "Geslo"
 msgid "Login"
 msgstr "Vstopi"
 
+msgid "Don't have an account?"
+msgstr ""
+
+#, fuzzy
+msgid "Register"
+msgstr "Ponastavi"
+
 msgid "New message"
 msgstr "Novo sporočilo"
 
@@ -466,6 +504,14 @@ msgid "Until contest starts:"
 msgstr "Čas do začetka:"
 
 msgid "Until contest ends:"
+msgstr "Čas do konca:"
+
+#, fuzzy
+msgid "Until analysis starts:"
+msgstr "Čas do začetka:"
+
+#, fuzzy
+msgid "Until analysis ends:"
 msgstr "Čas do konca:"
 
 msgid "Time left:"
@@ -501,11 +547,14 @@ msgstr "je objavljen pod"
 msgid "GNU Affero General Public License"
 msgstr "GNU Affero General Public License"
 
+msgid "Choose a contest"
+msgstr ""
+
 msgid "Programming languages and libraries"
 msgstr "Programski jeziki in knjižnice"
 
-msgid "Standard Template Library"
-msgstr "Standardna predložna knjižnica"
+msgid "The main Java class of the solution should have exactly the same name as the task."
+msgstr ""
 
 msgid "Submission details for compilation"
 msgstr "Podrobnosti oddaje o prevajanju"
@@ -532,6 +581,31 @@ msgstr "Vedi, da je poseg v Contest Management System (kot je preizkušanje stre
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Če naletiš na to težavo med normalno uporabo, prosim, pošlji e-pošto na weiss.simon.1995@gmail.com ."
 
+msgid "Public score"
+msgstr "Javne točke"
+
+msgid "Total score"
+msgstr "Skupne točke"
+
+msgid "Score"
+msgstr "Točke"
+
+msgid "Token"
+msgstr "Žeton"
+
+#, fuzzy
+msgid "no submissions"
+msgstr "Oddaje"
+
+msgid "Played"
+msgstr "Igrano"
+
+msgid "Play!"
+msgstr "Igraj!"
+
+msgid "No tokens"
+msgstr "Ni žetonov"
+
 msgid "General information"
 msgstr "Splošne informacije"
 
@@ -554,6 +628,30 @@ msgstr "Tekmovanje se je že končalo."
 
 #, python-format
 msgid "The contest started at %(start_time)s and ended at %(stop_time)s."
+msgstr "Tekmovanje se bo začelo ob %(start_time)s in končalo ob %(stop_time)s."
+
+#, fuzzy
+msgid "The analysis mode hasn't started yet."
+msgstr "Tekmovanje se še ni začelo"
+
+#, fuzzy, python-format
+msgid "The analysis mode will start at %(start_time)s and will end at %(stop_time)s."
+msgstr "Tekmovanje se bo začelo ob %(start_time)s in končalo ob %(stop_time)s."
+
+#, fuzzy
+msgid "The analysis mode is currently running."
+msgstr "Tekmovanje je v teku."
+
+#, fuzzy, python-format
+msgid "The analysis mode started at %(start_time)s and will end at %(stop_time)s."
+msgstr "Tekmovanje se je začelo ob %(start_time)s in se bo končalo ob %(stop_time)s."
+
+#, fuzzy
+msgid "The analysis mode has already ended."
+msgstr "Tekmovanje se je že končalo."
+
+#, fuzzy, python-format
+msgid "The analysis mode started at %(start_time)s and ended at %(stop_time)s."
 msgstr "Tekmovanje se bo začelo ob %(start_time)s in končalo ob %(stop_time)s."
 
 msgid "You have an infinite number of tokens."
@@ -696,6 +794,76 @@ msgstr "Pripravljam..."
 msgid "no print jobs yet"
 msgstr "ni tiskalniških opravil"
 
+msgid "The passwords do not match!"
+msgstr ""
+
+msgid "This username is already taken, please choose a different one."
+msgstr ""
+
+msgid "This user is already registered in the contest."
+msgstr ""
+
+msgid "No such user."
+msgstr ""
+
+msgid "The password is not correct."
+msgstr ""
+
+msgid "Registration"
+msgstr ""
+
+msgid "Please fill in the fields to register"
+msgstr ""
+
+#, fuzzy
+msgid "New user"
+msgstr "Nov odgovor"
+
+msgid "Join contest"
+msgstr ""
+
+#, fuzzy
+msgid "First name"
+msgstr "Ime datoteke"
+
+#, fuzzy
+msgid "Last name"
+msgstr "Ime datoteke"
+
+#, fuzzy
+msgid "E-mail"
+msgstr "podrobnosti"
+
+#, fuzzy
+msgid "Representing"
+msgstr "Tiskanje"
+
+#, python-format
+msgid "Must be one character or more."
+msgid_plural "Must be %(min_length)s characters or more."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#, fuzzy
+msgid "Confirm password"
+msgstr "Geslo"
+
+msgid "Registered in the contest successfully!"
+msgstr ""
+
+#, fuzzy
+msgid "Your username is:"
+msgstr "Uporabniško ime"
+
+msgid "Your password is stored securely."
+msgstr ""
+
+#, fuzzy
+msgid "Back to login"
+msgstr "Prijava ni uspela."
+
 msgid "Compilation output"
 msgstr "Izhod prevajalnika"
 
@@ -755,11 +923,18 @@ msgstr "Nekaj podrobnosti"
 msgid "Compilation commands"
 msgstr "Ukazi za prevajanje"
 
+#, fuzzy, python-format
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
+msgstr "Pravila o %(type_pl)sh najdeš na strani pri opisu vsake naloge."
+
 msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
 msgstr "Če želiš videti podrobnejši izzid oddaje, moraš uporabiti oba žetona."
 
 msgid "Attachments"
 msgstr "Priponke"
+
+msgid "unknown"
+msgstr ""
 
 msgid "loading..."
 msgstr "nalagam..."
@@ -768,8 +943,27 @@ msgstr "nalagam..."
 msgid "%(name)s (%(short_name)s) <small>submissions</small>"
 msgstr "%(name)s (%(short_name)s) <small>oddaje</small>"
 
+#, fuzzy
+msgid "Score:"
+msgstr "Točke"
+
+#, fuzzy
+msgid "Public score:"
+msgstr "Javne točke"
+
+#, fuzzy
+msgid "Score of tokened submissions:"
+msgstr "Predhodne oddaje"
+
+#, fuzzy
+msgid "Total score:"
+msgstr "Skupne točke"
+
 msgid "Submit a solution"
 msgstr "Oddaj rešitev"
+
+msgid "You may submit any subset of outputs in a single submission."
+msgstr ""
 
 #, python-format
 msgid "You can submit %(submissions_left)s more solution(s)."
@@ -780,6 +974,9 @@ msgstr "oddaja.zip"
 
 msgid "Previous submissions"
 msgstr "Predhodne oddaje"
+
+msgid "Tokens are not allowed on this task."
+msgstr ""
 
 msgid "Right now, you have infinite tokens available on this task."
 msgstr "Trenutno imaš na voljo neomejeno število žetonov za to nalogo."
@@ -808,6 +1005,14 @@ msgstr "Trenutno nimaš na voljo nobenega žetona za to nalogo."
 #, python-format
 msgid "But you will have to wait until %(expiration_time)s to use it."
 msgstr "Vendar moraš počakati do %(expiration_time)s, da ga lahko uporabiš."
+
+#, fuzzy
+msgid "Unofficial submissions"
+msgstr "Oddaje"
+
+#, fuzzy
+msgid "Official submissions"
+msgstr "Oddaje"
 
 msgid "Submission details"
 msgstr "Podrobnosti oddaje"
@@ -852,24 +1057,26 @@ msgstr "Počakaj..."
 msgid "None"
 msgstr "Brez"
 
-msgid "Public score"
-msgstr "Javne točke"
+msgid "Token request discarded"
+msgstr "Žeton je opuščen"
 
-msgid "Total score"
-msgstr "Skupne točke"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Tvoja zahteva je bila zavžena, ker nimaš na voljo žetonov."
 
-msgid "Score"
-msgstr "Točke"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Tvoja zahteva je bila zavržena, ker si pri tej oddaji že uporabil žeton."
 
-msgid "Token"
-msgstr "Žeton"
+#, fuzzy
+msgid "Invalid file"
+msgstr "Napačen format!"
 
-msgid "Played"
-msgstr "Igrano"
+#, fuzzy
+msgid "Print job has too many pages"
+msgstr "Shranjevanje tiska ni uspelo!"
 
-msgid "Play!"
-msgstr "Igraj!"
+msgid "Sent to printer"
+msgstr ""
 
-msgid "No tokens"
-msgstr "Ni žetonov"
+#~ msgid "Standard Template Library"
+#~ msgstr "Standardna predložna knjižnica"
 

--- a/cms/locale/th/LC_MESSAGES/cms.po
+++ b/cms/locale/th/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: th\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: th TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "N/A"
 
-msgid "Correct"
-msgstr "ถูกต้อง"
-
 msgid "Not correct"
 msgstr "ไม่ถูกต้อง"
+
+msgid "Correct"
+msgstr "ถูกต้อง"
 
 msgid "Partially correct"
 msgstr "ได้คะแนนบางส่วน"
 
-msgid "Outcome"
-msgstr "ผลลัพธ์"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "ผลลัพธ์"
 
 msgid "Details"
 msgstr "รายละเอียด"
@@ -107,11 +110,20 @@ msgstr "Execution timed out (wall clock limit exceeded)"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "โปรแกรมของคุณใช้เวลาประมวลผลนานเกินไป อาจเป็นเพราะโค้ด undefined หรือเกิด buffer overflow"
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "การคอมไพล์ถูกหยุด (อาจเป็นเพราะใช้หน่วยความจำมากเกินไป)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "ข้อจำกัดหน่วยความจำ"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "การส่งของคุณถูกหยุด ซึ่งอาจเป็นเพราะใช้หน่วยความจำในการคอมไพล์มากเกินไป ซึ่งหากใช้หน่วยความจำมากเกินไปจริง โปรแกรมจะแสดงผลขนาดหน่วยความจำก่อนที่จะเกินหน่วยความจำสูงสุด"
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "การส่งของคุณใช้เวลาประมวลของ CPU ผลนานเกินไป"
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "ใช้เวลาประมวลผลนานเกินไป"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "การรันไม่สำเร็จ เพราะโปรแกรมคืนค่าที่ไม่ใช่ศูนย์"
@@ -153,9 +165,17 @@ msgstr "โทเค็น"
 msgid "tokens"
 msgstr "โทเค็น"
 
+#, fuzzy, python-format
+msgid "You don't have %(type_pl)s available for this task."
+msgstr "คุณไม่เหลือโทเคนสำหรับโจทย์นี้แล้ว"
+
 #, python-format
 msgid "You have an infinite number of %(type_pl)s for this task."
 msgstr "คุณมี %(type_pl)s จำนวนไม่จำกัดสำหรับโจทย์นี้"
+
+#, fuzzy, python-format
+msgid "You start with no %(type_pl)s."
+msgstr "คุณเริ่มต้นด้วย %(gen_initial)d %(type_pl)s."
 
 #, python-format
 msgid "You start with one %(type_s)s."
@@ -167,21 +187,48 @@ msgid "Every minute "
 msgid_plural "Every %(gen_interval)g minutes "
 msgstr[0] "ทุก %(gen_interval)g นาที "
 
-msgid "Invalid format!"
-msgstr "รูปแบบไม่ถูกต้อง!"
-
-msgid "Please select the correct files."
-msgstr "กรุณาเลือกไฟล์ที่ถูกต้อง"
-
-msgid "File too big!"
-msgstr "ไฟล์ใหญ่เกิน!"
+#, fuzzy, python-format
+msgid "you get another %(type_s)s, "
+msgid_plural "you get %(gen_number)d other %(type_pl)s, "
+msgstr[0] "คุณเริ่มต้นด้วย %(gen_initial)d %(type_pl)s."
 
 #, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "ไฟล์ใหญ่ได้สูงสุด %d ไบต์"
+msgid "up to a maximum of one %(type_s)s."
+msgid_plural "up to a maximum of %(gen_max)d %(type_pl)s."
+msgstr[0] ""
 
-msgid "Please try again."
-msgstr "กรุณาลองใหม่อีกครั้ง"
+#, fuzzy, python-format
+msgid "you get another %(type_s)s."
+msgid_plural "you get %(gen_number)d other %(type_pl)s."
+msgstr[0] "คุณเริ่มต้นด้วย %(gen_initial)d %(type_pl)s."
+
+#, fuzzy, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "คุณเริ่มต้นด้วย %(gen_initial)d %(type_pl)s."
+
+#, python-format
+msgid "You can use a %(type_s)s every second "
+msgid_plural "You can use a %(type_s)s every %(min_interval)g seconds "
+msgstr[0] ""
+
+#, fuzzy, python-format
+msgid "and no more than one %(type_s)s in total."
+msgid_plural "and no more than %(max_number)d %(type_pl)s in total."
+msgstr[0] "คุณเริ่มต้นด้วย %(gen_initial)d %(type_pl)s."
+
+#, python-format
+msgid "You can use a %(type_s)s every second."
+msgid_plural "You can use a %(type_s)s every %(min_interval)g seconds."
+msgstr[0] ""
+
+#, fuzzy, python-format
+msgid "You can use no more than one %(type_s)s in total."
+msgid_plural "You can use no more than %(max_number)d %(type_pl)s in total."
+msgstr[0] "คุณเริ่มต้นด้วย %(gen_initial)d %(type_pl)s."
+
+#, fuzzy
+msgid "You have no limitations on how you use them."
+msgstr "คุณต้องรอจนถึง %(expiration_time)s เพื่อสามารถใช้โทเคนได้"
 
 msgid "Question received"
 msgstr "ได้รับคำถามแล้ว"
@@ -216,8 +263,20 @@ msgstr "ประเมินผลแล้ว"
 msgid "status"
 msgstr "สถานะ"
 
+#, fuzzy
+msgid "Token request received"
+msgstr "ได้รับชุดทดสอบแล้ว"
+
+#, fuzzy
+msgid "Your request has been received and applied to the submission."
+msgstr "ได้รับคำถามของคุณแล้ว, เราจะแจ้งเตือนคุณเมื่อได้รับคำตอบ"
+
 msgid "Test received"
 msgstr "ได้รับชุดทดสอบแล้ว"
+
+#, fuzzy
+msgid "Your test has been received and is currently being executed."
+msgstr "ได้รับการส่งของคุณแล้วและตอนนี้กำลังประมวลผลอยู่"
 
 msgid "details"
 msgstr "รายละเอียด"
@@ -227,6 +286,34 @@ msgstr "กำลังรัน..."
 
 msgid "Executed"
 msgstr "รันแล้ว"
+
+#, fuzzy
+msgid "Too many print jobs!"
+msgstr "ชุดทดสอบเยอะเกินไป!"
+
+#, fuzzy, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "สำหรับการแข่งขันนี้ คุณได้ทดสอบครบ %d ครั้งแล้ว"
+
+msgid "Invalid format!"
+msgstr "รูปแบบไม่ถูกต้อง!"
+
+msgid "Please select the correct files."
+msgstr "กรุณาเลือกไฟล์ที่ถูกต้อง"
+
+msgid "File too big!"
+msgstr "ไฟล์ใหญ่เกิน!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "ไฟล์ใหญ่ได้สูงสุด %d ไบต์"
+
+#, fuzzy
+msgid "Print job storage failed!"
+msgstr "สั่งปริ้นท์แล้ว"
+
+msgid "Please try again."
+msgstr "กรุณาลองใหม่อีกครั้ง"
 
 msgid "Too many submissions!"
 msgstr "การส่งมากเกินไป!"
@@ -250,6 +337,17 @@ msgstr "สำหรับการแข่งขันนี้ คุณส�
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "สำหรับโจทย์ข้อนี้ คุณสามารถส่งได้ทุก ๆ %d วินาที"
 
+msgid "Submission too big!"
+msgstr "การส่งใหญ่เกินไป"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "ขนาดไฟล์แต่ละไฟล์ที่ส่งมาจะต้องมีขนาดไม่เกิน %d ไบท์"
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "ไฟล์ archive เสีย"
 
@@ -259,12 +357,9 @@ msgstr "ไฟล์ archive เปิดไม่ได้"
 msgid "Invalid submission format!"
 msgstr "การส่งไม่ตรงตาม Format"
 
-msgid "Submission too big!"
+#, fuzzy
+msgid "Submission storage failed!"
 msgstr "การส่งใหญ่เกินไป"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "ขนาดไฟล์แต่ละไฟล์ที่ส่งมาจะต้องมีขนาดไม่เกิน %d ไบท์"
 
 msgid "Too many tests!"
 msgstr "ชุดทดสอบเยอะเกินไป!"
@@ -300,6 +395,10 @@ msgstr "ข้อมูลนำเข้าใหญ่เกินไป"
 #, python-format
 msgid "The input file must be at most %d bytes long."
 msgstr "ข้อมูลนำเข้าต้องมีขนาดไม่เกิน %d ไบท์"
+
+#, fuzzy
+msgid "Test storage failed!"
+msgstr "การทดสอบใหญ่เกินไป"
 
 msgid "Communication"
 msgstr "การสื่อสาร"
@@ -382,11 +481,11 @@ msgstr "ยังไม่ได้อ่าน %d ข้อความ"
 msgid "Until contest starts:"
 msgstr "การแข่งขันจะเริ่มเวลา"
 
-msgid "Until analysis starts:"
-msgstr "โหมดการวิเคราะห์จะเริ่มเวลา"
-
 msgid "Until contest ends:"
 msgstr "การแข่งขันจะจบเวลา"
+
+msgid "Until analysis starts:"
+msgstr "โหมดการวิเคราะห์จะเริ่มเวลา"
 
 msgid "Until analysis ends:"
 msgstr "โหมดการวิเคราะห์จะจบเวลา"
@@ -430,9 +529,6 @@ msgstr "เลือกการแข่งขัน"
 msgid "Programming languages and libraries"
 msgstr "ภาษาโปรแกรมและไลบรารี่"
 
-msgid "Standard Template Library"
-msgstr "STL"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "คลาส main ของภาษา Java จะต้องใช้ชื่อเดียวกับชื่อโจทย์เท่านั้น"
 
@@ -460,6 +556,30 @@ msgstr "การพยายามแฮคระบบ Contest Management Syst
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "หากคุณพบข้อผิดพลาดนี้ระหว่างการใช้งาน โปรดแจ้งให้ผู้ดูแลการแข่งขันทราบ"
+
+msgid "Public score"
+msgstr "คะแนนสาธารณะ"
+
+msgid "Total score"
+msgstr "คะแนนรวม"
+
+msgid "Score"
+msgstr "คะแนน"
+
+msgid "Token"
+msgstr "โทเค็น"
+
+msgid "no submissions"
+msgstr "ไม่มีการส่ง"
+
+msgid "Played"
+msgstr "เล่น"
+
+msgid "Play!"
+msgstr "เล่น!"
+
+msgid "No tokens"
+msgstr "ไม่มีโทเค็น"
 
 msgid "General information"
 msgstr "ข้อมูลทั่วไป"
@@ -739,6 +859,9 @@ msgstr "โจทย์ในข้อนี้มีหลายเวอร์
 msgid "You can see (and download) all of them using the list on the right."
 msgstr "คุณสามารถดู (และดาวน์โหลด) ทั้งหมดโดยการใช้แถบด้านขวา"
 
+msgid "Some suggested translations follow."
+msgstr ""
+
 #, python-format
 msgid "Statement in <b>%(lang)s</b>"
 msgstr "รายละเอียดโจทย์ในภาษา <b>%(lang)s</b>"
@@ -889,29 +1012,14 @@ msgstr "รอ..."
 msgid "None"
 msgstr "ไม่มี"
 
-msgid "Public score"
-msgstr "คะแนนสาธารณะ"
+msgid "Token request discarded"
+msgstr ""
 
-msgid "Total score"
-msgstr "คะแนนรวม"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr ""
 
-msgid "Score"
-msgstr "คะแนน"
-
-msgid "Token"
-msgstr "โทเค็น"
-
-msgid "no submissions"
-msgstr "ไม่มีการส่ง"
-
-msgid "Played"
-msgstr "เล่น"
-
-msgid "Play!"
-msgstr "เล่น!"
-
-msgid "No tokens"
-msgstr "ไม่มีโทเค็น"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr ""
 
 msgid "Invalid file"
 msgstr "ไฟล์ไม่ถูกต้อง"
@@ -921,4 +1029,13 @@ msgstr "การปริ้นท์มีจำนวนหน้ามาก
 
 msgid "Sent to printer"
 msgstr "ส่งปริ้นท์"
+
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "การคอมไพล์ถูกหยุด (อาจเป็นเพราะใช้หน่วยความจำมากเกินไป)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "การส่งของคุณถูกหยุด ซึ่งอาจเป็นเพราะใช้หน่วยความจำในการคอมไพล์มากเกินไป ซึ่งหากใช้หน่วยความจำมากเกินไปจริง โปรแกรมจะแสดงผลขนาดหน่วยความจำก่อนที่จะเกินหน่วยความจำสูงสุด"
+
+#~ msgid "Standard Template Library"
+#~ msgstr "STL"
 

--- a/cms/locale/uk/LC_MESSAGES/cms.po
+++ b/cms/locale/uk/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: uk\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: uk TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "N/A"
 
-msgid "Correct"
-msgstr "Правильно"
-
 msgid "Not correct"
 msgstr "Неправильно"
+
+msgid "Correct"
+msgstr "Правильно"
 
 msgid "Partially correct"
 msgstr "Частково правильно"
 
-msgid "Outcome"
-msgstr "Результат"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "Результат"
 
 msgid "Details"
 msgstr "Деталі"
@@ -107,11 +110,20 @@ msgstr "Час очікування минув (перевищено ліміт 
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "Ваша спроба використала забагато загального часу. Це може бути викликано, наприклад, невизначеним кодом або переповненням буфера. Зауважте, що в цьому випадку час процесора, видимий у деталях спроби, може бути набагато меншим за обмеження часу."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "Виконання припинено (може бути викликано порушенням обмежень пам’яті)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Обмеження пам'яті"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "Оцінювання було знищено сигналом. Серед іншого це може бути спричинено перевищенням ліміту пам’яті. Зауважте, що якщо це причина, використання пам’яті, видиме в деталях спроби, є використанням до розподілу, який спричинив сигнал."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Ваша спроба використала забагато процесорного часу."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Час запуску минув"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "Помилка виконання, оскільки код повернення був ненульовим"
@@ -194,15 +206,15 @@ msgstr[1] "до максимум двох %(type_s)s. "
 msgstr[2] "до максимум %(gen_max)d %(type_s)s. "
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Ви не отримуєте інших %(type_pl)s."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "ви отримуєте інший %(type_s)s."
 msgstr[1] "ви отримуєте інші два %(type_s)s."
 msgstr[2] "ви отримуєте інших %(gen_number)d %(type_s)s."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Ви не отримуєте інших %(type_pl)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -234,41 +246,6 @@ msgstr[2] "Загалом ви можете використовувати не 
 
 msgid "You have no limitations on how you use them."
 msgstr "Ви не маєте обмежень щодо того, як ви їх використовуєте."
-
-msgid "Too many print jobs!"
-msgstr "Забагато завдань для друку!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Ви досягли максимальної кількості завдань для друку (%d)."
-
-msgid "Invalid format!"
-msgstr "Недійсний формат!"
-
-msgid "Please select the correct files."
-msgstr "Виберіть правильні файли."
-
-msgid "File too big!"
-msgstr "Файл завеликий!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Довжина кожного файлу не повинна перевищувати %d байтів."
-
-msgid "Print job storage failed!"
-msgstr "Не вдалося зберегти завдання для друку!"
-
-msgid "Please try again."
-msgstr "Будь ласка спробуйте ще раз."
-
-msgid "Token request discarded"
-msgstr "Запит токена відхилено"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Ваш запит відхилено, оскільки у вас немає доступних токенів."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Ваш запит відхилено, оскільки ви вже використали токен для цієї спроби."
 
 msgid "Question received"
 msgstr "Питання отримано"
@@ -303,11 +280,11 @@ msgstr "Оцінено"
 msgid "status"
 msgstr "статус"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Ваш запит отримано та застосовано до спроби."
-
 msgid "Token request received"
 msgstr "Отримано запит на токен"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Ваш запит отримано та застосовано до спроби."
 
 msgid "Test received"
 msgstr "Тест отримано"
@@ -323,6 +300,32 @@ msgstr "Виконання..."
 
 msgid "Executed"
 msgstr "Виконано"
+
+msgid "Too many print jobs!"
+msgstr "Забагато завдань для друку!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Ви досягли максимальної кількості завдань для друку (%d)."
+
+msgid "Invalid format!"
+msgstr "Недійсний формат!"
+
+msgid "Please select the correct files."
+msgstr "Виберіть правильні файли."
+
+msgid "File too big!"
+msgstr "Файл завеликий!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Довжина кожного файлу не повинна перевищувати %d байтів."
+
+msgid "Print job storage failed!"
+msgstr "Не вдалося зберегти завдання для друку!"
+
+msgid "Please try again."
+msgstr "Будь ласка спробуйте ще раз."
 
 msgid "Too many submissions!"
 msgstr "Забагато спроб!"
@@ -346,6 +349,17 @@ msgstr "Серед усіх завдань ви можете надіслати 
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Це завдання можна надіслати знову через %d секунд після останньої спроби."
 
+msgid "Submission too big!"
+msgstr "Спроба занадто велика!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Довжина кожного вихідного файлу не повинна перевищувати %d байтів."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Невірний формат архіву!"
 
@@ -354,13 +368,6 @@ msgstr "Не вдалося відкрити надісланий архів."
 
 msgid "Invalid submission format!"
 msgstr "Недійсний формат спроби!"
-
-msgid "Submission too big!"
-msgstr "Спроба занадто велика!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Довжина кожного вихідного файлу не повинна перевищувати %d байтів."
 
 msgid "Submission storage failed!"
 msgstr "Помилка зберігання даних!"
@@ -484,11 +491,11 @@ msgstr "%d непрочитаних"
 msgid "Until contest starts:"
 msgstr "До початку змагання:"
 
-msgid "Until analysis starts:"
-msgstr "До початку аналізу:"
-
 msgid "Until contest ends:"
 msgstr "До закінчення змагання:"
+
+msgid "Until analysis starts:"
+msgstr "До початку аналізу:"
 
 msgid "Until analysis ends:"
 msgstr "До закінчення аналізу:"
@@ -532,9 +539,6 @@ msgstr "Виберіть змагання"
 msgid "Programming languages and libraries"
 msgstr "Мови програмування та бібліотеки"
 
-msgid "Standard Template Library"
-msgstr "Стандартна бібліотека шаблонів"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "Основний клас Java рішення повинен мати точно таке ж ім’я, як і завдання."
 
@@ -562,6 +566,30 @@ msgstr "Зауважте, що спроби підробити систему к
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Якщо ви зіткнулися з цією помилкою під час звичайного використання, повідомте про це адміністраторів змагання."
+
+msgid "Public score"
+msgstr "Публічний бал"
+
+msgid "Total score"
+msgstr "Сумарний бал"
+
+msgid "Score"
+msgstr "Бал"
+
+msgid "Token"
+msgstr "Токен"
+
+msgid "no submissions"
+msgstr "немає спроб"
+
+msgid "Played"
+msgstr "Зіграно"
+
+msgid "Play!"
+msgstr "Грати!"
+
+msgid "No tokens"
+msgstr "Немає токенів"
 
 msgid "General information"
 msgstr "Загальна інформація"
@@ -996,29 +1024,14 @@ msgstr "Чекайте..."
 msgid "None"
 msgstr "Немає"
 
-msgid "Public score"
-msgstr "Публічний бал"
+msgid "Token request discarded"
+msgstr "Запит токена відхилено"
 
-msgid "Total score"
-msgstr "Сумарний бал"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Ваш запит відхилено, оскільки у вас немає доступних токенів."
 
-msgid "Score"
-msgstr "Бал"
-
-msgid "Token"
-msgstr "Токен"
-
-msgid "no submissions"
-msgstr "немає спроб"
-
-msgid "Played"
-msgstr "Зіграно"
-
-msgid "Play!"
-msgstr "Грати!"
-
-msgid "No tokens"
-msgstr "Немає токенів"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Ваш запит відхилено, оскільки ви вже використали токен для цієї спроби."
 
 msgid "Invalid file"
 msgstr "Неправильний файл"
@@ -1028,4 +1041,13 @@ msgstr "Завдання для друку містить забагато ст�
 
 msgid "Sent to printer"
 msgstr "Відправлено на принтер"
+
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "Виконання припинено (може бути викликано порушенням обмежень пам’яті)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "Оцінювання було знищено сигналом. Серед іншого це може бути спричинено перевищенням ліміту пам’яті. Зауважте, що якщо це причина, використання пам’яті, видиме в деталях спроби, є використанням до розподілу, який спричинив сигнал."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Стандартна бібліотека шаблонів"
 

--- a/cms/locale/vi/LC_MESSAGES/cms.po
+++ b/cms/locale/vi/LC_MESSAGES/cms.po
@@ -1,33 +1,36 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: vi\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: vi TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "N/A"
 
-msgid "Correct"
-msgstr "Đúng"
-
 msgid "Not correct"
 msgstr "Sai"
+
+msgid "Correct"
+msgstr "Đúng"
 
 msgid "Partially correct"
 msgstr "Đúng một phần"
 
-msgid "Outcome"
-msgstr "Kết quả"
-
 msgid "#"
 msgstr "#"
+
+msgid "Outcome"
+msgstr "Kết quả"
 
 msgid "Details"
 msgstr "Chi tiết"
@@ -107,11 +110,20 @@ msgstr "Chạy quá lâu (vượt quá giới hạn thời gian thực tế)"
 msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
 msgstr "Bài nộp của bạn sử dụng quá nhiều thời gian thực tế. Lỗi này có thể do tràn bộ đệm. Lưu ý rằng trong trường hợp này, thời gian CPU được hiển thị có thể nhỏ hơn rất nhiều so với giới hạn thời gian."
 
-msgid "Execution killed (could be triggered by violating memory limits)"
-msgstr "Chương trình bị ngắt (có thể do vượt quá giới hạn bộ nhớ)"
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "Giới hạn bộ nhớ"
 
-msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
-msgstr "Quá trình chấm bài bị ngắt. Lỗi  này xảy ra có thể do sử dụng quá giới hạn bộ nhớ. Trong trường hợp đó, lượng bộ nhớ sử dụng được hiển thị là lượng bộ nhớ ngay trước thao tác cấp phát gây ra tín hiệu ngắt."
+#, fuzzy
+msgid "Your submission used too much memory."
+msgstr "Bài nộp của bạn sử dụng quá nhiều thời gian CPU."
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "Chạy quá thời gian"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
 
 msgid "Execution failed because the return code was nonzero"
 msgstr "Chương trình chạy không thành công vì exitcode khác 0"
@@ -186,13 +198,13 @@ msgid_plural "up to a maximum of %(gen_max)d %(type_pl)s."
 msgstr[0] ""
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "Bạn sẽ không có thêm %(type_pl)s."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] ""
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "Bạn sẽ không có thêm %(type_pl)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -216,41 +228,6 @@ msgstr[0] ""
 
 msgid "You have no limitations on how you use them."
 msgstr "Bạn có thể tự do sử dụng chúng."
-
-msgid "Too many print jobs!"
-msgstr "Quá nhiều yêu cầu in!"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "Bạn đã sử dụng hết giới hạn %d yêu cầu in."
-
-msgid "Invalid format!"
-msgstr "Định dạng không hợp lệ!"
-
-msgid "Please select the correct files."
-msgstr "Hãy chọn đúng file."
-
-msgid "File too big!"
-msgstr "File quá lớn!"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "Mỗi file có kích thước tối đa là %d byte."
-
-msgid "Print job storage failed!"
-msgstr "Không thể lưu trữ yêu cầu in!"
-
-msgid "Please try again."
-msgstr "Hãy thử lại."
-
-msgid "Token request discarded"
-msgstr "Yêu cầu sử dụng token không được chấp nhận"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Yêu cầu sử dụng token không được chấp nhận do bạn không còn token nào."
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "Yêu cầu sử dụng token không được chấp nhận do bạn đã sử dụng token cho bài nộp đó."
 
 msgid "Question received"
 msgstr "Đã nhận được câu hỏi"
@@ -282,11 +259,15 @@ msgstr "Đang tính điểm..."
 msgid "Evaluated"
 msgstr "Đã chấm xong"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "Yêu cầu của bạn đã được tiếp nhận và áp dụng vào bài nộp."
+#, fuzzy
+msgid "status"
+msgstr "Tình trạng"
 
 msgid "Token request received"
 msgstr "Đã nhận được yêu cầu sử dụng token"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "Yêu cầu của bạn đã được tiếp nhận và áp dụng vào bài nộp."
 
 msgid "Test received"
 msgstr "Đã nhận được yêu cầu chạy thử"
@@ -302,6 +283,32 @@ msgstr "Đang chạy..."
 
 msgid "Executed"
 msgstr "Đã chạy xong"
+
+msgid "Too many print jobs!"
+msgstr "Quá nhiều yêu cầu in!"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "Bạn đã sử dụng hết giới hạn %d yêu cầu in."
+
+msgid "Invalid format!"
+msgstr "Định dạng không hợp lệ!"
+
+msgid "Please select the correct files."
+msgstr "Hãy chọn đúng file."
+
+msgid "File too big!"
+msgstr "File quá lớn!"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "Mỗi file có kích thước tối đa là %d byte."
+
+msgid "Print job storage failed!"
+msgstr "Không thể lưu trữ yêu cầu in!"
+
+msgid "Please try again."
+msgstr "Hãy thử lại."
 
 msgid "Too many submissions!"
 msgstr "Quá nhiều bài nộp!"
@@ -325,6 +332,17 @@ msgstr "Với tất cả các bài, khoảng cách giữa hai lần nộp tối 
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "Với bài này, khoảng cách giữa hai lần nộp tối thiểu là %d giây."
 
+msgid "Submission too big!"
+msgstr "Kích thước bài nộp quá lớn!"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "Mỗi file mã nguồn có độ dài tối đa là %d byte."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "Định dạng file nén không hợp lệ!"
 
@@ -333,13 +351,6 @@ msgstr "Không mở được file nén đã nộp."
 
 msgid "Invalid submission format!"
 msgstr "Định dạng bài nộp không hợp lệ!"
-
-msgid "Submission too big!"
-msgstr "Kích thước bài nộp quá lớn!"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "Mỗi file mã nguồn có độ dài tối đa là %d byte."
 
 msgid "Submission storage failed!"
 msgstr "Không thể lưu trữ lại bài nộp!"
@@ -463,11 +474,11 @@ msgstr "chưa đọc %d"
 msgid "Until contest starts:"
 msgstr "Kì thi bắt đầu sau:"
 
-msgid "Until analysis starts:"
-msgstr "Nộp bài không chính thức bắt đầu sau:"
-
 msgid "Until contest ends:"
 msgstr "Kì thi kết thúc sau:"
+
+msgid "Until analysis starts:"
+msgstr "Nộp bài không chính thức bắt đầu sau:"
 
 msgid "Until analysis ends:"
 msgstr "Nộp bài không chính thức kết thúc sau:"
@@ -511,9 +522,6 @@ msgstr "Chọn kì thi"
 msgid "Programming languages and libraries"
 msgstr "Ngôn ngữ lập trình và thư viện"
 
-msgid "Standard Template Library"
-msgstr "Standard Template Library"
-
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "Lớp chính trong một bài nộp bằng Java phải được đặt tên trùng với tên bài."
 
@@ -541,6 +549,31 @@ msgstr "Việc làm sai lệch quá trình hoạt động của Contest Manageme
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "Nếu bạn gặp lỗi này khi đang sử dụng bình thường, hãy thông báo với ban tổ chức kì thi."
+
+msgid "Public score"
+msgstr "Điểm công khai"
+
+msgid "Total score"
+msgstr "Điểm tổng"
+
+msgid "Score"
+msgstr "Điểm"
+
+msgid "Token"
+msgstr "Token"
+
+#, fuzzy
+msgid "no submissions"
+msgstr "Bài nộp"
+
+msgid "Played"
+msgstr "Đã sử dụng"
+
+msgid "Play!"
+msgstr "Sử dụng!"
+
+msgid "No tokens"
+msgstr "Không có token"
 
 msgid "General information"
 msgstr "Thông tin chung"
@@ -736,6 +769,67 @@ msgstr "Tên người dùng này đã được đặt, vui lòng chọn tên ng�
 msgid "This user is already registered in the contest."
 msgstr "Người dùng này đã đăng kí cuộc thi."
 
+msgid "No such user."
+msgstr ""
+
+#, fuzzy
+msgid "The password is not correct."
+msgstr "Mật khẩu không khớp!"
+
+#, fuzzy
+msgid "Registration"
+msgstr "Đăng ký"
+
+msgid "Please fill in the fields to register"
+msgstr ""
+
+#, fuzzy
+msgid "New user"
+msgstr "Câu trả lời mới"
+
+#, fuzzy
+msgid "Join contest"
+msgstr "Chọn kì thi"
+
+#, fuzzy
+msgid "First name"
+msgstr "Tên file"
+
+#, fuzzy
+msgid "Last name"
+msgstr "Tên file"
+
+#, fuzzy
+msgid "E-mail"
+msgstr "chi tiết"
+
+#, fuzzy
+msgid "Representing"
+msgstr "In"
+
+#, python-format
+msgid "Must be one character or more."
+msgid_plural "Must be %(min_length)s characters or more."
+msgstr[0] ""
+
+#, fuzzy
+msgid "Confirm password"
+msgstr "Mật khẩu"
+
+msgid "Registered in the contest successfully!"
+msgstr ""
+
+#, fuzzy
+msgid "Your username is:"
+msgstr "Tài khoản"
+
+msgid "Your password is stored securely."
+msgstr ""
+
+#, fuzzy
+msgid "Back to login"
+msgstr "Đăng nhập không thành công."
+
 msgid "Compilation output"
 msgstr "Thông báo từ trình biên dịch"
 
@@ -794,6 +888,10 @@ msgstr "Chi tiết"
 
 msgid "Compilation commands"
 msgstr "Lệnh biên dịch"
+
+#, fuzzy, python-format
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
+msgstr "Xem trang tổng quan của mỗi bài để biết về quy định sử dụng %(type_pl)s."
 
 msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
 msgstr "Chú ý rằng để xem chi tiết chấm của một bài nộp bạn cần sử dụng một contest-token và một task-token."
@@ -870,6 +968,14 @@ msgstr "Tại thời điểm này, với bài này, bạn không có token nào.
 msgid "But you will have to wait until %(expiration_time)s to use it."
 msgstr "Nhưng bạn phải chờ tới thời điểm %(expiration_time)s mới có thể sử dụng."
 
+#, fuzzy
+msgid "Unofficial submissions"
+msgstr "Bài nộp"
+
+#, fuzzy
+msgid "Official submissions"
+msgstr "Bài nộp"
+
 msgid "Submission details"
 msgstr "Chi tiết bài nộp"
 
@@ -913,24 +1019,32 @@ msgstr "Chờ..."
 msgid "None"
 msgstr "Không có gì"
 
-msgid "Public score"
-msgstr "Điểm công khai"
+msgid "Token request discarded"
+msgstr "Yêu cầu sử dụng token không được chấp nhận"
 
-msgid "Total score"
-msgstr "Điểm tổng"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Yêu cầu sử dụng token không được chấp nhận do bạn không còn token nào."
 
-msgid "Score"
-msgstr "Điểm"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "Yêu cầu sử dụng token không được chấp nhận do bạn đã sử dụng token cho bài nộp đó."
 
-msgid "Token"
-msgstr "Token"
+#, fuzzy
+msgid "Invalid file"
+msgstr "Định dạng không hợp lệ!"
 
-msgid "Played"
-msgstr "Đã sử dụng"
+#, fuzzy
+msgid "Print job has too many pages"
+msgstr "Không thể lưu trữ yêu cầu in!"
 
-msgid "Play!"
-msgstr "Sử dụng!"
+msgid "Sent to printer"
+msgstr ""
 
-msgid "No tokens"
-msgstr "Không có token"
+#~ msgid "Execution killed (could be triggered by violating memory limits)"
+#~ msgstr "Chương trình bị ngắt (có thể do vượt quá giới hạn bộ nhớ)"
+
+#~ msgid "The evaluation was killed by a signal. Among other things, this might be caused by exceeding the memory limit. Note that if this is the reason, the memory usage visible in the submission details is the usage before the allocation that caused the signal."
+#~ msgstr "Quá trình chấm bài bị ngắt. Lỗi  này xảy ra có thể do sử dụng quá giới hạn bộ nhớ. Trong trường hợp đó, lượng bộ nhớ sử dụng được hiển thị là lượng bộ nhớ ngay trước thao tác cấp phát gây ra tín hiệu ngắt."
+
+#~ msgid "Standard Template Library"
+#~ msgstr "Standard Template Library"
 

--- a/cms/locale/zh_CN/LC_MESSAGES/cms.po
+++ b/cms/locale/zh_CN/LC_MESSAGES/cms.po
@@ -1,15 +1,209 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: zh_CN\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: zh_CN TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
+
+msgid "N/A"
+msgstr ""
+
+#, fuzzy
+msgid "Not correct"
+msgstr "总得分"
+
+#, fuzzy
+msgid "Correct"
+msgstr "得分"
+
+msgid "Partially correct"
+msgstr ""
+
+msgid "#"
+msgstr ""
+
+msgid "Outcome"
+msgstr ""
+
+#, fuzzy
+msgid "Details"
+msgstr "详细资料"
+
+#, fuzzy
+msgid "Execution time"
+msgstr "编译时间："
+
+#, fuzzy
+msgid "Memory used"
+msgstr "内存使用量："
+
+msgid "Score details temporarily unavailable."
+msgstr ""
+
+#, python-format
+msgid "Subtask %(index)s"
+msgstr ""
+
+#, fuzzy
+msgid "Compilation succeeded"
+msgstr "编译结果："
+
+msgid "Your submission successfully compiled to an executable."
+msgstr ""
+
+#, fuzzy
+msgid "Compilation failed"
+msgstr "编译时间："
+
+msgid "Your submission did not compile correctly."
+msgstr ""
+
+#, fuzzy
+msgid "Compilation timed out"
+msgstr "编译时间："
+
+msgid "Your submission exceeded the time limit while compiling. This might be caused by an excessive use of C++ templates, for example."
+msgstr ""
+
+#, python-format
+msgid "Compilation killed with signal %s (could be triggered by violating memory limits)"
+msgstr ""
+
+msgid "Your submission was killed with the specified signal. Among other things, this might be caused by exceeding the memory limit for the compilation, and in turn by an excessive use of C++ templates, for example."
+msgstr ""
+
+msgid "Output is correct"
+msgstr ""
+
+msgid "Your submission ran and gave the correct answer"
+msgstr ""
+
+msgid "Output is partially correct"
+msgstr ""
+
+msgid "Your submission ran and gave the partially correct answer"
+msgstr ""
+
+msgid "Output isn't correct"
+msgstr ""
+
+msgid "Your submission ran, but gave the wrong answer"
+msgstr ""
+
+#, python-format
+msgid "Evaluation didn't produce file %s"
+msgstr ""
+
+msgid "Your submission ran, but did not write on the correct output file"
+msgstr ""
+
+msgid "Execution timed out"
+msgstr ""
+
+msgid "Your submission used too much CPU time."
+msgstr ""
+
+msgid "Execution timed out (wall clock limit exceeded)"
+msgstr ""
+
+msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
+msgstr ""
+
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "内存限制"
+
+msgid "Your submission used too much memory."
+msgstr ""
+
+msgid "Execution killed by signal"
+msgstr ""
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
+
+msgid "Execution failed because the return code was nonzero"
+msgstr ""
+
+msgid "Your submission failed because it exited with a return code different from 0."
+msgstr ""
+
+msgid "Execution completed successfully"
+msgstr ""
+
+#, fuzzy
+msgid "No compilation needed"
+msgstr "编译时间："
+
+msgid "File not submitted"
+msgstr ""
+
+#, fuzzy
+msgid "Question too long!"
+msgstr "测试文件过大！"
+
+#, python-format
+msgid "Subject must be at most %(max_subject_length)d characters, content at most %(max_text_length)d."
+msgstr ""
+
+msgid "contest-token"
+msgstr ""
+
+#, fuzzy
+msgid "contest-tokens"
+msgstr "Token 已用尽"
+
+#, fuzzy
+msgid "task-token"
+msgstr "Token"
+
+#, fuzzy
+msgid "task-tokens"
+msgstr "Token"
+
+#, fuzzy
+msgid "token"
+msgstr "Token"
+
+#, fuzzy
+msgid "tokens"
+msgstr "Token"
+
+#, fuzzy, python-format
+msgid "You don't have %(type_pl)s available for this task."
+msgstr "现在，本题 Token 已用尽。"
+
+#, fuzzy, python-format
+msgid "You have an infinite number of %(type_pl)s for this task."
+msgstr "在本题中有无限量的 Token 可供使用。"
+
+#, fuzzy, python-format
+msgid "You start with no %(type_pl)s."
+msgstr "并不再产生新的 %(type_pl)s。"
+
+#, fuzzy, python-format
+msgid "You start with one %(type_s)s."
+msgid_plural "You start with %(gen_initial)d %(type_pl)s."
+msgstr[0] ""
+
+#, python-format
+msgid "Every minute "
+msgid_plural "Every %(gen_interval)g minutes "
+msgstr[0] ""
+
+#, fuzzy, python-format
+msgid "you get another %(type_s)s, "
+msgid_plural "you get %(gen_number)d other %(type_pl)s, "
+msgstr[0] ""
 
 #, python-format
 msgid "up to a maximum of one %(type_s)s."
@@ -17,13 +211,13 @@ msgid_plural "up to a maximum of %(gen_max)d %(type_pl)s."
 msgstr[0] ""
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "并不再产生新的 %(type_pl)s。"
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] ""
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "并不再产生新的 %(type_pl)s。"
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -47,41 +241,6 @@ msgstr[0] ""
 
 msgid "You have no limitations on how you use them."
 msgstr "使用规则中没有其他额外的限制。"
-
-msgid "Too many print jobs!"
-msgstr "打印次数过多！"
-
-#, python-format
-msgid "You have reached the maximum limit of at most %d print jobs."
-msgstr "在本题中, 您最多可以进行 %d 次测试。"
-
-msgid "Invalid format!"
-msgstr "非法的测试文件格式！"
-
-msgid "Please select the correct files."
-msgstr "请选择正确的文件。"
-
-msgid "File too big!"
-msgstr "测试文件过大！"
-
-#, python-format
-msgid "Each file must be at most %d bytes long."
-msgstr "每个文件长度不得超过 %d 字节。"
-
-msgid "Print job storage failed!"
-msgstr "打印文件储存失败。"
-
-msgid "Please try again."
-msgstr "请再试一次。"
-
-msgid "Token request discarded"
-msgstr "Token 使用已拒绝"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "由于无可用 Token，使用已拒绝。"
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "由于本次提交已使用过 Token，使用已拒绝。"
 
 msgid "Question received"
 msgstr "已送出询问"
@@ -113,11 +272,15 @@ msgstr "评分中..."
 msgid "Evaluated"
 msgstr "已评测"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "请查看本次提交的完整评测结果。"
+#, fuzzy
+msgid "status"
+msgstr "状态"
 
 msgid "Token request received"
 msgstr "Token 使用成功"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "请查看本次提交的完整评测结果。"
 
 msgid "Test received"
 msgstr "已收到测试"
@@ -133,6 +296,32 @@ msgstr "执行中..."
 
 msgid "Executed"
 msgstr "已评测"
+
+msgid "Too many print jobs!"
+msgstr "打印次数过多！"
+
+#, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "在本题中, 您最多可以进行 %d 次测试。"
+
+msgid "Invalid format!"
+msgstr "非法的测试文件格式！"
+
+msgid "Please select the correct files."
+msgstr "请选择正确的文件。"
+
+msgid "File too big!"
+msgstr "测试文件过大！"
+
+#, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "每个文件长度不得超过 %d 字节。"
+
+msgid "Print job storage failed!"
+msgstr "打印文件储存失败。"
+
+msgid "Please try again."
+msgstr "请再试一次。"
 
 msgid "Too many submissions!"
 msgstr "提交次数超出限制！"
@@ -156,6 +345,17 @@ msgstr "在本竞赛的最后一次提交过后 %d 秒始可再次提交。"
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "在本题的最后一次提交过后 %d 秒始可再次提交。"
 
+msgid "Submission too big!"
+msgstr "提交文件过大！"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "每个源文件长度不得超过 %d 字节。"
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "封装文件格式错误！"
 
@@ -164,13 +364,6 @@ msgstr "封装文件无法正常开启。"
 
 msgid "Invalid submission format!"
 msgstr "文件格式错误！"
-
-msgid "Submission too big!"
-msgstr "提交文件过大！"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "每个源文件长度不得超过 %d 字节。"
 
 msgid "Submission storage failed!"
 msgstr "提交文件存取错误！"
@@ -294,11 +487,11 @@ msgstr "%d 则信息未读"
 msgid "Until contest starts:"
 msgstr "距离竞赛开始："
 
-msgid "Until analysis starts:"
-msgstr "距离赛后评测开始："
-
 msgid "Until contest ends:"
 msgstr "距离竞赛结束："
+
+msgid "Until analysis starts:"
+msgstr "距离赛后评测开始："
 
 msgid "Until analysis ends:"
 msgstr "距离赛后评测结束："
@@ -336,11 +529,11 @@ msgstr "遵循"
 msgid "GNU Affero General Public License"
 msgstr "GNU AGPL 通用公共许可证"
 
+msgid "Choose a contest"
+msgstr ""
+
 msgid "Programming languages and libraries"
 msgstr "编程语言和库"
-
-msgid "Standard Template Library"
-msgstr "STL 标准样板函数库"
 
 msgid "The main Java class of the solution should have exactly the same name as the task."
 msgstr "Java 的 main class 应该与题目名称保持一致。"
@@ -370,6 +563,31 @@ msgstr "擅自以非正当方式操作本系统可能会被认定为作弊，并
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "若在正常使用的情况下发生错误, 请联络管理员。"
 
+msgid "Public score"
+msgstr "公开得分"
+
+msgid "Total score"
+msgstr "总得分"
+
+msgid "Score"
+msgstr "得分"
+
+msgid "Token"
+msgstr "Token"
+
+#, fuzzy
+msgid "no submissions"
+msgstr "评测页面"
+
+msgid "Played"
+msgstr "已使用"
+
+msgid "Play!"
+msgstr "现在使用"
+
+msgid "No tokens"
+msgstr "Token 已用尽"
+
 msgid "General information"
 msgstr "竞赛信息"
 
@@ -392,6 +610,30 @@ msgstr "竞赛已经结束。"
 
 #, python-format
 msgid "The contest started at %(start_time)s and ended at %(stop_time)s."
+msgstr "竞赛时间於 %(start_time)s 开始，并已於 %(stop_time)s 结束。"
+
+#, fuzzy
+msgid "The analysis mode hasn't started yet."
+msgstr "竞赛尚未开始。"
+
+#, fuzzy, python-format
+msgid "The analysis mode will start at %(start_time)s and will end at %(stop_time)s."
+msgstr "竞赛时间将于 %(start_time)s 开始，至 %(stop_time)s 结束。"
+
+#, fuzzy
+msgid "The analysis mode is currently running."
+msgstr "竞赛进行中。"
+
+#, fuzzy, python-format
+msgid "The analysis mode started at %(start_time)s and will end at %(stop_time)s."
+msgstr "竞赛时间为 %(start_time)s 至 %(stop_time)s。"
+
+#, fuzzy
+msgid "The analysis mode has already ended."
+msgstr "竞赛已经结束。"
+
+#, fuzzy, python-format
+msgid "The analysis mode started at %(start_time)s and ended at %(stop_time)s."
 msgstr "竞赛时间於 %(start_time)s 开始，并已於 %(stop_time)s 结束。"
 
 msgid "You have an infinite number of tokens."
@@ -421,6 +663,10 @@ msgstr "对于每次上传而言，使用两类 Token 各一枚即可查看该�
 
 #, python-format
 msgid "You can submit at most %(submissions)s solutions during this contest."
+msgstr "您在本题目的上传次数已达上限 %(submissions)s 次。"
+
+#, fuzzy, python-format
+msgid "You can submit at most %(user_tests)s user tests during this contest."
 msgstr "您在本题目的上传次数已达上限 %(submissions)s 次。"
 
 #, python-format
@@ -530,6 +776,74 @@ msgstr "评分中..."
 msgid "no print jobs yet"
 msgstr "尚未测试"
 
+msgid "The passwords do not match!"
+msgstr ""
+
+msgid "This username is already taken, please choose a different one."
+msgstr ""
+
+msgid "This user is already registered in the contest."
+msgstr ""
+
+msgid "No such user."
+msgstr ""
+
+msgid "The password is not correct."
+msgstr ""
+
+#, fuzzy
+msgid "Registration"
+msgstr "注册"
+
+msgid "Please fill in the fields to register"
+msgstr ""
+
+#, fuzzy
+msgid "New user"
+msgstr "新回复"
+
+msgid "Join contest"
+msgstr ""
+
+#, fuzzy
+msgid "First name"
+msgstr "文件名"
+
+#, fuzzy
+msgid "Last name"
+msgstr "文件名"
+
+#, fuzzy
+msgid "E-mail"
+msgstr "详细资料"
+
+#, fuzzy
+msgid "Representing"
+msgstr "打印中"
+
+#, python-format
+msgid "Must be one character or more."
+msgid_plural "Must be %(min_length)s characters or more."
+msgstr[0] ""
+
+#, fuzzy
+msgid "Confirm password"
+msgstr "密码"
+
+msgid "Registered in the contest successfully!"
+msgstr ""
+
+#, fuzzy
+msgid "Your username is:"
+msgstr "用户名"
+
+msgid "Your password is stored securely."
+msgstr ""
+
+#, fuzzy
+msgid "Back to login"
+msgstr "无法登入。"
+
 msgid "Compilation output"
 msgstr "编译信息"
 
@@ -589,18 +903,48 @@ msgstr "详细信息"
 msgid "Compilation commands"
 msgstr "编译指令"
 
+#, fuzzy, python-format
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
+msgstr "在题目描述页面中，可以看到该题目 %(type_pl)s 的使用规则。"
+
 msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
 msgstr "请注意：欲查看详细的评测结果，须使用竞赛-Token 与题目-Token 各一枚。"
 
 msgid "Attachments"
 msgstr "附件"
 
+msgid "unknown"
+msgstr ""
+
+#, fuzzy
+msgid "loading..."
+msgstr "评分中..."
+
 #, python-format
 msgid "%(name)s (%(short_name)s) <small>submissions</small>"
 msgstr "%(name)s (%(short_name)s) <small>评测页面</small>"
 
+#, fuzzy
+msgid "Score:"
+msgstr "得分"
+
+#, fuzzy
+msgid "Public score:"
+msgstr "公开得分"
+
+#, fuzzy
+msgid "Score of tokened submissions:"
+msgstr "评测记录"
+
+#, fuzzy
+msgid "Total score:"
+msgstr "总得分"
+
 msgid "Submit a solution"
 msgstr "提交解答"
+
+msgid "You may submit any subset of outputs in a single submission."
+msgstr ""
 
 #, python-format
 msgid "You can submit %(submissions_left)s more solution(s)."
@@ -611,6 +955,9 @@ msgstr "submission.zip"
 
 msgid "Previous submissions"
 msgstr "评测记录"
+
+msgid "Tokens are not allowed on this task."
+msgstr ""
 
 msgid "Right now, you have infinite tokens available on this task."
 msgstr "现在，您拥有不限数量的 Token 可供使用于本题。"
@@ -639,6 +986,14 @@ msgstr "现在，本题 Token 已用尽。"
 #, python-format
 msgid "But you will have to wait until %(expiration_time)s to use it."
 msgstr "但需等待 %(expiration_time)s 后才可再次使用 Token。"
+
+#, fuzzy
+msgid "Unofficial submissions"
+msgstr "评测页面"
+
+#, fuzzy
+msgid "Official submissions"
+msgstr "评测页面"
 
 msgid "Submission details"
 msgstr "提交详细信息"
@@ -683,24 +1038,26 @@ msgstr "等待中..."
 msgid "None"
 msgstr "无"
 
-msgid "Public score"
-msgstr "公开得分"
+msgid "Token request discarded"
+msgstr "Token 使用已拒绝"
 
-msgid "Total score"
-msgstr "总得分"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "由于无可用 Token，使用已拒绝。"
 
-msgid "Score"
-msgstr "得分"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "由于本次提交已使用过 Token，使用已拒绝。"
 
-msgid "Token"
-msgstr "Token"
+#, fuzzy
+msgid "Invalid file"
+msgstr "非法的测试文件格式！"
 
-msgid "Played"
-msgstr "已使用"
+#, fuzzy
+msgid "Print job has too many pages"
+msgstr "打印文件储存失败。"
 
-msgid "Play!"
-msgstr "现在使用"
+msgid "Sent to printer"
+msgstr ""
 
-msgid "No tokens"
-msgstr "Token 已用尽"
+#~ msgid "Standard Template Library"
+#~ msgstr "STL 标准样板函数库"
 

--- a/cms/locale/zh_TW/LC_MESSAGES/cms.po
+++ b/cms/locale/zh_TW/LC_MESSAGES/cms.po
@@ -1,27 +1,33 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: VERSION\n"
-"POT-Creation-Date: 2025-06-06 09:35+0000\n"
+"Project-Id-Version:  VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2025-08-16 14:52+0300\n"
 "PO-Revision-Date: 2025-06-06 09:35+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
 "Language: zh_TW\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: zh_TW TEAM <EMAIL@ADDRESS>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
 
 msgid "N/A"
 msgstr "(空)"
 
-msgid "Correct"
-msgstr "全部正確"
-
 msgid "Not correct"
 msgstr "無法得分"
 
+msgid "Correct"
+msgstr "全部正確"
+
 msgid "Partially correct"
 msgstr "部分正確"
+
+msgid "#"
+msgstr ""
 
 msgid "Outcome"
 msgstr "評測結果"
@@ -35,6 +41,9 @@ msgstr "執行時間"
 msgid "Memory used"
 msgstr "記憶體使用量"
 
+msgid "Score details temporarily unavailable."
+msgstr ""
+
 #, python-format
 msgid "Subtask %(index)s"
 msgstr "子問題 %(index)s"
@@ -42,31 +51,85 @@ msgstr "子問題 %(index)s"
 msgid "Compilation succeeded"
 msgstr "編譯成功"
 
+msgid "Your submission successfully compiled to an executable."
+msgstr ""
+
 msgid "Compilation failed"
 msgstr "編譯失敗"
 
+msgid "Your submission did not compile correctly."
+msgstr ""
+
 msgid "Compilation timed out"
 msgstr "編譯逾時"
+
+msgid "Your submission exceeded the time limit while compiling. This might be caused by an excessive use of C++ templates, for example."
+msgstr ""
 
 #, python-format
 msgid "Compilation killed with signal %s (could be triggered by violating memory limits)"
 msgstr "編譯程式因記憶體違規存取而強制終止 (信號 %s)"
 
+msgid "Your submission was killed with the specified signal. Among other things, this might be caused by exceeding the memory limit for the compilation, and in turn by an excessive use of C++ templates, for example."
+msgstr ""
+
 msgid "Output is correct"
 msgstr "輸出正確"
 
+msgid "Your submission ran and gave the correct answer"
+msgstr ""
+
+#, fuzzy
+msgid "Output is partially correct"
+msgstr "部分正確"
+
+msgid "Your submission ran and gave the partially correct answer"
+msgstr ""
+
 msgid "Output isn't correct"
 msgstr "輸出錯誤"
+
+msgid "Your submission ran, but gave the wrong answer"
+msgstr ""
 
 #, python-format
 msgid "Evaluation didn't produce file %s"
 msgstr "執行後並未產生檔案 %s"
 
+msgid "Your submission ran, but did not write on the correct output file"
+msgstr ""
+
 msgid "Execution timed out"
 msgstr "超過時間限制"
 
+msgid "Your submission used too much CPU time."
+msgstr ""
+
+msgid "Execution timed out (wall clock limit exceeded)"
+msgstr ""
+
+msgid "Your submission used too much total time. This might be triggered by undefined code, or buffer overflow, for example. Note that in this case the CPU time visible in the submission details might be much smaller than the time limit."
+msgstr ""
+
+#, fuzzy
+msgid "Memory limit exceeded"
+msgstr "記憶體限制"
+
+msgid "Your submission used too much memory."
+msgstr ""
+
+#, fuzzy
+msgid "Execution killed by signal"
+msgstr "超過時間限制"
+
+msgid "The evaluation was killed by a signal."
+msgstr ""
+
 msgid "Execution failed because the return code was nonzero"
 msgstr "執行失敗: 程式回傳值非零"
+
+msgid "Your submission failed because it exited with a return code different from 0."
+msgstr ""
 
 msgid "Execution completed successfully"
 msgstr "評測完成"
@@ -76,6 +139,14 @@ msgstr "略過編譯程序"
 
 msgid "File not submitted"
 msgstr "檔案未送出"
+
+#, fuzzy
+msgid "Question too long!"
+msgstr "測試檔案過大"
+
+#, python-format
+msgid "Subject must be at most %(max_subject_length)d characters, content at most %(max_text_length)d."
+msgstr ""
 
 msgid "contest-token"
 msgstr "競賽-Token"
@@ -128,13 +199,13 @@ msgid_plural "up to a maximum of %(gen_max)d %(type_pl)s."
 msgstr[0] ""
 
 #, python-format
-msgid "You don't get other %(type_pl)s."
-msgstr "並不再產生新的 %(type_pl)s."
-
-#, python-format
 msgid "you get another %(type_s)s."
 msgid_plural "you get %(gen_number)d other %(type_pl)s."
 msgstr[0] "會產生一個額外的 %(type_s)s."
+
+#, python-format
+msgid "You don't get other %(type_pl)s."
+msgstr "並不再產生新的 %(type_pl)s."
 
 #, python-format
 msgid "You can use a %(type_s)s every second "
@@ -159,26 +230,18 @@ msgstr[0] "且一旦產生 %(type_s)s 後將不會再增加."
 msgid "You have no limitations on how you use them."
 msgstr "使用規則中沒有其他額外的限制."
 
-msgid "Please select the correct files."
-msgstr "請選擇正確的檔案"
-
-msgid "Please try again."
-msgstr "請再試一次"
-
-msgid "Token request discarded"
-msgstr "Token 已繳交"
-
-msgid "Your request has been discarded because you have no tokens available."
-msgstr "Token 已經用光囉"
-
-msgid "Your request has been discarded because you already used a token on that submission."
-msgstr "本次傳送已使用過 Token"
-
 msgid "Question received"
 msgstr "已送出詢問"
 
 msgid "Your question has been received, you will be notified when it is answered."
 msgstr "您的詢問已成功送出, 待此詢問得到回覆後將會通知您."
+
+#, fuzzy
+msgid "Print job received"
+msgstr "已收到測試"
+
+msgid "Your print job has been received."
+msgstr ""
 
 msgid "Submission received"
 msgstr "已收到本次傳送"
@@ -198,11 +261,15 @@ msgstr "評分中..."
 msgid "Evaluated"
 msgstr "已評測"
 
-msgid "Your request has been received and applied to the submission."
-msgstr "請觀看本次傳送之完整評測結果"
+#, fuzzy
+msgid "status"
+msgstr "狀態"
 
 msgid "Token request received"
 msgstr "Token 使用成功"
+
+msgid "Your request has been received and applied to the submission."
+msgstr "請觀看本次傳送之完整評測結果"
 
 msgid "Test received"
 msgstr "已收到測試"
@@ -218,6 +285,36 @@ msgstr "執行中..."
 
 msgid "Executed"
 msgstr "已評測"
+
+#, fuzzy
+msgid "Too many print jobs!"
+msgstr "測試次數超出限制"
+
+#, fuzzy, python-format
+msgid "You have reached the maximum limit of at most %d print jobs."
+msgstr "在競賽中, 您最多可以進行 %d 次測試."
+
+#, fuzzy
+msgid "Invalid format!"
+msgstr "錯誤的測試檔案格式"
+
+msgid "Please select the correct files."
+msgstr "請選擇正確的檔案"
+
+#, fuzzy
+msgid "File too big!"
+msgstr "測試檔案過大"
+
+#, fuzzy, python-format
+msgid "Each file must be at most %d bytes long."
+msgstr "個別程式碼檔案容量不得超過 %d bytes."
+
+#, fuzzy
+msgid "Print job storage failed!"
+msgstr "測試檔案儲存失敗"
+
+msgid "Please try again."
+msgstr "請再試一次"
 
 msgid "Too many submissions!"
 msgstr "傳送次數超出限制!"
@@ -241,6 +338,17 @@ msgstr "在本競賽的最後一次傳送過後 %d 秒始可再次傳送."
 msgid "For this task, you can submit again after %d seconds from last submission."
 msgstr "在本題的最後一次傳送過後 %d 秒始可再次傳送."
 
+msgid "Submission too big!"
+msgstr "傳送檔案過大"
+
+#, python-format
+msgid "Each source file must be at most %d bytes long."
+msgstr "個別程式碼檔案容量不得超過 %d bytes."
+
+#, python-format
+msgid "The submission should contain at most %d files."
+msgstr ""
+
 msgid "Invalid archive format!"
 msgstr "封裝檔案格式錯誤"
 
@@ -249,13 +357,6 @@ msgstr "封裝檔案無法正常開啟"
 
 msgid "Invalid submission format!"
 msgstr "檔案格式錯誤"
-
-msgid "Submission too big!"
-msgstr "傳送檔案過大"
-
-#, python-format
-msgid "Each source file must be at most %d bytes long."
-msgstr "個別程式碼檔案容量不得超過 %d bytes."
 
 msgid "Submission storage failed!"
 msgstr "本傳送發生檔案存取錯誤"
@@ -342,6 +443,9 @@ msgstr "使用者 <strong>%(first_name)s %(last_name)s</strong> <em>(%(username)
 msgid "Failed to log in."
 msgstr "無法登入"
 
+msgid "Welcome"
+msgstr ""
+
 msgid "Please log in"
 msgstr "請登入後參與競賽"
 
@@ -379,6 +483,14 @@ msgstr "距離競賽開始:"
 msgid "Until contest ends:"
 msgstr "距離競賽結束:"
 
+#, fuzzy
+msgid "Until analysis starts:"
+msgstr "距離競賽開始:"
+
+#, fuzzy
+msgid "Until analysis ends:"
+msgstr "距離競賽結束:"
+
 msgid "Time left:"
 msgstr "剩餘時間:"
 
@@ -400,6 +512,9 @@ msgstr "參考資料"
 msgid "Testing"
 msgstr "線上測試"
 
+msgid "Printing"
+msgstr ""
+
 msgid "Contest Management System"
 msgstr "本系統"
 
@@ -415,11 +530,22 @@ msgstr "選擇一場競賽"
 msgid "Programming languages and libraries"
 msgstr "程式語言和函式庫"
 
-msgid "Standard Template Library"
-msgstr "STL 標準樣板函數庫"
+msgid "The main Java class of the solution should have exactly the same name as the task."
+msgstr ""
+
+#, fuzzy
+msgid "Submission details for compilation"
+msgstr "傳送詳細資料"
 
 msgid "Message"
 msgstr "訊息"
+
+msgid "Explanation"
+msgstr ""
+
+#, fuzzy
+msgid "Submission details for evaluation"
+msgstr "傳送詳細資料"
 
 #, python-format
 msgid "Error %(status_code)s"
@@ -433,6 +559,32 @@ msgstr "擅自以非正當方式操作本系統將導致取消競賽資格."
 
 msgid "If you encountered this error during normal usage, please notify the contest administrators."
 msgstr "若在正常使用的情況下發生錯誤, 請聯絡管理員."
+
+msgid "Public score"
+msgstr "公開得分"
+
+msgid "Total score"
+msgstr "總得分"
+
+msgid "Score"
+msgstr "得分"
+
+#, fuzzy
+msgid "Token"
+msgstr "Token"
+
+#, fuzzy
+msgid "no submissions"
+msgstr "評測頁面"
+
+msgid "Played"
+msgstr "已使用"
+
+msgid "Play!"
+msgstr "現在使用"
+
+msgid "No tokens"
+msgstr "Token 已用盡"
 
 msgid "General information"
 msgstr "競賽資訊"
@@ -456,6 +608,30 @@ msgstr "競賽已經結束"
 
 #, python-format
 msgid "The contest started at %(start_time)s and ended at %(stop_time)s."
+msgstr "競賽時間於 %(start_time)s 開始, 並已於 %(stop_time)s 結束."
+
+#, fuzzy
+msgid "The analysis mode hasn't started yet."
+msgstr "競賽尚未開始"
+
+#, fuzzy, python-format
+msgid "The analysis mode will start at %(start_time)s and will end at %(stop_time)s."
+msgstr "競賽時間將於 %(start_time)s 開始, 至 %(stop_time)s 結束."
+
+#, fuzzy
+msgid "The analysis mode is currently running."
+msgstr "競賽進行中"
+
+#, fuzzy, python-format
+msgid "The analysis mode started at %(start_time)s and will end at %(stop_time)s."
+msgstr "競賽時間為 %(start_time)s 至 %(stop_time)s."
+
+#, fuzzy
+msgid "The analysis mode has already ended."
+msgstr "競賽已經結束"
+
+#, fuzzy, python-format
+msgid "The analysis mode started at %(start_time)s and ended at %(stop_time)s."
 msgstr "競賽時間於 %(start_time)s 開始, 並已於 %(stop_time)s 結束."
 
 msgid "You have an infinite number of tokens."
@@ -482,6 +658,14 @@ msgstr "Token 分為兩類: 競賽-Token (競賽共用的 Token), 與題目-Toke
 
 msgid "You can see the detailed result of a submission by using two tokens on it, one of each type."
 msgstr "對於每次傳送而言, 使用兩類 Token 各一枚即可觀看該次詳細的評測結果."
+
+#, fuzzy, python-format
+msgid "You can submit at most %(submissions)s solutions during this contest."
+msgstr "您在本題目之傳送次數已達上限 (%d 次)"
+
+#, python-format
+msgid "You can submit at most %(user_tests)s user tests during this contest."
+msgstr ""
 
 #, python-format
 msgid "Every user is allowed to compete (i.e. submit solutions) for a uninterrupted time frame of %(per_user_time)s."
@@ -537,14 +721,43 @@ msgstr "作答形式"
 msgid "Files"
 msgstr "傳送檔案"
 
+#, fuzzy
+msgid "Tokens"
+msgstr "Token"
+
 msgid "Yes"
 msgstr "是"
 
 msgid "No"
 msgstr "否"
 
+#, fuzzy
+msgid "Print"
+msgstr "輸入"
+
+#, python-format
+msgid "You can print %(remaining_jobs)s more text or PDF files of up to %(max_pages)s pages each."
+msgstr ""
+
+#, python-format
+msgid "You can print %(remaining_jobs)s more text files of up to %(max_pages)s pages each."
+msgstr ""
+
+msgid "File (text or PDF)"
+msgstr ""
+
+msgid "File (text)"
+msgstr ""
+
 msgid "Submit"
 msgstr "傳送"
+
+msgid "You cannot print anything any more as you have used up your printing quota."
+msgstr ""
+
+#, fuzzy
+msgid "Previous print jobs"
+msgstr "測試記錄"
 
 msgid "Date and time"
 msgstr "日期與時間"
@@ -552,8 +765,88 @@ msgstr "日期與時間"
 msgid "Time"
 msgstr "時間"
 
+#, fuzzy
+msgid "File name"
+msgstr "標題"
+
 msgid "Status"
 msgstr "狀態"
+
+#, fuzzy
+msgid "Preparing..."
+msgstr "執行中..."
+
+#, fuzzy
+msgid "no print jobs yet"
+msgstr "尚未測試"
+
+msgid "The passwords do not match!"
+msgstr ""
+
+msgid "This username is already taken, please choose a different one."
+msgstr ""
+
+msgid "This user is already registered in the contest."
+msgstr ""
+
+msgid "No such user."
+msgstr ""
+
+msgid "The password is not correct."
+msgstr ""
+
+#, fuzzy
+msgid "Registration"
+msgstr "註冊"
+
+msgid "Please fill in the fields to register"
+msgstr ""
+
+#, fuzzy
+msgid "New user"
+msgstr "新回覆"
+
+#, fuzzy
+msgid "Join contest"
+msgstr "選擇一場競賽"
+
+msgid "First name"
+msgstr ""
+
+#, fuzzy
+msgid "Last name"
+msgstr "標題"
+
+#, fuzzy
+msgid "E-mail"
+msgstr "詳細資料"
+
+#, fuzzy
+msgid "Representing"
+msgstr "線上測試"
+
+#, python-format
+msgid "Must be one character or more."
+msgid_plural "Must be %(min_length)s characters or more."
+msgstr[0] ""
+
+#, fuzzy
+msgid "Confirm password"
+msgstr "密碼"
+
+msgid "Registered in the contest successfully!"
+msgstr ""
+
+#, fuzzy
+msgid "Your username is:"
+msgstr "帳號"
+
+msgid "Your password is stored securely."
+msgstr ""
+
+#, fuzzy
+msgid "Back to login"
+msgstr "無法登入"
 
 msgid "Compilation output"
 msgstr "編譯訊息"
@@ -614,11 +907,18 @@ msgstr "詳細資訊"
 msgid "Compilation commands"
 msgstr "編譯指令"
 
+#, fuzzy, python-format
+msgid "You can find the rules for the %(type_pl)s on the <a href=\"%(contest_root)s\">contest overview page</a>."
+msgstr "在題目敘述頁面中, 可以看到該題目 %(type_pl)s 的使用規則."
+
 msgid "Remember that to see the detailed result of a submission you need to use both a contest-token and a task-token."
 msgstr "請注意: 欲觀看詳細的評測結果, 須使用競賽-Token 與題目-Token 各一枚."
 
 msgid "Attachments"
 msgstr "附件"
+
+msgid "unknown"
+msgstr ""
 
 msgid "loading..."
 msgstr "載入中..."
@@ -627,11 +927,41 @@ msgstr "載入中..."
 msgid "%(name)s (%(short_name)s) <small>submissions</small>"
 msgstr "%(name)s (%(short_name)s) <small>評測頁面</small>"
 
+#, fuzzy
+msgid "Score:"
+msgstr "得分"
+
+#, fuzzy
+msgid "Public score:"
+msgstr "公開得分"
+
+#, fuzzy
+msgid "Score of tokened submissions:"
+msgstr "評測記錄"
+
+#, fuzzy
+msgid "Total score:"
+msgstr "總得分"
+
 msgid "Submit a solution"
 msgstr "傳送作答"
 
+msgid "You may submit any subset of outputs in a single submission."
+msgstr ""
+
+#, python-format
+msgid "You can submit %(submissions_left)s more solution(s)."
+msgstr ""
+
+#, fuzzy
+msgid "submission.zip"
+msgstr "評測頁面"
+
 msgid "Previous submissions"
 msgstr "評測記錄"
+
+msgid "Tokens are not allowed on this task."
+msgstr ""
 
 msgid "Right now, you have infinite tokens available on this task."
 msgstr "您擁有無限量供應的 Token 可供使用於本題."
@@ -661,6 +991,14 @@ msgstr "本題 Token 已用盡."
 msgid "But you will have to wait until %(expiration_time)s to use it."
 msgstr "但需等待至 %(expiration_time)s 後才可再次使用 Token."
 
+#, fuzzy
+msgid "Unofficial submissions"
+msgstr "評測頁面"
+
+#, fuzzy
+msgid "Official submissions"
+msgstr "評測頁面"
+
 msgid "Submission details"
 msgstr "傳送詳細資料"
 
@@ -672,6 +1010,14 @@ msgstr "下載"
 
 msgid "Submit a test"
 msgstr "傳送測試"
+
+#, python-format
+msgid "You can submit %(user_tests_left)s more test(s)."
+msgstr ""
+
+#, fuzzy
+msgid "input"
+msgstr "輸入"
 
 msgid "Previous tests"
 msgstr "測試記錄"
@@ -697,21 +1043,24 @@ msgstr "等待中..."
 msgid "None"
 msgstr "無"
 
-msgid "Public score"
-msgstr "公開得分"
+msgid "Token request discarded"
+msgstr "Token 已繳交"
 
-msgid "Total score"
-msgstr "總得分"
+msgid "Your request has been discarded because you have no tokens available."
+msgstr "Token 已經用光囉"
 
-msgid "Score"
-msgstr "得分"
+msgid "Your request has been discarded because you already used a token on that submission."
+msgstr "本次傳送已使用過 Token"
 
-msgid "Played"
-msgstr "已使用"
+msgid "Invalid file"
+msgstr ""
 
-msgid "Play!"
-msgstr "現在使用"
+msgid "Print job has too many pages"
+msgstr ""
 
-msgid "No tokens"
-msgstr "Token 已用盡"
+msgid "Sent to printer"
+msgstr ""
+
+#~ msgid "Standard Template Library"
+#~ msgstr "STL 標準樣板函數庫"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,8 @@ mapping_file: babel_mapping.cfg
 keywords: n_:1,2 Nn_:1,2
 output_file: cms/locale/cms.pot
 no_location: 1
-width: 79
+sort_by_file: 1
+no_wrap: 1
 project: Contest Management System
 copyright_holder: CMS development group
 msgid_bugs_address: contestms@googlegroups.com
@@ -14,13 +15,13 @@ msgid_bugs_address: contestms@googlegroups.com
 domain: cms
 input_file: cms/locale/cms.pot
 output_dir: cms/locale
-width: 79
+no_wrap: 1
 
 [update_catalog]
 domain: cms
 input_file: cms/locale/cms.pot
 output_dir: cms/locale
-width: 79
+no_wrap: 1
 
 [compile_catalog]
 domain: cms


### PR DESCRIPTION
By default, `./setup.py extract_messages` will generate the .pot file in basically a random order (depending on the order of os.listdir, which returns the files in whichever order they are actually stored on disk). This means running extract_messages effectively shuffles the .pot file, generating an unnecessarily large diff and introducing merge conflicts.

To fix this, I added `sort_by_file: 1` to the extract_messages settings in setup.cfg, which sorts the strings in the .pot file by the filepath they are used in.

I then also ran extract_messages. Of course, because the order changed again, this commit once again does some arbitrary shuffling of the strings, but hopefully this is the last time it happens :)

I also ran update_catalog for all languages; hopefully this makes new strings show up on Weblate properly.