### PR TITLE
disable dependabot PRs (for non-security updates)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 30
+    # Disable all dependabot updates, except when we explicitly ask for them.
+    # This does not disable security updates: those have a hardcoded limit of
+    # 10 which is separate from this limit.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
most dependency updates are completely irrelevant for us. (especially transitive deps.) security updates are theoretically an exception, but those aren't disabled by this change.

currently the flood of dependabot PRs which we never merge is just email spam and a waste of CI time (well, not that i'm particularly sorry for wasting github's resources, but still).

Martin proposed just updating deps at the start of a development cycle, which seems reasonable to me. if we decide we like dependabot enough, then we can re-enable it just for that occasion, but i'd also be happy to just bump the deps by hand.

([source](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-) for the separate security PR limit claim.)