### PR TITLE
Allow setting sandbox parameters per-language, make sandbox more restrictive

### DIFF
--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -287,23 +287,22 @@ class Sandbox:
         # between sandboxes.
         self.dirs.append((None, "/dev/shm", "tmp"))
 
-        # Set common environment variables.
+        # Set common configuration that is relevant for multiple
+        # languages.
+
+        self.set_env["PATH"] = "/usr/local/bin:/usr/bin:/bin"
+
         # Specifically needed by Python, that searches the home for
         # packages.
         self.set_env["HOME"] = self._home_dest
 
-        # Needed on Ubuntu by PHP (and more), since /usr/bin only contains a
-        # symlink to one out of many alternatives.
+        # Needed on Ubuntu by PHP, Java, Pascal etc, since /usr/bin
+        # only contains a symlink to one out of many alternatives.
         self.maybe_add_mapped_directory("/etc/alternatives")
 
         # On Arch Linux, pypy3 is installed in `/opt` and `/usr/bin/pypy3` is
         # just a symlink.
         self.maybe_add_mapped_directory("/opt/pypy3")
-
-        # Likewise, needed by C# programs. The Mono runtime looks in
-        # /etc/mono/config to obtain the default DllMap, which includes, in
-        # particular, the System.Native assembly.
-        self.maybe_add_mapped_directory("/etc/mono", options="noexec")
 
         # Tell isolate to get the sandbox ready. We do our best to cleanup
         # after ourselves, but we might have missed something if a previous
@@ -769,9 +768,6 @@ class Sandbox:
 
             # Put archive to FS
             sandbox_archive.seek(0)
-            return file_cacher.put_file_from_fobj(
-                sandbox_archive, "Sandbox %s" % self.get_root_path()
-            )
 
     def add_mapped_directory(
         self,

--- a/cms/grading/language.py
+++ b/cms/grading/language.py
@@ -21,6 +21,7 @@
 import logging
 import os
 from abc import ABCMeta, abstractmethod
+from cms.grading.Sandbox import Sandbox
 
 
 logger = logging.getLogger(__name__)
@@ -135,6 +136,13 @@ class Language(metaclass=ABCMeta):
         """
         pass
 
+    def configure_compilation_sandbox(self, sandbox: Sandbox):
+        """
+        Set sandbox parameters necessary for running the compilation
+        commands.
+        """
+        pass
+
     @abstractmethod
     def get_evaluation_commands(
         self,
@@ -153,6 +161,13 @@ class Language(metaclass=ABCMeta):
         return: a list of commands, each a list of
             strings to be passed to subprocess.
 
+        """
+        pass
+
+    def configure_evaluation_sandbox(self, sandbox: Sandbox):
+        """
+        Set sandbox parameters necessary for running the evaluation
+        commands.
         """
         pass
 

--- a/cms/grading/languages/csharp_mono.py
+++ b/cms/grading/languages/csharp_mono.py
@@ -67,3 +67,12 @@ class CSharpMono(Language):
             self, executable_filename, main=None, args=None):
         """See Language.get_evaluation_commands."""
         return [["/usr/bin/mono", executable_filename]]
+
+    def configure_compilation_sandbox(self, sandbox):
+        # The Mono runtime looks in /etc/mono/config to obtain the
+        # default DllMap, which includes, in particular, the
+        # System.Native assembly.
+        sandbox.maybe_add_mapped_directory("/etc/mono", options="noexec")
+
+    def configure_evaluation_sandbox(self, sandbox):
+        sandbox.maybe_add_mapped_directory("/etc/mono", options="noexec")

--- a/cms/grading/languages/haskell_ghc.py
+++ b/cms/grading/languages/haskell_ghc.py
@@ -64,6 +64,13 @@ class HaskellGhc(CompiledLanguage):
                          executable_filename, source_filenames[0]])
         return commands
 
