### PR TITLE
Serve static files with their expected hashes for cache-busting

### DIFF
--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -326,6 +326,7 @@ class BaseHandler(CommonRequestHandler):
         params["timestamp"] = make_datetime()
         params["contest"] = self.contest
         params["url"] = self.url
+        params["static_url"] = self.static_url_helper
         params["xsrf_form_html"] = self.xsrf_form_html()
         # FIXME These objects provide too broad an access: their usage
         # should be extracted into with narrower-scoped parameters.

--- a/cms/server/admin/templates/base.html
+++ b/cms/server/admin/templates/base.html
@@ -2,18 +2,18 @@
 <html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <link rel="shortcut icon" href="{{ url("static", "favicon.ico") }}" />
-    <link rel="stylesheet" type="text/css" href="{{ url("static", "reset.css") }}">
-    <link rel="stylesheet" type="text/css" href="{{ url("static", "aws_style.css") }}">
-    <script src="{{ url("static", "web_rpc.js") }}"></script>
-    <script src="{{ url("static", "aws_utils.js") }}"></script>
-    <script src="{{ url("static", "jq", "jquery-3.6.0.min.js") }}"></script>
-    <script src="{{ url("static", "jq", "jquery.jqplot.min.js") }}"></script>
-    <script src="{{ url("static", "jq", "jqplot.dateAxisRenderer.min.js") }}"></script>
-    <script src="{{ url("static", "jq", "jqplot.enhancedLegendRenderer.min.js") }}"></script>
-    <link rel="stylesheet" type="text/css" href="{{ url("static", "jq", "jquery.jqplot.min.css") }}"/>
-    <link rel="stylesheet" type="text/css" href="{{ url("static", "prism.css") }}">
-    <script src="{{ url("static", "prism.js") }}" data-manual></script>
+    <link rel="shortcut icon" href="{{ static_url("static", "favicon.ico") }}" />
+    <link rel="stylesheet" type="text/css" href="{{ static_url("static", "reset.css") }}">
+    <link rel="stylesheet" type="text/css" href="{{ static_url("static", "aws_style.css") }}">
+    <script src="{{ static_url("static", "web_rpc.js") }}"></script>
+    <script src="{{ static_url("static", "aws_utils.js") }}"></script>
+    <script src="{{ static_url("static", "jq", "jquery-3.6.0.min.js") }}"></script>
+    <script src="{{ static_url("static", "jq", "jquery.jqplot.min.js") }}"></script>
+    <script src="{{ static_url("static", "jq", "jqplot.dateAxisRenderer.min.js") }}"></script>
+    <script src="{{ static_url("static", "jq", "jqplot.enhancedLegendRenderer.min.js") }}"></script>
+    <link rel="stylesheet" type="text/css" href="{{ static_url("static", "jq", "jquery.jqplot.min.css") }}"/>
+    <link rel="stylesheet" type="text/css" href="{{ static_url("static", "prism.css") }}">
+    <script src="{{ static_url("static", "prism.js") }}" data-manual></script>
 
     {% if contest is none %}
     <title>Admin</title>

--- a/cms/server/admin/templates/login.html
+++ b/cms/server/admin/templates/login.html
@@ -3,9 +3,9 @@
 <html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <link rel="shortcut icon" href="{{ url("static", "favicon.ico") }}" />
-    <link rel="stylesheet" type="text/css" href="{{ url("static", "reset.css") }}">
-    <link rel="stylesheet" type="text/css" href="{{ url("static", "aws_style.css") }}">
+    <link rel="shortcut icon" href="{{ static_url("static", "favicon.ico") }}" />
+    <link rel="stylesheet" type="text/css" href="{{ static_url("static", "reset.css") }}">
+    <link rel="stylesheet" type="text/css" href="{{ static_url("static", "aws_style.css") }}">
     <title>Admin</title>
   </head>
   <body class="admin">

--- a/cms/server/admin/templates/overview.html
+++ b/cms/server/admin/templates/overview.html
@@ -258,7 +258,7 @@ update_statuses();
       </tr>
     </thead>
     <tbody>
-      <tr><td style="text-align: center;" colspan="2"><img src="{{ url("static", "loading.gif") }}" alt="loading..." /></td></tr>
+      <tr><td style="text-align: center;" colspan="2"><img src="{{ static_url("static", "loading.gif") }}" alt="loading..." /></td></tr>
     </tbody>
   </table>
   <div class="hr"></div>
@@ -277,7 +277,7 @@ update_statuses();
       </tr>
     </thead>
     <tbody>
