### PR TITLE
CWS: Mark ajax request endpoints as @api_login_required

### DIFF
--- a/cms/server/contest/handlers/api.py
+++ b/cms/server/contest/handlers/api.py
@@ -20,18 +20,15 @@
 
 """
 
-from collections.abc import Callable
-import functools
 import ipaddress
 import logging
-import typing
 
 from cms.db.submission import Submission
 from cms.server import multi_contest
 from cms.server.contest.authentication import validate_login
 from cms.server.contest.submission import \
     UnacceptableSubmission, accept_submission
-from .contest import ContestHandler
+from .contest import ContestHandler, api_login_required
 from ..phase_management import actual_phase_required
 
 logger = logging.getLogger(__name__)
@@ -45,27 +42,6 @@ class ApiContestHandler(ContestHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.api_request = True
-
-
-_P = typing.ParamSpec("_P")
-_R = typing.TypeVar("_R")
-_Self = typing.TypeVar("_Self", bound="ApiContestHandler")
-
-def api_login_required(
-    func: Callable[typing.Concatenate[_Self, _P], _R],
-) -> Callable[typing.Concatenate[_Self, _P], _R | None]:
-    """A decorator filtering out unauthenticated requests.
-
-    """
-
-    @functools.wraps(func)
-    def wrapped(self: _Self, *args: _P.args, **kwargs: _P.kwargs):
-        if not self.current_user:
-            self.json({"error": "An authenticated user is required"}, 403)
-        else:
-            return func(self, *args, **kwargs)
-
-    return wrapped
 
 
 class ApiLoginHandler(ApiContestHandler):

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -58,7 +58,7 @@ from cms.server.contest.printing import accept_print_job, PrintingDisabled, \
     UnacceptablePrintJob
 from cmscommon.crypto import hash_password, validate_password
 from cmscommon.datetime import make_datetime, make_timestamp
-from .contest import ContestHandler
+from .contest import ContestHandler, api_login_required
 from ..phase_management import actual_phase_required
 
 
@@ -294,7 +294,7 @@ class NotificationsHandler(ContestHandler):
 
     refresh_cookie = False
 
-    @tornado.web.authenticated
+    @api_login_required
     @multi_contest
     def get(self):
         participation: Participation = self.current_user

--- a/cms/server/contest/handlers/tasksubmission.py
+++ b/cms/server/contest/handlers/tasksubmission.py
@@ -57,7 +57,7 @@ from cms.server.contest.tokening import \
     UnacceptableToken, TokenAlreadyPlayed, accept_token, tokens_available
 from cmscommon.crypto import encrypt_number
 from cmscommon.mimetypes import get_type_for_file_name
-from .contest import ContestHandler, FileHandler
+from .contest import ContestHandler, FileHandler, api_login_required
 from ..phase_management import actual_phase_required
 
 
@@ -236,7 +236,7 @@ class SubmissionStatusHandler(ContestHandler):
             data["task_tokened_score"], score_type.max_score, None,
             task.score_precision, translation=self.translation)
 
-    @tornado.web.authenticated
+    @api_login_required
     @actual_phase_required(0, 1, 2, 3, 4)
     @multi_contest
     def get(self, task_name, opaque_id):
@@ -296,7 +296,7 @@ class SubmissionDetailsHandler(ContestHandler):
 
     refresh_cookie = False
 
-    @tornado.web.authenticated
+    @api_login_required
     @actual_phase_required(0, 1, 2, 3, 4)
     @multi_contest
     def get(self, task_name, opaque_id):

--- a/cms/server/contest/handlers/taskusertest.py
+++ b/cms/server/contest/handlers/taskusertest.py
@@ -48,7 +48,7 @@ from cms.server.contest.submission import get_submission_count, \
     TestingNotAllowed, UnacceptableUserTest, accept_user_test
 from cmscommon.crypto import encrypt_number
 from cmscommon.mimetypes import get_type_for_file_name
-from .contest import ContestHandler, FileHandler
+from .contest import ContestHandler, FileHandler, api_login_required
 from ..phase_management import actual_phase_required
 
 
@@ -166,7 +166,7 @@ class UserTestStatusHandler(ContestHandler):
 
     refresh_cookie = False
 
-    @tornado.web.authenticated
+    @api_login_required
     @actual_phase_required(0)
     @multi_contest
     def get(self, task_name, user_test_num):
@@ -221,7 +221,7 @@ class UserTestDetailsHandler(ContestHandler):
 
     refresh_cookie = False
 
-    @tornado.web.authenticated
+    @api_login_required
     @actual_phase_required(0)
     @multi_contest
     def get(self, task_name, user_test_num):

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -40,7 +40,11 @@ $(document).on("click", ".submission_list tbody tr td.status .details", function
     var modal = $("#submission_detail");
     var modal_body = modal.children(".modal-body");
     modal_body.html('<div class="loading"><img src="{{ url("static", "loading.gif") }}"/>{% trans %}loading...{% endtrans %}</div>');
-    modal_body.load(utils.contest_url("tasks", "{{ task.name }}", "submissions", submission_id, "details"), function() {
+    modal_body.load(utils.contest_url("tasks", "{{ task.name }}", "submissions", submission_id, "details"), function(response, status, xhr) {
+        if(status != "success") {
+            $(this).html("{% trans %}Error loading details, please refresh the page.{% endtrans %}");
+            return;
+        }
         $(".score_details .subtask .subtask-head").each(function () {
             $(this).prepend("<i class=\"icon-chevron-right\"></i>");
         });

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -25,7 +25,11 @@ $(document).on("click", ".user_test_list tbody tr td.status .details", function 
     var modal = $("#user_test_detail");
     var modal_body = modal.children(".modal-body");
     modal_body.html('<div class="loading"><img src="{{ url("static", "loading.gif") }}"/>{% trans %}loading...{% endtrans %}</div>');
-    modal_body.load(utils.contest_url("tasks", task_id, "tests", user_test_id, "details"));
+    modal_body.load(utils.contest_url("tasks", task_id, "tests", user_test_id, "details"), function(response, status, xhr) {
+        if(status != "success") {
+            $(this).html("{% trans %}Error loading details, please refresh the page.{% endtrans %}");
+        }
+    });
     modal.modal("show");
 });
 


### PR DESCRIPTION
This prevents cases where ajax requests would redirect to the login screen unexpectedly. Also improved handling of errors in the submission details popup.

Fixes #1089.