+    def configure_compilation_sandbox(self, sandbox):
+        # Directory required to be visible during a compilation with GHC.
+        # GHC looks for the Haskell's package database in
+        # "/usr/lib/ghc/package.conf.d" (already visible by isolate's default,
+        # but it is a symlink to "/var/lib/ghc/package.conf.d")
+        sandbox.maybe_add_mapped_directory("/var/lib/ghc")
+
     @staticmethod
     def _capitalize(string: str):
         dirname, basename = os.path.split(string)

--- a/cms/grading/languages/java_jdk.py
+++ b/cms/grading/languages/java_jdk.py
@@ -21,6 +21,7 @@ in the system.
 
 """
 
+import os
 from shlex import quote as shell_quote
 
 from cms.grading import Language
@@ -91,3 +92,10 @@ class JavaJDK(Language):
             command = ["/usr/bin/java", "-Deval=true", "-Xmx512M", "-Xss64M",
                        main] + args
             return [unzip_command, command]
+
+    def configure_compilation_sandbox(self, sandbox):
+        # the jvm conf directory is often symlinked to /etc in
+        # distributions, but the location of it in /etc is inconsistent.
+        for path in os.listdir("/etc"):
+            if path == "java" or path.startswith("java-"):
+                sandbox.add_mapped_directory(f"/etc/{path}")

--- a/cms/grading/languages/pascal_fpc.py
+++ b/cms/grading/languages/pascal_fpc.py
@@ -60,3 +60,7 @@ class PascalFpc(CompiledLanguage):
         command += ["-O2", "-XSs", "-o%s" % executable_filename]
         command += [source_filenames[0]]
         return [command]
+
+    def configure_compilation_sandbox(self, sandbox):
+        # Needed for /etc/fpc.cfg.
+        sandbox.maybe_add_mapped_directory("/etc")

--- a/cms/grading/languages/python3_pypy.py
+++ b/cms/grading/languages/python3_pypy.py
@@ -79,3 +79,11 @@ class Python3PyPy(CompiledLanguage):
         """See Language.get_evaluation_commands."""
         args = args if args is not None else []
         return [["/usr/bin/pypy3", executable_filename] + args]
+
+    def configure_compilation_sandbox(self, sandbox):
+        # Needed on Arch, where /usr/bin/pypy3 is a symlink into
+        # /opt/pypy3.
+        sandbox.maybe_add_mapped_directory("/opt/pypy3")
+
+    def configure_evaluation_sandbox(self, sandbox):
+        sandbox.maybe_add_mapped_directory("/opt/pypy3")

--- a/cms/grading/steps/evaluation.py
+++ b/cms/grading/steps/evaluation.py
@@ -30,6 +30,7 @@ import subprocess
 
 from cms import config
 from cms.grading.Sandbox import Sandbox
+from cms.grading.language import Language
 from .messages import HumanMessage, MessageCollection
 from .stats import StatsDict, execution_stats
 
@@ -83,6 +84,7 @@ EVALUATION_MESSAGES = MessageCollection([
 def evaluation_step(
     sandbox: Sandbox,
     commands: list[list[str]],
+    language: Language | None,
     time_limit: float | None = None,
     memory_limit: int | None = None,
     dirs_map: dict[str, tuple[str | None, str | None]] | None = None,
@@ -101,6 +103,8 @@ def evaluation_step(
 
     sandbox: the sandbox we consider, already created.
     commands: evaluation commands to execute.
+    language: language of the submission (or None if the commands to
+        execute are not from a Language's get_evaluation_commands).
     time_limit: time limit in seconds (applied to each command);
         if None, no time limit is enforced.
     memory_limit: memory limit in bytes (applied to each command);
@@ -135,7 +139,7 @@ def evaluation_step(
     """
     for command in commands:
         success = evaluation_step_before_run(
-            sandbox, command, time_limit, memory_limit,
+            sandbox, command, language, time_limit, memory_limit,
             None, dirs_map, writable_files, stdin_redirect,
             stdout_redirect, multiprocess, wait=True)
         if not success:
@@ -152,6 +156,7 @@ def evaluation_step(
 def evaluation_step_before_run(
     sandbox: Sandbox,
     command: list[str],
+    language: Language | None,
     time_limit: float | None = None,
     memory_limit: int | None = None,
     wall_limit: float | None = None,
@@ -221,6 +226,10 @@ def evaluation_step_before_run(
 
     sandbox.set_multiprocess(multiprocess)
     sandbox.close_fds = close_fds
+
+    # Configure per-language sandbox parameters.
+    if language:
+        language.configure_evaluation_sandbox(sandbox)
 
     # Actually run the evaluation command.
     logger.debug("Starting execution step.")

--- a/cms/grading/tasktypes/Batch.py
+++ b/cms/grading/tasktypes/Batch.py
@@ -244,7 +244,7 @@ class Batch(TaskType):
 
         # Run the compilation.
         box_success, compilation_success, text, stats = \
-            compilation_step(sandbox, commands)
+            compilation_step(sandbox, commands, language)
 
         # Retrieve the compiled executables.
         job.success = box_success
@@ -311,6 +311,7 @@ class Batch(TaskType):
         box_success, evaluation_success, stats = evaluation_step(
             sandbox,
             commands,
+            language,
             job.time_limit,
             job.memory_limit,
             writable_files=files_allowing_write,

--- a/cms/grading/tasktypes/Communication.py
+++ b/cms/grading/tasktypes/Communication.py
@@ -229,7 +229,7 @@ class Communication(TaskType):
 
         # Run the compilation.
         box_success, compilation_success, text, stats = \
-            compilation_step(sandbox, commands)
+            compilation_step(sandbox, commands, language)
 
         # Retrieve the compiled executables.
         job.success = box_success
@@ -324,6 +324,7 @@ class Communication(TaskType):
         manager_ = evaluation_step_before_run(
             sandbox_mgr,
             manager_command,
+            None,
             manager_time_limit,
             config.sandbox.trusted_sandbox_max_memory_kib * 1024,
             dirs_map=dict((fifo_dir[i], (sandbox_fifo_dir[i], "rw")) for i in indices),
@@ -359,11 +360,13 @@ class Communication(TaskType):
             # Assumes that the actual execution of the user solution is the
             # last command in commands, and that the previous are "setup"
             # that don't need tight control.
+            # TODO: why can't this use normal evaluation step??
             if len(commands) > 1:
                 trusted_step(sandbox_user[i], commands[:-1])
             the_process = evaluation_step_before_run(
                 sandbox_user[i],
                 commands[-1],
+                language,
                 job.time_limit,
                 job.memory_limit,
                 dirs_map={fifo_dir[i]: (sandbox_fifo_dir[i], "rw")},

--- a/cms/grading/tasktypes/Interactive.py
+++ b/cms/grading/tasktypes/Interactive.py
@@ -176,7 +176,7 @@ class Interactive(TaskType):
             sandbox.create_file_from_storage(filename, digest, file_cacher)
 
         box_success, compilation_success, text, stats = compilation_step(
-            sandbox, commands
+            sandbox, commands, language
         )
 
         job.success = box_success
@@ -231,6 +231,7 @@ class Interactive(TaskType):
                     "input.txt",
                 ],
                 "solution_files": [executable_filename],
+                "solution_language": job.language,
                 "controller_wall_limit": self.controller_wall_limit,
                 "controller_time_limit": self.controller_time_limit,
                 "controller_memory_limit": self.controller_memory_limit,

--- a/cms/grading/tasktypes/TwoSteps.py
+++ b/cms/grading/tasktypes/TwoSteps.py
@@ -196,7 +196,7 @@ class TwoSteps(TaskType):
 
         # Run the compilation.
         box_success, compilation_success, text, stats = \
-            compilation_step(sandbox, commands)
+            compilation_step(sandbox, commands, language)
 
         # Retrieve the compiled executables
         job.success = box_success
@@ -253,6 +253,7 @@ class TwoSteps(TaskType):
         first = evaluation_step_before_run(
             first_sandbox,
             first_command,
+            None,
             job.time_limit,
             job.memory_limit,
             dirs_map={fifo_dir: ("/fifo", "rw")},
@@ -277,6 +278,7 @@ class TwoSteps(TaskType):
         second = evaluation_step_before_run(
             second_sandbox,
             second_command,
+            None,
             job.time_limit,
             job.memory_limit,
             dirs_map={fifo_dir: ("/fifo", "rw")},

--- a/cms/grading/tasktypes/interactive_keeper.py
+++ b/cms/grading/tasktypes/interactive_keeper.py
@@ -32,6 +32,7 @@ from cms.grading.steps.evaluation import (
 )
 from cms.grading.steps.stats import merge_execution_stats
 from cms.grading.steps import trusted_step
+from cms.grading.languagemanager import get_language
 
 # Note: we keep a separate interactive keeper (running in a separate
 # process) to avoid opening many file descriptors in the main worker.
@@ -72,6 +73,7 @@ def main():
     solution_commands = config["solution_commands"]
     controller_files = config["controller_files"]
     solution_files = config["solution_files"]
+    solution_language = config["solution_language"]
     controller_wall_limit = config.get("controller_wall_limit")
     controller_time_limit = config.get("controller_time_limit")
     controller_memory_limit = config.get("controller_memory_limit")
@@ -99,9 +101,12 @@ def main():
             with open(os.path.join(temp_dir, path), "rb") as g:
                 shutil.copyfileobj(g, f)
 
+    language = get_language(solution_language)
+
     controller_proc = evaluation_step_before_run(
         controller_sandbox,
         controller_command,
+        None,
         time_limit=controller_time_limit,
         memory_limit=controller_memory_limit,
         wall_limit=controller_wall_limit,
@@ -149,6 +154,7 @@ def main():
             sol_proc = evaluation_step_before_run(
                 sandbox_sol,
                 solution_commands[-1],
+                language,
                 time_limit=solution_time_limit,
                 wall_limit=controller_wall_limit,
                 # the wall-clock limit mostly exists to eventually kill stuck

--- a/cmstestsuite/unit_tests/grading/steps/compilation_test.py
+++ b/cmstestsuite/unit_tests/grading/steps/compilation_test.py
@@ -26,6 +26,7 @@ from cms.grading.steps import COMPILATION_MESSAGES, compilation_step
 from cmstestsuite.unit_tests.grading.steps.fakesandbox \
     import FakeSandbox
 from cmstestsuite.unit_tests.grading.steps.stats_test import get_stats
+from cmstestsuite.unit_tests.grading.tasktypes.tasktypetestutils import LANG_1
 
 
 ONE_COMMAND = [["test", "command"]]
@@ -54,7 +55,7 @@ class TestCompilationStep(unittest.TestCase):
         with patch("cms.grading.steps.compilation.generic_step",
                    return_value=expected_stats) as mock_generic_step:
             success, compilation_success, text, stats = compilation_step(
-                self.sandbox, ONE_COMMAND)
+                self.sandbox, ONE_COMMAND, LANG_1)
 
         mock_generic_step.assert_called_once_with(
             self.sandbox, ONE_COMMAND, "compilation", collect_output=True)
@@ -73,7 +74,7 @@ class TestCompilationStep(unittest.TestCase):
         with patch("cms.grading.steps.compilation.generic_step",
                    return_value=expected_stats):
             success, compilation_success, text, stats = compilation_step(
-                self.sandbox, ONE_COMMAND)
+                self.sandbox, ONE_COMMAND, LANG_1)
 
         # User's fault, no error needs to be logged.
         self.assertLoggedError(False)
@@ -91,7 +92,7 @@ class TestCompilationStep(unittest.TestCase):
         with patch("cms.grading.steps.compilation.generic_step",
                    return_value=expected_stats):
             success, compilation_success, text, stats = compilation_step(
-                self.sandbox, ONE_COMMAND)
+                self.sandbox, ONE_COMMAND, LANG_1)
 
         # User's fault, no error needs to be logged.
         self.assertLoggedError(False)
@@ -109,7 +110,7 @@ class TestCompilationStep(unittest.TestCase):
         with patch("cms.grading.steps.compilation.generic_step",
                    return_value=expected_stats):
             success, compilation_success, text, stats = compilation_step(
-                self.sandbox, ONE_COMMAND)
+                self.sandbox, ONE_COMMAND, LANG_1)
 
         # User's fault, no error needs to be logged.
         self.assertLoggedError(False)
@@ -127,7 +128,7 @@ class TestCompilationStep(unittest.TestCase):
         with patch("cms.grading.steps.compilation.generic_step",
                    return_value=expected_stats):
             success, compilation_success, text, stats = compilation_step(
-                self.sandbox, ONE_COMMAND)
+                self.sandbox, ONE_COMMAND, LANG_1)
 
         # User's fault, no error needs to be logged.
         self.assertLoggedError(False)
@@ -141,7 +142,7 @@ class TestCompilationStep(unittest.TestCase):
         with patch("cms.grading.steps.compilation.generic_step",
                    return_value=None):
             success, compilation_success, text, stats = compilation_step(
-                self.sandbox, ONE_COMMAND)
+                self.sandbox, ONE_COMMAND, LANG_1)
 
         # Sandbox should never fail. If it does, should notify the admin.
         self.assertLoggedError()
@@ -156,7 +157,7 @@ class TestCompilationStep(unittest.TestCase):
         with patch("cms.grading.steps.compilation.generic_step",
                    return_value=expected_stats) as mock_generic_step:
             success, compilation_success, text, stats = compilation_step(
-                self.sandbox, TWO_COMMANDS)
+                self.sandbox, TWO_COMMANDS, LANG_1)
 
         mock_generic_step.assert_called_once_with(
             self.sandbox, TWO_COMMANDS, "compilation", collect_output=True)

--- a/cmstestsuite/unit_tests/grading/tasktypes/BatchTest.py
+++ b/cmstestsuite/unit_tests/grading/tasktypes/BatchTest.py
@@ -153,7 +153,7 @@ class TestCompile(TaskTypeTestMixin, unittest.TestCase):
         # Compilation step called correctly.
         self.compilation_step.assert_called_once_with(
             sandbox, fake_compilation_commands(
-                COMPILATION_COMMAND_1, ["foo.l1"], "foo"))
+                COMPILATION_COMMAND_1, ["foo.l1"], "foo"), LANG_1)
         # Results put in job, executable stored and sandbox deleted.
         self.assertResultsInJob(job)
         sandbox.get_file_to_storage.assert_called_once_with("foo", self.file_cacher, ANY)