-      <tr><td style="text-align: center;" colspan="4"><img src="{{ url("static", "loading.gif") }}" alt="loading..." /></td></tr>
+      <tr><td style="text-align: center;" colspan="4"><img src="{{ static_url("static", "loading.gif") }}" alt="loading..." /></td></tr>
     </tbody>
   </table>
   <div class="hr"></div>
@@ -296,7 +296,7 @@ update_statuses();
       </tr>
     </thead>
     <tbody>
-      <tr><td style="text-align: center;" colspan="5"><img src="{{ url("static", "loading.gif") }}" alt="loading..." /></td></tr>
+      <tr><td style="text-align: center;" colspan="5"><img src="{{ static_url("static", "loading.gif") }}" alt="loading..." /></td></tr>
     </tbody>
   </table>
   <div class="hr"></div>
@@ -316,7 +316,7 @@ update_statuses();
       </tr>
     </thead>
     <tbody>
-      <tr><td style="text-align: center;" colspan="5"><img src="{{ url("static", "loading.gif") }}" alt="loading..." /></td></tr>
+      <tr><td style="text-align: center;" colspan="5"><img src="{{ static_url("static", "loading.gif") }}" alt="loading..." /></td></tr>
     </tbody>
   </table>
   <div class="hr"></div>

--- a/cms/server/admin/templates/resources.html
+++ b/cms/server/admin/templates/resources.html
@@ -211,7 +211,7 @@ var getters = [];
 
         kill_service: function(s, link)
         {
-            link.parentNode.innerHTML = '<img src="{{ url("static", "loading.gif") }}" alt="loading..." />';
+            link.parentNode.innerHTML = '<img src="{{ static_url("static", "loading.gif") }}" alt="loading..." />';
             cmsrpc_request("ResourceService", this.shard,
                            "kill_service",
                            {"service": s});
@@ -302,7 +302,7 @@ for (var i in shards)
       </tr>
     </thead>
     <tbody>
-      <tr><td style="text-align: center;" colspan="8"><img src="{{ url("static", "loading.gif") }}" alt="loading..." /></td></tr>
+      <tr><td style="text-align: center;" colspan="8"><img src="{{ static_url("static", "loading.gif") }}" alt="loading..." /></td></tr>
     </tbody>
   </table>
 

--- a/cms/server/contest/handlers/base.py
+++ b/cms/server/contest/handlers/base.py
@@ -136,6 +136,7 @@ class BaseHandler(CommonRequestHandler):
         ret["now"] = self.timestamp
         ret["utc"] = utc_tzinfo
         ret["url"] = self.url
+        ret["static_url"] = self.static_url_helper
 
         ret["available_translations"] = self.available_translations
 

--- a/cms/server/contest/templates/base.html
+++ b/cms/server/contest/templates/base.html
@@ -6,15 +6,15 @@
 
         <title>{% block title %}{% endblock title %}</title>
 
-        <link rel="shortcut icon" href="{{ url("static", "favicon.ico") }}" />
-        <link rel="stylesheet" href="{{ url("static", "css", "bootstrap.css") }}">
-        <link rel="stylesheet" href="{{ url("static", "cws_style.css") }}">
+        <link rel="shortcut icon" href="{{ static_url("static", "favicon.ico") }}" />
+        <link rel="stylesheet" href="{{ static_url("static", "css", "bootstrap.css") }}">
+        <link rel="stylesheet" href="{{ static_url("static", "cws_style.css") }}">
 
-        <script src="{{ url("static", "jq", "jquery-3.6.0.min.js") }}"></script>
+        <script src="{{ static_url("static", "jq", "jquery-3.6.0.min.js") }}"></script>
         {# For compatibility with Bootstrap 2.x #}
-        <script src="{{ url("static", "jq", "jquery-migrate-3.3.2.min.js") }}"></script>
-        <script src="{{ url("static", "js", "bootstrap.js") }}"></script>
-        <script src="{{ url("static", "cws_utils.js") }}"></script>
+        <script src="{{ static_url("static", "jq", "jquery-migrate-3.3.2.min.js") }}"></script>
+        <script src="{{ static_url("static", "js", "bootstrap.js") }}"></script>
+        <script src="{{ static_url("static", "cws_utils.js") }}"></script>
 
         {% block js %}{% endblock js %}
     </head>

--- a/cms/server/contest/templates/macro/submission.html
+++ b/cms/server/contest/templates/macro/submission.html
@@ -1,4 +1,4 @@
-{% macro rows(url, contest_url, translation, xsrf_form_html,
+{% macro rows(url, static_url, contest_url, translation, xsrf_form_html,
               actual_phase, task, submissions,
               can_use_tokens, can_play_token, can_play_token_now,
               tokens_info,
@@ -7,6 +7,7 @@
 Render a submission table with all (un)official submissions passed.
 
 url (Url): the URL instance referring to the root of CWS.
+static_url: static url helper constructed from url
 contest_url (Url): the URL instance referring to the main contest page.
 translation (Translation): locale to use to show messages.
 xsrf_form_html (str): input element for the XSRF protection.
@@ -91,6 +92,7 @@ official (boolean): whether to display only the official (true) or unofficial
                 {# loop.revindex is broken: https://github.com/pallets/jinja/issues/794 #}
                 {{ row(
                     url,
+                    static_url,
                     contest_url,
                     translation,
                     xsrf_form_html,
@@ -110,7 +112,7 @@ official (boolean): whether to display only the official (true) or unofficial
 </table>
 {%- endmacro %}
 
-{% macro row(url, contest_url, translation, xsrf_form_html,
+{% macro row(url, static_url, contest_url, translation, xsrf_form_html,
              actual_phase, s, opaque_id, show_date,
              can_use_tokens, can_play_token, can_play_token_now,
              tokens_info,
@@ -119,6 +121,7 @@ official (boolean): whether to display only the official (true) or unofficial
 Render a row in a submission table.
 
 url (Url): the URL instance referring to the root of CWS.
+static_url: static url helper constructed from url
 contest_url (Url): the URL instance referring to the main contest page.
 translation (Translation): locale to use to show messages.
 xsrf_form_html (str): input element for the XSRF protection.
@@ -149,16 +152,16 @@ submissions_download_allowed (bool): whether to allow users to download
     <td class="status">
 {% if status == SubmissionResult.COMPILING %}
         {% trans %}Compiling...{% endtrans %}
-      <img class="details" src="{{ url("static", "loading.gif") }}" />
+      <img class="details" src="{{ static_url("static", "loading.gif") }}" />
 {% elif status == SubmissionResult.COMPILATION_FAILED %}
         {% trans %}Compilation failed{% endtrans %}
         <a class="details">{% trans %}details{% endtrans %}</a>
 {% elif status == SubmissionResult.EVALUATING %}
         {% trans %}Evaluating...{% endtrans %}
-      <img class="details" src="{{ url("static", "loading.gif") }}" />
+      <img class="details" src="{{ static_url("static", "loading.gif") }}" />
 {% elif status == SubmissionResult.SCORING %}
         {% trans %}Scoring...{% endtrans %}
-      <img class="details" src="{{ url("static", "loading.gif") }}" />
+      <img class="details" src="{{ static_url("static", "loading.gif") }}" />
 {% elif status == SubmissionResult.SCORED %}
         {% trans %}Evaluated{% endtrans %}
         <a class="details">{% trans %}details{% endtrans %}</a>

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -186,9 +186,9 @@
             <li>
                 <a href="{{ contest_url("tasks", task.name, "attachments", filename) }}" class="btn">
             {% if type_icon is not none %}
-                    <img src="{{ url("static", "img", "mimetypes", "%s.png"|format(type_icon)) }}" alt="{{ mime_type }}" />
+                    <img src="{{ static_url("static", "img", "mimetypes", "%s.png"|format(type_icon)) }}" alt="{{ mime_type }}" />
             {% else %}
-                    <img src="{{ url("static", "img", "mimetypes", "unknown.png") }}" alt="{% trans %}unknown{% endtrans %}" />
+                    <img src="{{ static_url("static", "img", "mimetypes", "unknown.png") }}" alt="{% trans %}unknown{% endtrans %}" />
             {% endif %}
                     <span class="first_line">
                         <span class="name">{{ filename }}</span>

--- a/cms/server/contest/templates/task_submissions.html
+++ b/cms/server/contest/templates/task_submissions.html
@@ -39,7 +39,7 @@ $(document).on("click", ".submission_list tbody tr td.status .details", function
     var submission_id = $(this).parent().parent().attr("data-submission");
     var modal = $("#submission_detail");
     var modal_body = modal.children(".modal-body");
-    modal_body.html('<div class="loading"><img src="{{ url("static", "loading.gif") }}"/>{% trans %}loading...{% endtrans %}</div>');
+    modal_body.html('<div class="loading"><img src="{{ static_url("static", "loading.gif") }}"/>{% trans %}loading...{% endtrans %}</div>');
     modal_body.load(utils.contest_url("tasks", "{{ task.name }}", "submissions", submission_id, "details"), function(response, status, xhr) {
         if(status != "success") {
             $(this).html("{% trans %}Error loading details, please refresh the page.{% endtrans %}");
@@ -108,7 +108,7 @@ update_score = function(score_elem, task_score_elem,
     task_score_span.text(task_score_message);
     if (task_score_is_partial) {
         task_score_span.append(
-            $("<img class=\"details\" src=\"{{ url("static", "loading.gif") }}\"/>"));
+            $("<img class=\"details\" src=\"{{ static_url("static", "loading.gif") }}\"/>"));
     }
     task_score_elem.removeClass("undefined");
     task_score_elem.removeClass("score_0");
@@ -124,7 +124,7 @@ update_scores = function (submission_id, data) {
     var terminal_status = is_status_terminal(data["status"]);
     if (!terminal_status) {
         row.children("td.status").append(
-            $("<img class=\"details\" src=\"{{ url("static", "loading.gif") }}\"/>"));
+            $("<img class=\"details\" src=\"{{ static_url("static", "loading.gif") }}\"/>"));
     } else {
         row.children("td.status").append(
             $("<a class=\"details\">{% trans %}details{% endtrans %}</a>"));
@@ -205,7 +205,7 @@ $(document).ready(function () {
         <span class="score">
             {{ score_type.format_score(public_score, score_type.max_public_score, none, task.score_precision, translation=translation) }}
         {% if is_score_partial %}
-            <img src="{{ url("static", "loading.gif") }}" />
+            <img src="{{ static_url("static", "loading.gif") }}" />
         {% endif %}
         </span>
     </div>
@@ -227,7 +227,7 @@ $(document).ready(function () {
         {% if can_use_tokens %}
             {{ score_type.format_score(tokened_score, score_type.max_score, none, task.score_precision, translation=translation) }}
             {% if is_score_partial %}
-            <img src="{{ url("static", "loading.gif") }}" />
+            <img src="{{ static_url("static", "loading.gif") }}" />
             {% endif %}
         {% else %}
             {% trans %}N/A{% endtrans %}
@@ -366,6 +366,7 @@ $(document).ready(function () {
 <h3>{% trans %}Unofficial submissions{% endtrans %}</h3>
   {{ macro_submission.rows(
       url,
+      static_url,
       contest_url,
       translation,
       xsrf_form_html,
@@ -383,6 +384,7 @@ $(document).ready(function () {
 
 {{ macro_submission.rows(
     url,
+    static_url,
     contest_url,
     translation,
     xsrf_form_html,

--- a/cms/server/contest/templates/test_interface.html
+++ b/cms/server/contest/templates/test_interface.html
@@ -24,7 +24,7 @@ $(document).on("click", ".user_test_list tbody tr td.status .details", function 
     var user_test_id = $this.parent().parent().attr("data-user-test");
     var modal = $("#user_test_detail");
     var modal_body = modal.children(".modal-body");
-    modal_body.html('<div class="loading"><img src="{{ url("static", "loading.gif") }}"/>{% trans %}loading...{% endtrans %}</div>');
+    modal_body.html('<div class="loading"><img src="{{ static_url("static", "loading.gif") }}"/>{% trans %}loading...{% endtrans %}</div>');
     modal_body.load(utils.contest_url("tasks", task_id, "tests", user_test_id, "details"), function(response, status, xhr) {
         if(status != "success") {
             $(this).html("{% trans %}Error loading details, please refresh the page.{% endtrans %}");

--- a/cms/server/util.py
+++ b/cms/server/util.py
@@ -45,6 +45,8 @@ from cms.db import Session
 from cms.server.file_middleware import FileServerMiddleware
 from cmscommon.datetime import make_datetime
 
+if typing.TYPE_CHECKING:
+    from cms.io.web_service import WebService
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +185,7 @@ class CommonRequestHandler(RequestHandler):
         self.r_params = None
         self.contest = None
         self.url: Url = None
+        self.static_url_helper = None
 
     def prepare(self):
         """This method is executed at the beginning of each request.
@@ -190,6 +193,7 @@ class CommonRequestHandler(RequestHandler):
         """
         super().prepare()
         self.url = Url(get_url_root(self.request.path))
+        self.static_url_helper = self.service.static_file_hasher.make(self.url)
         self.set_header("Cache-Control", "no-cache, must-revalidate")
 
     def finish(self, *args, **kwargs):
@@ -216,5 +220,5 @@ class CommonRequestHandler(RequestHandler):
             logger.debug("Connection closed before our reply.")
 
     @property
-    def service(self):
+    def service(self) -> "WebService":
         return self.application.service


### PR DESCRIPTION
This makes it unnecessary to do a hard refresh after editing static files (especially relevant for cws_utils.js or cws_style.css), as the edited files will have a different hash and thus will be cached separately.

I actually would have liked to do this for RWS too, but RWS's Ranking.html is a static file, not a jinja template. I guess we'd need some different solution for it.