### PR TITLE
CWS: show "task overview" table on contest overview page in more cases

### DIFF
--- a/cms/server/contest/templates/overview.html
+++ b/cms/server/contest/templates/overview.html
@@ -179,7 +179,7 @@
 
 
 
-{% if actual_phase == 0 or actual_phase == 3 or participation.unrestricted or (0 <= actual_phase <= 3 and contest.allow_unofficial_submission_before_analysis_mode)%}
+{% if actual_phase >= 0 or participation.unrestricted %}
 <h2>{% trans %}Task overview{% endtrans %}</h2>
 
 <table class="table table-bordered table-striped">


### PR DESCRIPTION
This used to only be shown when submissions were allowed, but I think it makes more sense to show it whenever the task statement pages are visible.