@@ -188,8 +188,12 @@ class TestCompile(TaskTypeTestMixin, unittest.TestCase):
         self.assertEqual(sandbox.create_file_from_storage.call_count, 2)
         # Compilation step called correctly.
         self.compilation_step.assert_called_once_with(
-            sandbox, fake_compilation_commands(
-                COMPILATION_COMMAND_1, ["foo.l1", "bar.l1"], "bar_foo"))
+            sandbox,
+            fake_compilation_commands(
+                COMPILATION_COMMAND_1, ["foo.l1", "bar.l1"], "bar_foo"
+            ),
+            LANG_1,
+        )
         # Results put in job, executable stored and sandbox deleted.
         self.assertResultsInJob(job)
         sandbox.get_file_to_storage.assert_called_once_with("bar_foo", self.file_cacher, ANY)
@@ -252,8 +256,12 @@ class TestCompile(TaskTypeTestMixin, unittest.TestCase):
         self.assertEqual(sandbox.create_file_from_storage.call_count, 3)
         # Compilation step called correctly.
         self.compilation_step.assert_called_once_with(
-            sandbox, fake_compilation_commands(
-                COMPILATION_COMMAND_1, ["foo.l1", "grader.l1"], "foo"))
+            sandbox,
+            fake_compilation_commands(
+                COMPILATION_COMMAND_1, ["foo.l1", "grader.l1"], "foo"
+            ),
+            LANG_1,
+        )
         # Results put in job, executable stored and sandbox deleted.
         self.assertResultsInJob(job)
         sandbox.get_file_to_storage.assert_called_once_with("foo", self.file_cacher, ANY)
