### PR TITLE
Better handling of compilation memory limit exceeded errors

### DIFF
--- a/cms/grading/Sandbox.py
+++ b/cms/grading/Sandbox.py
@@ -415,11 +415,15 @@ class Sandbox:
                 return self.EXIT_TIMEOUT_WALL
             else:
                 return self.EXIT_TIMEOUT
+        elif 'cg-oom-killed' in self.meta:
+            # OOM killer was activated in the sandbox. It killed either the
+            # main process (in which case the exit status is SG) or a
+            # subprocess (in which case the main process gets to decide how to
+            # handle it, but probably RE). In both cases, we want to
+            # "root-cause" the verdict as "memory limit exceeded".
+            return self.EXIT_MEM_LIMIT
         elif "SG" in status_list:
-            if "cg-oom-killed" in self.meta:
-                return self.EXIT_MEM_LIMIT
-            else:
-                return self.EXIT_SIGNAL
+            return self.EXIT_SIGNAL
         elif "RE" in status_list:
             return self.EXIT_NONZERO_RETURN
         # OK status is not reported in the meta file, it's implicit.

--- a/cms/grading/steps/compilation.py
+++ b/cms/grading/steps/compilation.py
@@ -55,13 +55,16 @@ COMPILATION_MESSAGES = MessageCollection([
                  N_("Your submission exceeded the time limit while compiling. "
                     "This might be caused by an excessive use of C++ "
                     "templates, for example.")),
+    HumanMessage("memorylimit",
+                 N_("Compilation memory limit exceeded"),
+                 N_("Your submission exceeded the memory limit while compiling. "
+                    "This might be caused by an excessive use of C++ "
+                    "templates, or too large global variables, for example.")),
     HumanMessage("signal",
-                 N_("Compilation killed with signal %s (could be triggered "
-                    "by violating memory limits)"),
+                 N_("Compilation killed with signal %s"),
                  N_("Your submission was killed with the specified signal. "
-                    "Among other things, this might be caused by exceeding "
-                    "the memory limit for the compilation, and in turn by an "
-                    "excessive use of C++ templates, for example.")),
+                    "This might be caused by a bug in the compiler, "
+                    "for example.")),
 ])
 
 
@@ -134,6 +137,13 @@ def compilation_step(
         # to them.
         logger.debug("Compilation timed out.")
         text = [COMPILATION_MESSAGES.get("timeout").message]
+        return True, False, text, stats
+
+    elif exit_status == Sandbox.EXIT_MEM_LIMIT:
+        # Memory limit: we assume it is the user's fault, and we return the
+        # error to them.
+        logger.debug("Compilation memory limit exceeded.")
+        text = [COMPILATION_MESSAGES.get("memorylimit").message]
         return True, False, text, stats
 
     elif exit_status == Sandbox.EXIT_SIGNAL:

--- a/cmstestsuite/Tests.py
+++ b/cmstestsuite/Tests.py
@@ -258,6 +258,11 @@ ALL_TESTS = [
          languages=(LANG_CPP,),
          checks=[CheckCompilationFail()]),
 
+    Test('compile-memory-limit',
+         task=batch_fileio, filenames=['compile-memory-limit.%l'],
+         languages=(LANG_CPP,),
+         checks=[CheckCompilationFail()]),
+
     # Various timeout conditions.
 
     Test('timeout-cputime',

--- a/cmstestsuite/code/compile-memory-limit.cpp
+++ b/cmstestsuite/code/compile-memory-limit.cpp
@@ -1,0 +1,9 @@
+#ifdef EVAL // this file can accidentally OOM editors/language servers...
+#define a "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+#define b a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+#define c b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+#define d c c c c c c c c c c c c c c c c c c c c c c c c c c c c c c c c
+#define e d d d d d d d d d d d d d d d d d d d d d d d d d d d d d d d d
+const char* x = e e;
+#endif
+int main() { return 0; }


### PR DESCRIPTION
* check for the sandbox "memory limit exceeded" result in `compilation_step`.
* change the sandbox so that memory limit is diagnosed more often: specifically, gcc has a driver process which catches the child's death and prints a nice error message. with the previous code this would result in a regular "nonzero return" verdict; now it's memory-limit (though the nice message on stderr is still visible).
* add a new user-visible compilation outcome for it.
* added a test for it. this test tries to use 1.1GB of memory for me, and fails in CMS in around 0.3 seconds, so it should quite reliably trigger the memory limit.
   * currently AWS actually doesn't distinguish the different kinds of compilation failure, so these tests all just assert that some compilation failure happened. this could be made more specific in the future.