### PR TITLE
Fix PrometheusExporter double counting questions

### DIFF
--- a/cmscontrib/PrometheusExporter.py
+++ b/cmscontrib/PrometheusExporter.py
@@ -200,7 +200,7 @@ class PrometheusExporter(Service, Collector):
         data = (
             session.query(func.count(Question.id))
             .select_from(Question)
-            .filter(Question.ignored == True)
+            .filter((Question.ignored == True) & (Question.reply_timestamp == None))
             .all()
         )
         metric.add_metric(["ignored"], data[0][0])


### PR DESCRIPTION
In cms some questions can be both answered and ignored at the same time, this made PrometheusExporter double count them.