@@ -354,6 +362,7 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
         self.evaluation_step.assert_called_once_with(
             sandbox,
             fake_evaluation_commands(EVALUATION_COMMAND_1, "foo", "foo"),
+            LANG_1,
             2.5, 123 * 1024 * 1024,
             writable_files=[],
             stdin_redirect="input.txt",
@@ -475,6 +484,7 @@ class TestEvaluate(TaskTypeTestMixin, unittest.TestCase):
         self.evaluation_step.assert_called_once_with(
             sandbox,
             fake_evaluation_commands(EVALUATION_COMMAND_1, "foo", "foo"),
+            LANG_1,
             2.5, 123 * 1024 * 1024,
             writable_files=["myout"],
             stdin_redirect=None,

--- a/cmstestsuite/unit_tests/grading/tasktypes/CommunicationTest.py
+++ b/cmstestsuite/unit_tests/grading/tasktypes/CommunicationTest.py
@@ -167,8 +167,12 @@ class TestCompile(TaskTypeTestMixin, unittest.TestCase):
         self.assertEqual(sandbox.create_file_from_storage.call_count, 2)
         # Compilation step called correctly.
         self.compilation_step.assert_called_once_with(
-            sandbox, fake_compilation_commands(
-                COMPILATION_COMMAND_1, ["stub.l1", "foo.l1"], "foo"))
+            sandbox,
+            fake_compilation_commands(
+                COMPILATION_COMMAND_1, ["stub.l1", "foo.l1"], "foo"
+            ),
+            LANG_1,
+        )
         # Results put in job, executable stored and sandbox deleted.
         self.assertResultsInJob(job, True, True, TEXT, STATS_OK)
         sandbox.get_file_to_storage.assert_called_once_with("foo", self.file_cacher, ANY)
@@ -227,9 +231,12 @@ class TestCompile(TaskTypeTestMixin, unittest.TestCase):
         self.assertEqual(sandbox.create_file_from_storage.call_count, 3)
         # Compilation step called correctly.
         self.compilation_step.assert_called_once_with(
-            sandbox, fake_compilation_commands(
-                COMPILATION_COMMAND_1, ["stub.l1", "foo.l1", "bar.l1"],
-                "bar_foo"))
+            sandbox,
+            fake_compilation_commands(
+                COMPILATION_COMMAND_1, ["stub.l1", "foo.l1", "bar.l1"], "bar_foo"
+            ),
+            LANG_1,
+        )
         # Results put in job, executable stored and sandbox deleted.
         self.assertResultsInJob(job, True, True, TEXT, STATS_OK)
         sandbox.get_file_to_storage.assert_called_once_with("bar_foo", self.file_cacher, ANY)
