### PR TITLE
CWS: fix submission language selector

### DIFF
--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -6,19 +6,6 @@
 
 {% set score_type = get_score_type(dataset=task.active_dataset) %}
 
-{% block js_init %}
-// Define TASK_LANGUAGES for task-specific language filtering
-var TASK_LANGUAGES = {
-{% for lang in task.get_allowed_languages() or [] %}
-    '{{ lang }}': {
-{% for extension in (lang|to_language).source_extensions %}
-        '{{ extension }}': true,
-{% endfor %}
-    },
-{% endfor %}
-};
-{% endblock js_init %}
-
 {# Whether tokens are allowed on this contest. #}
 {% set can_use_tokens_in_contest =
        tokens_contest != TOKEN_MODE_DISABLED
@@ -37,6 +24,16 @@ var TASK_LANGUAGES = {
 {% set can_play_token_now = can_play_token and tokens_info[2] is none %}
 
 {% block additional_js %}
+// Define TASK_LANGUAGES for task-specific language filtering
+var TASK_LANGUAGES = {
+{% for lang in task.get_allowed_languages() or [] %}
+    '{{ lang }}': {
+{% for extension in (lang|to_language).source_extensions %}
+        '{{ extension }}': true,
+{% endfor %}
+    },
+{% endfor %}
+};
 
 $(document).on("click", ".submission_list tbody tr td.status .details", function (event) {
     var submission_id = $(this).parent().parent().attr("data-submission");

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -2,20 +2,22 @@
 
 {% set page = "test_interface" %}
 
-{% block js_init %}
+{% block additional_js %}
 // Define TASK_LANGUAGES for task-specific language filtering
 var TASK_LANGUAGES = {
-{% for lang in task.get_allowed_languages() or [] %}
-    '{{ lang }}': {
-{% for extension in (lang|to_language).source_extensions %}
-        '{{ extension }}': true,
-{% endfor %}
-    },
+{% for task in contest.tasks %}
+  '{{ task.name }}': {
+    {% for lang in task.get_allowed_languages() or [] %}
+      '{{ lang }}': {
+        {% for extension in (lang|to_language).source_extensions %}
+          '{{ extension }}': true,
+        {% endfor %}
+      },
+    {% endfor %}
+  },
 {% endfor %}
 };
-{% endblock js_init %}
 
-{% block additional_js %}
 $(document).on("click", ".user_test_list tbody tr td.status .details", function (event) {
     var $this = $(this);
     var task_id = $this.parent().parent().parent().parent().attr("data-task");
@@ -117,8 +119,10 @@ $(document).ready(function () {
                     <div class="controls">
                         <input type="file" class="input-xlarge"
                                id="input{{ loop.index0 }}" name="{{ filename }}"
-                               onchange="CMS.CWSUtils.filter_languages($(this).parents('form').find('select[name=language] option'),
-                                                                       $(this).parents('form').find('input[type=file]').not('#input_file'), TASK_LANGUAGES)"/>
+                               onchange="CMS.CWSUtils.filter_languages(
+                                   $(this).parents('form').find('select[name=language] option'),
+                                   $(this).parents('form').find('input[type=file]').not('#input_file'),
+                                   TASK_LANGUAGES['{{ task.name }}'])"/>
                     </div>
                 </div>
 {% endfor %}


### PR DESCRIPTION
#1486 broke the JS for language selection. I guess it's partially my fault for not locally testing it enough...

CWS doesn't use the js_init block, so this code was never getting evaluated at all. This seems like a weird failure mode in jinja, the entire block just gets completely ignored with no error?

I moved it to the correct additional_js block; and fixed the logic in test_interface. (that one has all tasks on the same page, so one global TASK_LANGUAGES isn't enough.)