### PR TITLE
Fix controller hang when submission exits early

### DIFF
--- a/cms/grading/tasktypes/Interactive.py
+++ b/cms/grading/tasktypes/Interactive.py
@@ -252,7 +252,11 @@ class Interactive(TaskType):
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
             )
-            stdout, _ = p.communicate(timeout=self.controller_wall_limit * 2)
+            try:
+                stdout, _ = p.communicate(timeout=self.controller_wall_limit * 2)
+            except subprocess.TimeoutExpired:
+                p.kill()
+                stdout, _ = p.communicate()
 
             KEEPER_ERROR_MESSAGE = "Internal error in interactive keeper"
 

--- a/cms/grading/tasktypes/interactive_keeper.py
+++ b/cms/grading/tasktypes/interactive_keeper.py
@@ -87,10 +87,8 @@ def main():
     for i in range(process_limit):
         c_to_u_r, c_to_u_w = os.pipe()
         u_to_c_r, u_to_c_w = os.pipe()
-        os.set_inheritable(c_to_u_r, True)
         os.set_inheritable(c_to_u_w, True)
         os.set_inheritable(u_to_c_r, True)
-        os.set_inheritable(u_to_c_w, True)
         pipes.append({"c_to_u": (c_to_u_r, c_to_u_w), "u_to_c": (u_to_c_r, u_to_c_w)})
 
     controller_sandbox = Sandbox(0, shard, name="controller", temp_dir=temp_dir)
@@ -165,7 +163,8 @@ def main():
                 wait=False,
             )
 
-            os.close(p["c_to_u"][0])
+            # We do not close p["c_to_u"][0] -- it only risks crashing the
+            # controller with SIGPIPE if the submission exits early.
             os.close(p["u_to_c"][1])
 
             try:

--- a/cms/grading/tasktypes/interactive_keeper.py
+++ b/cms/grading/tasktypes/interactive_keeper.py
@@ -163,8 +163,7 @@ def main():
                 wait=False,
             )
 
-            # We do not close p["c_to_u"][0] -- it only risks crashing the
-            # controller with SIGPIPE if the submission exits early.
+            os.close(p["c_to_u"][0])
             os.close(p["u_to_c"][1])
 
             try:


### PR DESCRIPTION
Having the `u_to_c_w` fd inherit to the controller means that when the submission exits, the controller will never read EOF, because it still itself has the write end of the pipe open. Easy fix is just to make that not inherit: nothing actually needs the inheritance, in fact it's rather a bit of a security issue that each spawned submission get access to extra fd's.

Small additional related fixes:
- if the interactive keeper hits walltime limit (claude pointed out some obscure circumstances in which this can happen, e.g. if the submission causes lots of isolate warning spam which clogs an stderr pipe which is never read from), we currently crash and leave the child un-waited. Better to generate a proper error.
- the change to make `c_to_u_r` not inherit means that now if the submission exits, controller writing will cause SIGPIPE unless the controller ignores that signal. We don't particularly want that to happen (it makes it impossible to detect which process exited first, which we really ought to do to give proper verdicts); better to leave the pipe unclosed.