### PR TITLE
Remove token for codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,17 +37,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload unit test coverage results to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: ${{ !cancelled() }}
         with:
           files: ./codecov/unittests.xml
           flags: unittests
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload functional test coverage results to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: ${{ !cancelled() }}
         with:
           files: ./codecov/functionaltests.xml
           flags: functionaltests
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
In v5 it should not be required anymore for public repositories

See https://github.com/codecov/codecov-action?tab=readme-ov-file#v5-release