### PR TITLE
Add RWS public config and configurable id column

### DIFF
--- a/cmsranking/Config.py
+++ b/cmsranking/Config.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 import os
 import sys
@@ -38,6 +38,11 @@ def default_path(name):
 
 
 @dataclass
+class PublicConfig:
+    show_id_column: bool = False
+
+
+@dataclass
 class Config:
     # Connection.
     bind_address: str = "127.0.0.1"
@@ -50,6 +55,9 @@ class Config:
     realm_name: str = "Scoreboard"
     username: str = "usern4me"
     password: str = "passw0rd"
+
+    # UI.
+    public: PublicConfig = field(default_factory=PublicConfig)
 
     # Buffers
     buffer_size: int = 100

--- a/cmsranking/static/Config.js
+++ b/cmsranking/static/Config.js
@@ -73,4 +73,24 @@ var Config = new function () {
     self.get_history_url = function () {
         return "history";
     }
+
+    self.get_public_config_url = function () {
+        return "config";
+    }
 };
+
+var PublicConfig = {
+    show_id_column: false
+};
+
+$.ajax({
+    url: Config.get_public_config_url(),
+    dataType: "json",
+    async: false,
+    success: function (data, status, xhr) {
+        PublicConfig = data;
+    },
+    error: function () {
+        console.error("Error while getting public configuration data");
+    }
+});

--- a/cmsranking/static/Scoreboard.js
+++ b/cmsranking/static/Scoreboard.js
@@ -194,9 +194,9 @@ var Scoreboard = new function () {
     <th class=\"sel\"></th> \
     <th class=\"rank\">Rank</th> \
     <th colspan=\"10\" class=\"f_name\">First Name</th> \
-    <th colspan=\"10\" class=\"l_name\">Last Name</th> \
-    <th class=\"user_id\">ID</th> \
-    <th class=\"team\">Team</th>";
+    <th colspan=\"10\" class=\"l_name\">Last Name</th>" +
+            (PublicConfig.show_id_column ? "<th class=\"user_id\">ID</th>" : "") +
+            "<th class=\"team\">Team</th>";
 
         var contests = DataStore.contest_list;
         for (var i in contests) {
@@ -244,8 +244,8 @@ var Scoreboard = new function () {
     <td class=\"sel\"></td> \
     <td class=\"rank\">" + user["rank"] + "</td> \
     <td colspan=\"10\" class=\"f_name\">" + escapeHTML(user["f_name"]) + "</td> \
-    <td colspan=\"10\" class=\"l_name\">" + escapeHTML(user["l_name"]) + "</td> \
-    <td class=\"user_id\">" + user["key"] + "</td>";
+    <td colspan=\"10\" class=\"l_name\">" + escapeHTML(user["l_name"]) + "</td>" +
+            (PublicConfig.show_id_column ? "<td class=\"user_id\">" + user["key"] + "</td>" : "");
 
         if (user['team']) {
             result += " \

--- a/config/cms_ranking.sample.toml
+++ b/config/cms_ranking.sample.toml
@@ -25,3 +25,7 @@ buffer_size = 100
 #log_dir = "INSTALL_DIR/log/ranking"
 # Data directory (the scoreboard data is stored here).
 #lib_dir = "INSTALL_DIR/lib/ranking"
+
+# UI
+[public]
+show_id_column = false


### PR DESCRIPTION
The new ID column in RWS does not really work for non IOI-style usernames or similar, since longer ones overflow into neighbouring columns. Also in some contests it is not really meaningful: for example in the Italian national competition usernames are just last names so they overflow and do not really add any meaningful information.
So this adds a configuration option to show or hide this column.