### PR TITLE
Security: Fix checking of admin tokens in CWS

### DIFF
--- a/cms/server/contest/authentication.py
+++ b/cms/server/contest/authentication.py
@@ -123,8 +123,11 @@ def validate_login(
         return None, None
 
     if admin_token != "":
-        if (config.contest_web_server.contest_admin_token is not None
-            and admin_token != config.contest_web_server.contest_admin_token):
+        if config.contest_web_server.contest_admin_token is None:
+            log_failed_attempt("admin token not configured")
+            return None, None
+
+        if admin_token != config.contest_web_server.contest_admin_token:
             log_failed_attempt("invalid admin token")
             return None, None
 

--- a/cmstestsuite/unit_tests/server/contest/authentication_test.py
+++ b/cmstestsuite/unit_tests/server/contest/authentication_test.py
@@ -165,6 +165,10 @@ class TestValidateLogin(DatabaseMixin, unittest.TestCase):
     def test_unsuccessful_impersonation(self):
         self.assertFailure("myuser", "", "127.0.0.1", "bad-admin-token")
 
+    def test_impersonation_with_no_config(self):
+        with patch.object(config.contest_web_server, "contest_admin_token", None):
+            self.assertFailure("myuser", "", "127.0.0.1", "admin-token")
+
     def test_impersonation_overrides_unallowed_password_authentication(self):
         self.contest.allow_password_authentication = False
 


### PR DESCRIPTION
When the login endpoint of the CWS API was called with an admin token, but no admin token was configured, login succeeded.

This allowed attackers to impersonate any CWS user in CMS instances with no admin token configured.

Thanks to Samet Akıllı <ssametakilli@gmail.com> for reporting the issue.