### PR TITLE
fix schema_diff_test on new debian

### DIFF
--- a/cmstestsuite/unit_tests/schema_diff_test.py
+++ b/cmstestsuite/unit_tests/schema_diff_test.py
@@ -35,7 +35,12 @@ def split_schema(schema: str) -> list[list[str]]:
     statements: list[list[str]] = []
     cur_statement: list[str] = []
     for line in schema.splitlines():
-        if line == "" or line.startswith("--"):
+        if (
+            line == ""
+            or line.startswith("--")
+            or line.startswith("\\restrict")
+            or line.startswith("\\unrestrict")
+        ):
             continue
         cur_statement.append(line)
         if line.endswith(";"):


### PR DESCRIPTION
https://www.postgresql.org/docs/release/17.6/ added `\restrict` and `\unrestrict` to pg_dump output. we need to filter them out.