@@ -252,8 +259,10 @@ class TestCompile(TaskTypeTestMixin, unittest.TestCase):
             "foo.l1", "digest of foo.l1", self.file_cacher)
         # Compilation step called correctly, without the stub.
         self.compilation_step.assert_called_once_with(
-            sandbox, fake_compilation_commands(
-                COMPILATION_COMMAND_1, ["foo.l1"], "foo"))
+            sandbox,
+            fake_compilation_commands(COMPILATION_COMMAND_1, ["foo.l1"], "foo"),
+            LANG_1,
+        )
         # Results put in job, executable stored and sandbox deleted.
         self.assertResultsInJob(job, True, True, TEXT, STATS_OK)
         sandbox.get_file_to_storage.assert_called_once_with("foo", self.file_cacher, ANY)
@@ -281,8 +290,10 @@ class TestCompile(TaskTypeTestMixin, unittest.TestCase):
         self.assertEqual(sandbox.create_file_from_storage.call_count, 2)
         # Compilation step called correctly, without the stub.
         self.compilation_step.assert_called_once_with(
-            sandbox, fake_compilation_commands(
-                COMPILATION_COMMAND_1, ["foo.l1"], "foo"))
+            sandbox,
+            fake_compilation_commands(COMPILATION_COMMAND_1, ["foo.l1"], "foo"),
+            LANG_1,
+        )
         # Results put in job, executable stored and sandbox deleted.
         self.assertResultsInJob(job, True, True, TEXT, STATS_OK)
         sandbox.get_file_to_storage.assert_called_once_with("foo", self.file_cacher, ANY)
@@ -391,11 +402,11 @@ class TestEvaluate(TaskTypeTestMixin, FileSystemMixin, unittest.TestCase):
         cmdline_usr = ["run1", "foo", "stub",
                        "/fifo0/m_to_u0", "/fifo0/u0_to_m"]
         self.evaluation_step_before_run.assert_has_calls([
-            call(sandbox_mgr, cmdline_mgr, 4321, 1234 * 1024 * 1024,
+            call(sandbox_mgr, cmdline_mgr, None, 4321, 1234 * 1024 * 1024,
                  dirs_map={os.path.join(self.base_dir, "0"): ("/fifo0", "rw")},
                  writable_files=["output.txt"],
                  stdin_redirect="input.txt", multiprocess=True),
-            call(sandbox_usr, cmdline_usr, 2.5, 123 * 1024 * 1024,
+            call(sandbox_usr, cmdline_usr, LANG_1, 2.5, 123 * 1024 * 1024,
                  dirs_map={os.path.join(self.base_dir, "0"): ("/fifo0", "rw")},
                  stdin_redirect=None,
                  stdout_redirect=None,
@@ -421,7 +432,7 @@ class TestEvaluate(TaskTypeTestMixin, FileSystemMixin, unittest.TestCase):
         tt.evaluate(job, self.file_cacher)
 
         self.evaluation_step_before_run.assert_has_calls([
-            call(sandbox_mgr, ANY, 2.5 + 1, ANY, dirs_map=ANY,
+            call(sandbox_mgr, ANY, None, 2.5 + 1, ANY, dirs_map=ANY,
                  writable_files=ANY, stdin_redirect=ANY, multiprocess=ANY)])
 
     def test_single_process_missing_manager(self):
@@ -594,7 +605,7 @@ class TestEvaluate(TaskTypeTestMixin, FileSystemMixin, unittest.TestCase):
         # redirects and no command line arguments.
         cmdline_usr = ["run1", "foo", "stub"]
         self.evaluation_step_before_run.assert_has_calls([
-            call(sandbox_usr, cmdline_usr, ANY, ANY, dirs_map=ANY,
+            call(sandbox_usr, cmdline_usr, LANG_1, ANY, ANY, dirs_map=ANY,
                  stdin_redirect="/fifo0/m_to_u0",
                  stdout_redirect="/fifo0/u0_to_m",
                  multiprocess=ANY)])
@@ -642,19 +653,19 @@ class TestEvaluate(TaskTypeTestMixin, FileSystemMixin, unittest.TestCase):
         cmdline_usr1 = ["run1", "foo", "stub",
                         "/fifo1/m_to_u1", "/fifo1/u1_to_m", "1"]
         self.evaluation_step_before_run.assert_has_calls([
-            call(sandbox_mgr, cmdline_mgr, 4321, 1234 * 1024 * 1024,
+            call(sandbox_mgr, cmdline_mgr, None, 4321, 1234 * 1024 * 1024,
                  dirs_map={
                      os.path.join(self.base_dir, "0"): ("/fifo0", "rw"),
                      os.path.join(self.base_dir, "1"): ("/fifo1", "rw"),
                  },
                  writable_files=["output.txt"],
                  stdin_redirect="input.txt", multiprocess=True),
-            call(sandbox_usr0, cmdline_usr0, 2.5, 123 * 1024 * 1024,
+            call(sandbox_usr0, cmdline_usr0, LANG_1, 2.5, 123 * 1024 * 1024,
                  dirs_map={os.path.join(self.base_dir, "0"): ("/fifo0", "rw")},
                  stdin_redirect=None,
                  stdout_redirect=None,
                  multiprocess=True),
-            call(sandbox_usr1, cmdline_usr1, 2.5, 123 * 1024 * 1024,
+            call(sandbox_usr1, cmdline_usr1, LANG_1, 2.5, 123 * 1024 * 1024,
                  dirs_map={os.path.join(self.base_dir, "1"): ("/fifo1", "rw")},
                  stdin_redirect=None,
                  stdout_redirect=None,
@@ -683,7 +694,7 @@ class TestEvaluate(TaskTypeTestMixin, FileSystemMixin, unittest.TestCase):
         tt.evaluate(job, self.file_cacher)
 
         self.evaluation_step_before_run.assert_has_calls([
-            call(sandbox_mgr, ANY, 2 * (2.5 + 1), ANY, dirs_map=ANY,
+            call(sandbox_mgr, ANY, None, 2 * (2.5 + 1), ANY, dirs_map=ANY,
                  writable_files=ANY, stdin_redirect=ANY, multiprocess=ANY)])
 
     def test_many_processes_first_user_failure(self):
@@ -778,11 +789,11 @@ class TestEvaluate(TaskTypeTestMixin, FileSystemMixin, unittest.TestCase):
         cmdline_usr0 = ["run1", "foo", "stub", "0"]
         cmdline_usr1 = ["run1", "foo", "stub", "1"]
         self.evaluation_step_before_run.assert_has_calls([
-            call(sandbox_usr0, cmdline_usr0, ANY, ANY, dirs_map=ANY,
+            call(sandbox_usr0, cmdline_usr0, LANG_1, ANY, ANY, dirs_map=ANY,
                  stdin_redirect="/fifo0/m_to_u0",
                  stdout_redirect="/fifo0/u0_to_m",
                  multiprocess=ANY),
-            call(sandbox_usr1, cmdline_usr1, ANY, ANY, dirs_map=ANY,
+            call(sandbox_usr1, cmdline_usr1, LANG_1, ANY, ANY, dirs_map=ANY,
                  stdin_redirect="/fifo1/m_to_u1",
                  stdout_redirect="/fifo1/u1_to_m",
                  multiprocess=ANY)


### PR DESCRIPTION
* Allow each language to modify the parameters of the sandbox for both compilation and evaluation.
* Don't put /etc in the sandbox by default, only include the parts of /etc that are necessary for specific languages. (except for pascal... isolate doesn't support bind-mounting individual files, and pascal uses /etc/fpc.cfg instead of a subdirectory, so we still need to mount all of /etc for it. Note that the kernel does support bind-mounting files - should this feature be added to isolate?)
* Don't use preserve_env=True for compilation sandboxes, instead set PATH (which seems to be the only environment variable that was actually necessary) to a reasonable value manually.

This implements one part of #1480 and is necessary for supporting dotnet (#1243).

I call configure_compilation_sandbox and configure_evaluation_sandbox as late as possible, to allow languages to override the general parameters if needed. None of them need that currently, but it might be useful in the future.

Note that TwoSteps doesn't actually call configure_evaluation_sandbox, but then again it never even called get_evaluation_commands in the first place...